### PR TITLE
feat(merchant): add upgrade after the level limit

### DIFF
--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -1,7 +1,7 @@
 // Global vars
 var attack_mode = true;
 var partyMems = ["MooohMoooh", "CowTheMooh", "MowTheCooh"];
-var partyCodeSlot = [9, 2, 4, 5]
+var partyCodeSlot = [9, 2, 4, 5];
 var partyMerchant = "MerchantMooh";
 var buffThreshold = 0.7;
 
@@ -24,27 +24,81 @@ var min_xp = 100;
 var max_att = 2000;
 var bossOffset = 0.99;
 var boss = ["mrpumpkin", "mrgreen"];
-var map = 'winterland';
+var map = "winterland";
 var mapX = 73;
 var mapY = -909;
 var type = "grinch";
 var altType1 = "boar";
-var altType2 = "boar"
+var altType2 = "boar";
 
 // desired elixir named
-var desiredElixir = 'elixirluck';
+var desiredElixir = "elixirluck";
 
 // Debug stucking
 var smartmoveDebug = false;
 
 // Merch boundary
-var ignore = ['x0', 'x1', 'x2', 'x3', 'x4', 'x5', 'x6', 'x7', 'x8', 'hpot0', 'mpot0', 'cscroll0', 'cscroll1', 'cscroll2', 'scroll0', 'scroll1', 'ornament', 'mistletoe', 'candy1', 'candycane', 'candy0', 'stand0', 'pickaxe', 'rod', 'broom', 'pumpkinspice', 'tracker']
-var saleAble = ['cclaw', 'wattire', 'dagger', 'snowball', 'rednose', 'iceskates', 'stinger', 'vitring', 'harmor', 'skullamulet', 'stinger', 'lantern', 'hpbelt', 'hpamulet', 'gphelmet', 'phelmet', 'maceofthedead', 'pmaceofthedead', 'maceofthedead', 'daggerofthedead', 'staffofthedead', 'bowofthedead', 'swordofthedead', 'throwingstars', 'smoke'];
+var ignore = [
+  "x0",
+  "x1",
+  "x2",
+  "x3",
+  "x4",
+  "x5",
+  "x6",
+  "x7",
+  "x8",
+  "hpot0",
+  "mpot0",
+  "cscroll0",
+  "cscroll1",
+  "cscroll2",
+  "scroll0",
+  "scroll1",
+  "ornament",
+  "mistletoe",
+  "candy1",
+  "candycane",
+  "candy0",
+  "stand0",
+  "pickaxe",
+  "rod",
+  "broom",
+  "pumpkinspice",
+  "tracker",
+];
+var saleAble = [
+  "cclaw",
+  "wattire",
+  "dagger",
+  "snowball",
+  "rednose",
+  "iceskates",
+  "stinger",
+  "vitring",
+  "harmor",
+  "skullamulet",
+  "stinger",
+  "lantern",
+  "hpbelt",
+  "hpamulet",
+  "gphelmet",
+  "phelmet",
+  "maceofthedead",
+  "pmaceofthedead",
+  "maceofthedead",
+  "daggerofthedead",
+  "staffofthedead",
+  "bowofthedead",
+  "swordofthedead",
+  "throwingstars",
+  "smoke",
+];
 var maxUpgrade = 7;
 var maxCompound = 3;
 
 // Bank
-const bankSlots = ['items0', 'items1', 'items3'];
+const bankSlots = ["items0", "items1", "items3"];
 // Pre-set function
 async function sortInv() {
   var inv = character.items;
@@ -75,7 +129,7 @@ async function sortInv() {
           inv[i] = inv[j];
           inv[j] = temp;
           promises.push(swap(i, j));
-        };
+        }
       }
     }
   }
@@ -83,19 +137,22 @@ async function sortInv() {
 }
 
 function isMerchant() {
-  return character.ctype === 'merchant';
+  return character.ctype === "merchant";
 }
 
 function getMonstersOnDeclares() {
   return (
     get_nearest_monster({ min_xp, max_att, type }) ??
-    get_nearest_monster({ min_xp, max_att, type: altType1 }) ?? 
+    get_nearest_monster({ min_xp, max_att, type: altType1 }) ??
     get_nearest_monster({ min_xp, max_att, type: altType2 })
   );
 }
 
 function buff() {
-  if (character.hp / character.max_hp < character.mp / character.max_mp || character.hp < character.max_hp * 0.6) {
+  if (
+    character.hp / character.max_hp < character.mp / character.max_mp ||
+    character.hp < character.max_hp * 0.6
+  ) {
     if (character.hp < 0.7 * character.max_hp && !is_on_cooldown("use_hp"))
       use_skill("use_hp");
     if (character.hp < character.max_hp - 50 && !is_on_cooldown("regen_hp"))
@@ -104,28 +161,30 @@ function buff() {
     if (character.mp < 0.5 * character.max_mp && !is_on_cooldown("use_mp"))
       use_skill("use_mp");
     if (character.mp < character.max_mp - 100 && !is_on_cooldown("regen_mp"))
-      use_skill("regen_mp"); 
+      use_skill("regen_mp");
   }
 }
 
 function getTarget() {
   var target = get_targeted_monster();
-  
-  if (target && !get_nearest_monster({type: target.mtype})) target = undefined;
-  
+
+  if (target && !get_nearest_monster({ type: target.mtype }))
+    target = undefined;
+
   if (!target) {
     const leader = get_entity(partyMems[0]);
     if (leader)
       target =
         character.name === partyMems[0]
           ? getMonstersOnDeclares()
-          : (get_target_of(leader) ?? undefined);
+          : get_target_of(leader) ?? undefined;
     else target = getMonstersOnDeclares();
     if (target) change_target(target);
     else {
       set_message("No Monsters, move to leader location");
       if (
-        leader && !smart.moving &&
+        leader &&
+        !smart.moving &&
         Math.sqrt(
           (character.x - leader.x) * (character.x - leader.x) +
             (character.y - leader.y) * (character.y - leader.y)
@@ -176,14 +235,14 @@ function hitAndRun(target, rangeRate) {
       flipRotation *= -1;
       flipRotationCooldown = 2;
     }
-    angle = angle + flipRotation * Math.PI / 4;
+    angle = angle + (flipRotation * Math.PI) / 4;
   }
 
   // Calculate our new desired position. It will be our max attack range
   // from the target, at the angle described by var angle.
   var new_x = target.real_x + character.range * rangeRate * Math.cos(angle);
   var new_y = target.real_y + character.range * rangeRate * Math.sin(angle);
-  
+
   // Save current position and last position
   last_x2 = last_x; // Keep track of one more back to detect edges better
   last_y2 = last_y; //
@@ -194,7 +253,8 @@ function hitAndRun(target, rangeRate) {
   // Has a cooldown after flipping so it doesn't thrash back and forth
   if (flip_cooldown > 18) {
     if (
-      parent.distance(character, target) <= character.range * 0.2 * rangeRate
+      parent.distance(character, target) <=
+      character.range * 0.2 * rangeRate
     ) {
       angle = angle + flipRotation * Math.PI * 2 * 0.35;
     }
@@ -203,7 +263,7 @@ function hitAndRun(target, rangeRate) {
 
   flip_cooldown++;
   flipRotationCooldown--;
-  
+
   move(new_x, new_y);
 }
 
@@ -237,132 +297,105 @@ function sleep(delay) {
 }
 
 function shouldGoToBoss(mboss) {
-  return !boss.includes(getTarget()?.mtype) && parent.S[mboss] && parent.S[mboss].live && ((parent.S[mboss].hp < bossOffset * parent.S[mboss].max_hp && parent.S[mboss].target !== null && !partyMems.includes(parent.S[mboss].target)) || mboss === "snowman");
+  return (
+    !boss.includes(getTarget()?.mtype) &&
+    parent.S[mboss] &&
+    parent.S[mboss].live &&
+    ((parent.S[mboss].hp < bossOffset * parent.S[mboss].max_hp &&
+      parent.S[mboss].target !== null &&
+      !partyMems.includes(parent.S[mboss].target)) ||
+      mboss === "snowman")
+  );
 }
 
 function goToBoss() {
   for (i in boss) {
     if (shouldGoToBoss(boss[i])) {
-      log('Attempting boss');
-      stop('move');
+      log("Attempting boss");
+      stop("move");
       change_target();
       smartmoveDebug = false;
-      if (!smart.moving) smart_move(parent.S[boss[i]]).then(() => targetBoss(boss[i])).catch(e => { use_skill('use_town'); change_target(); });
+      if (!smart.moving)
+        smart_move(parent.S[boss[i]])
+          .then(() => targetBoss(boss[i]))
+          .catch((e) => {
+            use_skill("use_town");
+            change_target();
+          });
       return true;
     }
   }
   return false;
 }
 
-//// INVENTORY functions
-function item_info(item) {
-    return parent.G.items[item.name];
-}
-
-async function compoundInv() {
-  let inv = character.items;
-  
-  if(character.q.compound) return;
-  
-  for (let i = 0; i < inv.length; i++) {
-    let breakFlag = false;
-
-    if (inv[i] && (inv[i]?.level > 2 || item_grade(inv[i]) === 2)) continue;
-
-    if (item_info(inv[i]).compound) {
-      const scrollType = `cscroll${item_grade(inv[i])}`;
-      let scrollSlot = locate_item(scrollType);
-      if (scrollSlot === -1) {
-        buy(scrollType, 1).then(() => {
-          scrollSlot = locate_item(scrollType);
-        })
-        .catch(e => {breakFlag = true;})
-      }
-      
-      if ( character.mp > 20 && !is_on_cooldown("massproduction"))
-        use_skill('massproduction')
-
-      if (inv[i] !== null && (new Set([inv[i]?.name, inv[i + 1]?.name, inv[i + 2]?.name])).size === 1 && (new Set([inv[i]?.level, inv[i + 1]?.level, inv[i + 2]?.level])).size === 1)
-        compound(i, i + 1, i + 2, scrollSlot)
-          .then((e) => {breakFlag = true;})
-          .catch((e) => e)
-    }
-    if (breakFlag) break;
-  }
-}
-
-async function upgradeInv() {
-  let inv = character.items;
-  
-  if(character.q.upgrade) return;
-  
-  for (let i = 0; i < inv.length; i++) {
-    let breakFlag = false;
-
-    if (inv[i] && (inv[i]?.level > maxUpgrade || item_grade(inv[i]) === 2 || ignore.includes(inv[i].name) )) continue;
-
-    if (item_info(inv[i]).upgrade) {
-      const scrollType = `scroll${item_grade(inv[i])}`;
-      let scrollSlot = locate_item(scrollType);
-      if (scrollSlot === -1) {
-        buy(scrollType, 1).then(() => {
-          scrollSlot = locate_item(scrollType);
-        })
-        .catch(e => {breakFlag = true;})
-      }
-      if ( character.mp > 20 && !is_on_cooldown("massproduction"))
-        use_skill('massproduction')
-      upgrade(i, scrollSlot)
-        .then((e) => {breakFlag = true;})
-        .catch((e) => e)
-    }
-    if (breakFlag) break;
-  }
-}
-
 function filterCompoundableAndStackable() {
   const inv = character.items;
-  const res = Array.from({length: inv.length}, (_, i) => i + 0).filter((i) => inv[i] && (item_info(inv[i]).compound || inv[i].q) && !['hpot1', 'mpot1'].includes(inv[i].name));
+  const res = Array.from({ length: inv.length }, (_, i) => i + 0).filter(
+    (i) =>
+      inv[i] &&
+      (item_info(inv[i]).compound || inv[i].q) &&
+      !["hpot1", "mpot1"].includes(inv[i].name)
+  );
   return res;
 }
 
 //// Interval threads
 // Code Messaging
-setInterval(async function(){
+setInterval(async function () {
   // Xmas buffs
-  if (parent.S['holidayseason'] && !character.s.holidayspirit) {
-    await smart_move({map: 'main', x: -152, y: -137});
-    parent.socket.emit("interaction",{type:"newyear_tree"});
+  if (parent.S["holidayseason"] && !character.s.holidayspirit) {
+    await smart_move({ map: "main", x: -152, y: -137 });
+    parent.socket.emit("interaction", { type: "newyear_tree" });
   }
 
   if (isMerchant()) return;
-  
+
   await sortInv();
   // Fix a bug where character is stuck to corner
   const currentTarget = get_targeted_monster();
 
-  if (currentTarget && !is_in_range(currentTarget, 'attack') && !smart.moving) {
+  if (currentTarget && !is_in_range(currentTarget, "attack") && !smart.moving) {
     smartmoveDebug = true;
-    smart_move({x: currentTarget.x, y: currentTarget.y}).then(() => { smartmoveDebug = false; }).catch(() => { smartmoveDebug = false; });
+    smart_move({ x: currentTarget.x, y: currentTarget.y })
+      .then(() => {
+        smartmoveDebug = false;
+      })
+      .catch(() => {
+        smartmoveDebug = false;
+      });
   }
 
   // Re-equip
-  if (!character.slots.helmet || saleAble.includes(character.slots.helmet.name)) {
-    await equip(character.items.findIndex((item) => !saleAble.includes(item.name) && item_info(item).type === 'helmet' && item.level > 0 ));
+  if (
+    !character.slots.helmet ||
+    saleAble.includes(character.slots.helmet.name)
+  ) {
+    await equip(
+      character.items.findIndex(
+        (item) =>
+          !saleAble.includes(item.name) &&
+          item_info(item).type === "helmet" &&
+          item.level > 0
+      )
+    );
   }
 
   const obj = {
     map: character.map,
     x: character.x,
     y: character.y,
-  }
-  
+  };
+
   // Merchant buff
-  if (!character.s || !character.s.mluck || character.s.mluck.f !== partyMerchant) {
-    log('Asking our merchant for some luck!');
-    send_cm(partyMerchant, {msg: 'buff_mluck', ...obj})
+  if (
+    !character.s ||
+    !character.s.mluck ||
+    character.s.mluck.f !== partyMerchant
+  ) {
+    log("Asking our merchant for some luck!");
+    send_cm(partyMerchant, { msg: "buff_mluck", ...obj });
   }
-  
+
   // Send gold to merchant if he's nearby
   if (get_entity(partyMerchant)) {
     send_gold(partyMerchant, character.gold - 1000000);
@@ -370,31 +403,26 @@ setInterval(async function(){
 
   // Inventory check and potions
   if (character.items[41]) {
-    log('Inventory full! Calling our merchant!');
-    send_cm(partyMerchant, {msg: 'inv_full', ...obj});
-  }
-  else if (!character.items[40] && locate_item('mpot1') === -1) {
-    log('Asking the merchant for some mana potions...');
-    send_cm(partyMerchant, {msg: 'buy_mana', ...obj})
-  }
-  else if (!character.items[40] && locate_item('hpot1') === -1) {
-    log('Asking the merchant for some health potions...');
-    send_cm(partyMerchant, {msg: 'buy_hp', ...obj})
-  }
-  else if (!character.slots.elixir || !character.slots.elixir.name) {
-    log('Drinking Elixir');
+    log("Inventory full! Calling our merchant!");
+    send_cm(partyMerchant, { msg: "inv_full", ...obj });
+  } else if (!character.items[40] && locate_item("mpot1") === -1) {
+    log("Asking the merchant for some mana potions...");
+    send_cm(partyMerchant, { msg: "buy_mana", ...obj });
+  } else if (!character.items[40] && locate_item("hpot1") === -1) {
+    log("Asking the merchant for some health potions...");
+    send_cm(partyMerchant, { msg: "buy_hp", ...obj });
+  } else if (!character.slots.elixir || !character.slots.elixir.name) {
+    log("Drinking Elixir");
 
-    const elixirSlot = locate_item(desiredElixir)
-    
+    const elixirSlot = locate_item(desiredElixir);
+
     if (elixirSlot !== -1) {
       consume(elixirSlot);
-    }
-    else {
-      log('No elixir left! Callin our merchant...');
-      send_cm(partyMerchant, {msg: 'elixir', ...obj, elixir: desiredElixir});
+    } else {
+      log("No elixir left! Callin our merchant...");
+      send_cm(partyMerchant, { msg: "elixir", ...obj, elixir: desiredElixir });
     }
   }
-
 }, 15000);
 
 // Party Setups
@@ -403,12 +431,15 @@ setInterval(function () {
   const loadedCharacters = get_active_characters();
   const allCharacters = [...partyMems, partyMerchant];
 
-  if (allCharacters.filter((characterId) => characterId !== character.name).length !== loadedCharacters.length)
+  if (
+    allCharacters.filter((characterId) => characterId !== character.name)
+      .length !== loadedCharacters.length
+  )
     allCharacters.forEach((characterId, index) => {
       if (!loadedCharacters[characterId]) {
-        start_character(characterId, partyCodeSlot[index])
+        start_character(characterId, partyCodeSlot[index]);
       }
-    })
+    });
 
   if (partyMems.length !== parent.party_list.length) {
     if (character.name === partyMems[0]) {
@@ -422,7 +453,7 @@ setInterval(function () {
     const leader = get_entity(partyMems[0]);
     if (leader && get_target_of(leader)) change_target(get_target_of(leader));
   }
-  
+
   leaveJail();
 }, 1000);
 
@@ -436,16 +467,18 @@ function on_party_invite(name) {
 async function on_game_event(event) {
   if (isMerchant()) return;
   if (boss.includes(event.name)) {
-    log('Attempting boss from game event!');
+    log("Attempting boss from game event!");
 
     const target = getTarget();
-    while(!shouldGoToBoss()) {
+    while (!shouldGoToBoss()) {
       await sleep(5000);
     }
-    
-    stop('move');
+
+    stop("move");
     change_target();
-    smart_move(parent.S[event.name]).then(() => targetBoss(event.name)).catch(() => change_target());
+    smart_move(parent.S[event.name])
+      .then(() => targetBoss(event.name))
+      .catch(() => change_target());
   }
 }
 
@@ -455,58 +488,74 @@ function changeToDailyEventTargets() {
   const isFightingBoss = boss.includes(getTarget()?.mtype);
 
   if (parent.S.snowman?.live && !isFightingBoss) {
-    const snowmanInstance = get_nearest_monster({type: 'snowman'});
+    const snowmanInstance = get_nearest_monster({ type: "snowman" });
     if (!snowmanInstance) smart_move(parent.S.snowman);
     else {
-      if (snowmanInstance.s?.fullguardx) change_target(get_nearest_monster({type: 'arcticbee'}));
+      if (snowmanInstance.s?.fullguardx)
+        change_target(get_nearest_monster({ type: "arcticbee" }));
       else change_target(snowmanInstance);
 
-      return snowmanInstance.s?.fullguardx ? get_nearest_monster({type: 'arcticbee'}) : snowmanInstance;
+      return snowmanInstance.s?.fullguardx
+        ? get_nearest_monster({ type: "arcticbee" })
+        : snowmanInstance;
     }
-  } 
+  }
 
   if (parent.S.crabxx?.live && !isFightingBoss) {
-    const crabxxInstance = get_nearest_monster({type: 'crabxx'});
-    const crabxInstance = get_nearest_monster({type: 'crabx'});
-    if (!crabxxInstance)
-      join('crabxx');
+    const crabxxInstance = get_nearest_monster({ type: "crabxx" });
+    const crabxInstance = get_nearest_monster({ type: "crabx" });
+    if (!crabxxInstance) join("crabxx");
     if (!target) {
       change_target(crabxInstance || crabxxInstance);
       return crabxInstance || crabxxInstance;
     }
-    if (target?.mtype === 'crabxx' && get_nearest_monster({type: 'crabx'})) 
-      return crabxInstance
+    if (target?.mtype === "crabxx" && get_nearest_monster({ type: "crabx" }))
+      return crabxInstance;
   }
-  
-  if (parent.S.icegolem?.live && !isFightingBoss && parent.S.icegolem?.hp < 0.9 * parent.S.icegolem?.max_hp && !partyMems.includes(parent.S.icegolem?.target)) {
-    const iceGolemInstance = get_nearest_monster({type: 'icegolem'});
+
+  if (
+    parent.S.icegolem?.live &&
+    !isFightingBoss &&
+    parent.S.icegolem?.hp < 0.9 * parent.S.icegolem?.max_hp &&
+    !partyMems.includes(parent.S.icegolem?.target)
+  ) {
+    const iceGolemInstance = get_nearest_monster({ type: "icegolem" });
     if (!iceGolemInstance) {
-      if (character.range < 100) join('icegolem');
+      if (character.range < 100) join("icegolem");
       else {
-        smart_move({map: 'winterland', x: 771, y: 273});
+        smart_move({ map: "winterland", x: 771, y: 273 });
       }
     }
     change_target(iceGolemInstance);
     return iceGolemInstance;
-  }
-  else if (get_nearest_monster({type:'icegolem'})) {
+  } else if (get_nearest_monster({ type: "icegolem" })) {
     change_target(target);
-    return get_nearest_monster({type: 'icegolem'});
+    return get_nearest_monster({ type: "icegolem" });
   }
-  
-  if (parent.S.franky && parent.S.franky?.hp < 0.9 * parent.S.franky?.max_hp && !isFightingBoss && !partyMems.includes(parent.S.franky?.target)) {
-    const frankyInstance = get_nearest_monster({type:'franky'});
-    if (!frankyInstance)
-      join('franky');
+
+  if (
+    parent.S.franky &&
+    parent.S.franky?.hp < 0.9 * parent.S.franky?.max_hp &&
+    !isFightingBoss &&
+    !partyMems.includes(parent.S.franky?.target)
+  ) {
+    const frankyInstance = get_nearest_monster({ type: "franky" });
+    if (!frankyInstance) join("franky");
     change_target(frankyInstance);
     return frankyInstance;
   }
 
   if (parent.S.abtesting) {
-    if (character.map!="abtesting")
-      join('abtesting');
+    if (character.map != "abtesting") join("abtesting");
 
-    const priority = ['priest', 'mage', 'ranger', 'rogue', 'warrior', 'paladin'];
+    const priority = [
+      "priest",
+      "mage",
+      "ranger",
+      "rogue",
+      "warrior",
+      "paladin",
+    ];
 
     let pvpTarget = {
       priority: priority.length + 1,
@@ -520,38 +569,47 @@ function changeToDailyEventTargets() {
       if (currentCharacter.team === character.team) continue;
 
       const currentCharacterTarget = {
-        priority: priority.findIndex((element) => element === currentCharacter.ctype),
+        priority: priority.findIndex(
+          (element) => element === currentCharacter.ctype
+        ),
         entity: currentCharacter,
-        sqrDistance: Math.pow(currentCharacter.real_x - character.real_x, 2) + Math.pow(currentCharacter.real_y - character.real_y, 2),
+        sqrDistance:
+          Math.pow(currentCharacter.real_x - character.real_x, 2) +
+          Math.pow(currentCharacter.real_y - character.real_y, 2),
       };
-      
-      if (currentCharacterTarget.priority < pvpTarget.priority) 
+
+      if (currentCharacterTarget.priority < pvpTarget.priority)
         pvpTarget = currentCharacterTarget;
 
-      if (currentCharacterTarget.priority === pvpTarget.priority && currentCharacterTarget.sqrDistance < pvpTarget.sqrDistance)
+      if (
+        currentCharacterTarget.priority === pvpTarget.priority &&
+        currentCharacterTarget.sqrDistance < pvpTarget.sqrDistance
+      )
         pvpTarget = currentCharacterTarget;
     }
 
     target = pvpTarget.entity;
   }
 
-  if (parent.S.goobrawl && !isFightingBoss){
-    if (character.map !== "goobrawl")
-      join('goobrawl');
+  if (
+    (parent.S.goobrawl || get_nearest_monster({ type: "bgoo" })) &&
+    !isFightingBoss
+  ) {
+    if (character.map !== "goobrawl") join("goobrawl");
 
-    const rgooInstance = get_nearest_monster({type: 'rgoo'});
-    const bgooInstance = get_nearest_monster({type: 'bgoo'});
+    const rgooInstance = get_nearest_monster({ type: "rgoo" });
+    const bgooInstance = get_nearest_monster({ type: "bgoo" });
 
     if (rgooInstance) {
       change_target(target);
-      return get_nearest_monster({type: 'rgoo'});
+      return get_nearest_monster({ type: "rgoo" });
     }
 
-    if (!(target && ['bgoo', 'rgoo'].includes(target.mtype))) {
+    if (!(target && ["bgoo", "rgoo"].includes(target.mtype))) {
       change_target(rgooInstance || bgooInstance);
       return rgooInstance || bgooInstance;
     }
   }
-  
+
   return target;
 }

--- a/basic_merchant.5.js
+++ b/basic_merchant.5.js
@@ -2,7 +2,7 @@
 // This is CODE, lets you control your character with code.
 // If you don't know how to code, don't worry, It's easy.
 // Just set attack_mode to true and ENGAGE!
-load_code(7);
+load_code(10);
 // Global Vars
 var onDuty = false;
 var isExeing = false;

--- a/merchant_crafting.10.js
+++ b/merchant_crafting.10.js
@@ -1,0 +1,277 @@
+load_code(7);
+
+let BANK_CACHE = undefined;
+
+const KEEP_THRESHOLD = {
+  // Every character needs
+  helmet: 3,
+  pants: 3,
+  gloves: 3,
+  shoes: 3,
+  chest: 3,
+  cape: 3,
+
+  // Class based
+  weapon: 2,
+  orb: 2,
+  shield: 1, // warrior, 0 if unneccessary
+  source: 2, // priest and mage
+
+  // Class attribute based
+  earring: 4,
+  ring: 4,
+  amulet: 2,
+  belt: 2,
+};
+const ITEMS_HIGHEST_LEVEL = {};
+
+//// INVENTORY functions
+function item_info(item) {
+  return parent.G.items[item.name];
+}
+
+async function retrieveMaxItemsLevel() {
+  if (character.map !== "bank") return;
+
+  // Reset counter;
+  Object.keys(ITEMS_HIGHEST_LEVEL).forEach(
+    (key) => delete ITEMS_HIGHEST_LEVEL[key]
+  );
+
+  BANK_CACHE = character.bank;
+
+  character.items
+    .filter((item) => item && !item.q)
+    .forEach((item) => {
+      if (item.q) return;
+
+      if (!ITEMS_HIGHEST_LEVEL[item.name]) {
+        ITEMS_HIGHEST_LEVEL[item.name] = {
+          level: item.level,
+          quantity: 1,
+          ...item_info(item),
+        };
+      } else {
+        if (item.level > ITEMS_HIGHEST_LEVEL[item.name].level)
+          ITEMS_HIGHEST_LEVEL[item.name].level = item.level;
+        else if (item.level === ITEMS_HIGHEST_LEVEL[item.name].level)
+          ITEMS_HIGHEST_LEVEL[item.name].quantity++;
+      }
+    });
+
+  for (slot in character.bank) {
+    if (slot === "gold") continue;
+
+    log(slot);
+    character.bank[slot]
+      .filter((item) => item && !item.q)
+      .forEach((item) => {
+        if (item.q) return;
+
+        if (!ITEMS_HIGHEST_LEVEL[item.name]) {
+          ITEMS_HIGHEST_LEVEL[item.name] = {
+            level: item.level,
+            quantity: 1,
+            ...item_info(item),
+          };
+        } else {
+          if (item.level > ITEMS_HIGHEST_LEVEL[item.name].level)
+            ITEMS_HIGHEST_LEVEL[item.name].level = item.level;
+          else if (item.level === ITEMS_HIGHEST_LEVEL[item.name].level)
+            ITEMS_HIGHEST_LEVEL[item.name].quantity++;
+        }
+      });
+  }
+}
+
+function getItemBankSlots(itemId) {
+  if (!BANK_CACHE) return [];
+  const result = [];
+  for (id in BANK_CACHE) {
+    if (id === "gold") continue;
+    character.bank[id].forEach((item, index) => {
+      if (!item) return;
+      if (item.name === itemId)
+        result.push({
+          ...item,
+          slot: index,
+          pack: id,
+        });
+    });
+  }
+
+  return result.sort((lhs, rhs) => lhs.level - rhs.level);
+}
+
+function retrievedBankItemToUpgrade() {
+  let desiredItemId = undefined;
+  let maxItemQuantity = 0;
+  for (id in ITEMS_HIGHEST_LEVEL) {
+    if (ITEMS_HIGHEST_LEVEL[id].quantity > maxItemQuantity) {
+      maxItemQuantity = ITEMS_HIGHEST_LEVEL[id].quantity;
+      desiredItemId = id;
+    }
+  }
+
+  let desiredItems = getItemBankSlots(desiredItemId);
+  desiredItems = desiredItems.splice(
+    0,
+    desiredItems.length -
+      KEEP_THRESHOLD[ITEMS_HIGHEST_LEVEL[desiredItemId].type]
+  );
+
+  let inventoryEmptySlots = character.items.filter((item) => !item).length - 5;
+
+  for (const itemSlot of desiredItems) {
+    if (inventoryEmptySlots === 0) break;
+    else inventoryEmptySlots--;
+
+    bank_retrieve(itemSlot.pack, itemSlot.slot);
+  }
+}
+
+if (Object.keys(ITEMS_HIGHEST_LEVEL).length === 0) {
+  close_stand();
+  smart_move("bank").then(() => {
+    retrieveMaxItemsLevel();
+    retrievedBankItemToUpgrade();
+  });
+}
+setInterval(() => {
+  if (
+    character.map === "main" &&
+    !onDuty &&
+    !smart.moving &&
+    !character.q.exchange &&
+    !character.c.fishing &&
+    !character.c.mining
+  ) {
+    close_stand();
+    smart_move("bank").then(() => {
+      retrieveMaxItemsLevel();
+      retrievedBankItemToUpgrade();
+    });
+  }
+}, 120000);
+
+async function compoundInv() {
+  let inv = character.items;
+
+  if (character.q.compound) return;
+
+  for (let i = 0; i < inv.length; i++) {
+    let breakFlag = false;
+
+    if (inv[i] && (inv[i]?.level > 2 || item_grade(inv[i]) === 2))
+      if (
+        !(
+          ITEMS_HIGHEST_LEVEL[inv[i]?.name] &&
+          ITEMS_HIGHEST_LEVEL[inv[i]?.name].quantity >
+            KEEP_THRESHOLD[ITEMS_HIGHEST_LEVEL[inv[i]?.name].type] &&
+          inv[i]?.level === ITEMS_HIGHEST_LEVEL[inv[i]?.name].level
+        )
+      )
+        continue;
+
+    if (item_info(inv[i]).compound) {
+      const scrollType = `cscroll${item_grade(inv[i])}`;
+      let scrollSlot = locate_item(scrollType);
+      if (scrollSlot === -1) {
+        buy(scrollType, 1)
+          .then(() => {
+            scrollSlot = locate_item(scrollType);
+          })
+          .catch((e) => {
+            breakFlag = true;
+          });
+      }
+
+      if (character.mp > 20 && !is_on_cooldown("massproduction"))
+        use_skill("massproduction");
+
+      if (
+        inv[i] !== null &&
+        new Set([inv[i]?.name, inv[i + 1]?.name, inv[i + 2]?.name]).size ===
+          1 &&
+        new Set([inv[i]?.level, inv[i + 1]?.level, inv[i + 2]?.level]).size ===
+          1
+      )
+        compound(i, i + 1, i + 2, scrollSlot)
+          .then((e) => {
+            breakFlag = true;
+          })
+          .catch((e) => e);
+    }
+    if (breakFlag) break;
+  }
+}
+
+async function upgradeInv() {
+  let inv = character.items;
+
+  if (character.q.upgrade) return;
+
+  for (let i = 0; i < inv.length; i++) {
+    let breakFlag = false;
+    if (ignore.includes(inv[i].name)) continue;
+
+    if (
+      inv[i] &&
+      (inv[i]?.level > maxUpgrade || item_grade(inv[i]) === 2) &&
+      inv[i]?.level >= ITEMS_HIGHEST_LEVEL[inv[i]?.name].level
+    )
+      if (
+        !(
+          ITEMS_HIGHEST_LEVEL[inv[i]?.name] &&
+          ITEMS_HIGHEST_LEVEL[inv[i]?.name].quantity >
+            KEEP_THRESHOLD[ITEMS_HIGHEST_LEVEL[inv[i]?.name].type] &&
+          inv[i]?.level === ITEMS_HIGHEST_LEVEL[inv[i]?.name].level
+        )
+      )
+        continue;
+
+    if (item_info(inv[i]).upgrade) {
+      const scrollType = `scroll${item_grade(inv[i])}`;
+      let scrollSlot = locate_item(scrollType);
+      if (scrollSlot === -1) {
+        buy(scrollType, 1)
+          .then(() => {
+            scrollSlot = locate_item(scrollType);
+          })
+          .catch((e) => {
+            breakFlag = true;
+          });
+      }
+      if (character.mp > 20 && !is_on_cooldown("massproduction"))
+        use_skill("massproduction");
+      upgrade(i, scrollSlot)
+        .then(async (e) => {
+          if (e?.success === true) {
+            if (e?.level > ITEMS_HIGHEST_LEVEL[inv[i]?.name].level)
+              ITEMS_HIGHEST_LEVEL[item.name] = {
+                level: item.level,
+                quantity: 1,
+                ...item_info(item),
+              };
+
+            if (e?.level >= ITEMS_HIGHEST_LEVEL[inv[i]?.name].level - 1) {
+              close_stand();
+              smart_move("bank").then(() =>
+                bank_store(
+                  character.items.findIndex(
+                    (item) =>
+                      item &&
+                      item.name === inv[i].name &&
+                      item.level === e?.level
+                  )
+                )
+              );
+            }
+          }
+          breakFlag = true;
+        })
+        .catch((e) => e);
+    }
+    if (breakFlag) break;
+  }
+}


### PR DESCRIPTION
- [x] Merchant now go to bank every 2 minutes to check out the bank and cache the data, also listing the highest level of upgradables and compoundables.
- [x] As merchant go to the bank to checkout the data, it will also get the item with the most duplicates of lowest level to retrieve to upgrade at `main`
- [x] The level limit on upgrade and compound will alter between the set value and the max level on cache.
- [ ] Storing the item after upgrade/compound if its level is greater or equal max level - 1 of this item in cache (still buggy)