### PR TITLE
Feat/merchant craft

### DIFF
--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -327,6 +327,10 @@ function goToBoss() {
   }
   return false;
 }
+//// INVENTORY functions
+function item_info(item) {
+  return parent.G.items[item.name];
+}
 
 function filterCompoundableAndStackable() {
   const inv = character.items;

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -66,7 +66,67 @@ var ignore = [
   "broom",
   "pumpkinspice",
   "tracker",
+  "sword",
 ];
+
+var storeAble = [
+  "vitscroll",
+  "snowball",
+  "pvptoken",
+  "pumpkinspice",
+  "eggnog",
+  "offeringp",
+  "offering",
+  "monstertoken",
+  "hotchocolate",
+  "gum",
+  "essenceofgreed",
+  "elixirint0",
+  "elixirdex0",
+  "egg5",
+  "cscroll2",
+  "cryptkey",
+  "cake",
+  "elixirstr0",
+  "elixirstr1",
+  "elixirvit0",
+  "elixirvit1",
+  "elixirvit2",
+  "essenceoflife",
+  "frozenkey",
+  "funtoken",
+  "gem1",
+  "whiteegg",
+  "sstinger",
+  "spores",
+  "snakefang",
+  "seashell",
+  "rattail",
+  "pstem",
+  "poison",
+  "pleather",
+  "lspores",
+  "lotusf",
+  "lostearring",
+  "leather",
+  "ink",
+  "gslime",
+  "frogt",
+  "forscroll",
+  "feather0",
+  "essenceofnature",
+  "essenceoffrost",
+  "dexscroll",
+  "cshell",
+  "crabclaw",
+  "carrot",
+  "bwing",
+  "btusk",
+  "bfur",
+  "beewings",
+  "ascale",
+];
+
 var saleAble = [
   "cclaw",
   "wattire",
@@ -92,6 +152,11 @@ var saleAble = [
   "bowofthedead",
   "swordofthedead",
   "throwingstars",
+  "hhelmet",
+  "hgloves",
+  "harmor",
+  "hpants",
+  "hboots",
   "smoke",
 ];
 var maxUpgrade = 7;
@@ -332,6 +397,10 @@ function item_info(item) {
   return parent.G.items[item.name];
 }
 
+function isInvFull(slots = 1) {
+  return character.items.filter((item) => !item).length <= slots;
+}
+
 function filterCompoundableAndStackable() {
   const inv = character.items;
   const res = Array.from({ length: inv.length }, (_, i) => i + 0).filter(
@@ -354,7 +423,6 @@ setInterval(async function () {
 
   if (isMerchant()) return;
 
-  await sortInv();
   // Fix a bug where character is stuck to corner
   const currentTarget = get_targeted_monster();
 
@@ -406,13 +474,13 @@ setInterval(async function () {
   }
 
   // Inventory check and potions
-  if (character.items[41]) {
+  if (isInvFull()) {
     log("Inventory full! Calling our merchant!");
     send_cm(partyMerchant, { msg: "inv_full", ...obj });
-  } else if (!character.items[40] && locate_item("mpot1") === -1) {
+  } else if (!isInvFull(2) && locate_item("mpot1") === -1) {
     log("Asking the merchant for some mana potions...");
     send_cm(partyMerchant, { msg: "buy_mana", ...obj });
-  } else if (!character.items[40] && locate_item("hpot1") === -1) {
+  } else if (!isInvFull(2) && locate_item("hpot1") === -1) {
     log("Asking the merchant for some health potions...");
     send_cm(partyMerchant, { msg: "buy_hp", ...obj });
   } else if (!character.slots.elixir || !character.slots.elixir.name) {

--- a/basic_mage.4.js
+++ b/basic_mage.4.js
@@ -5,54 +5,117 @@ load_code(8);
 // Kiting
 var rangeRate = 0.76;
 
-function fight(target) {	
-	if(character.rip) {respawn(); return;}
-	
-	if(can_attack(target))
-	{
-		set_message("Attacking");
-		attack(target);
-		if(!is_on_cooldown("burst") && target.hp > 3000 && character.mp > 2000)
-			use_skill('burst');
-		if(!is_on_cooldown("energize") && character.mp > 1200){
-			const buffee = getLowestMana();
-			if (buffee.max_mp - buffee.mp > 500 && buffee.mp < buffee.max_mp * 0.5) use_skill('energize', buffee);
-		}
-		if(target['damage_type'] === 'magical' &&  !is_on_cooldown("reflection") && partyMems.includes(target.target) && character.mp > 1000) {
-			use_skill('reflection', get_entity(target.target));
-		}
-		if(character.mp > 100 && !is_on_cooldown("scare") && target.max_hp > 3000 && Object.keys(parent.entities).some(entity => parent.entities[entity]?.target === character.name))
-			use_skill('scare');
-	}
-	
-	if (!smartmoveDebug) {
-		hitAndRun(target, rangeRate);	
-  		angle = angle + flipRotation * Math.asin((character.speed * (1 / character.frequency) / 4) / (character.range * rangeRate)) * 2;
-	}
-	else {
-		angle = undefined;
-	}
+function fight(target) {
+  if (character.rip) {
+    respawn();
+    return;
+  }
+
+  if (can_attack(target)) {
+    set_message("Attacking");
+    attack(target);
+    if (
+      !is_on_cooldown("burst") &&
+      target.hp > 3000 &&
+      target.resistance > 400 &&
+      character.mp > 2000
+    ) {
+      log("Maxima Burst!");
+      use_skill("burst");
+    }
+
+    // if (
+    //   !is_on_cooldown("cburst") &&
+    //   character.mp > 1000 &&
+    //   get_targeted_monster().hp < 200 &&
+    //   !get_targeted_monster().hp?.["1hp"]
+    // ) {
+    //   use_skill("cburst", [[get_targeted_monster(), target.hp * 2]]);
+    // }
+
+    if (!is_on_cooldown("energize") && character.mp > 1200) {
+      const buffee = getLowestMana();
+      if (buffee.max_mp - buffee.mp > 500 && buffee.mp < buffee.max_mp * 0.5) {
+        log("Energize " + buffee?.name);
+        use_skill("energize", buffee);
+      } else {
+        use_skill("energize", get_entity(partyMems[0]));
+      }
+    }
+    if (
+      target["damage_type"] === "magical" &&
+      !is_on_cooldown("reflection") &&
+      partyMems.includes(target.target) &&
+      character.mp > 1000
+    ) {
+      use_skill("reflection", get_entity(target.target));
+    }
+    if (
+      character.mp > 100 &&
+      !is_on_cooldown("scare") &&
+      target.max_hp > 3000 &&
+      Object.keys(parent.entities).some(
+        (entity) => parent.entities[entity]?.target === character.name
+      )
+    )
+      use_skill("scare");
+  }
+
+  if (character.mp > 2000 && !is_on_cooldown("alchemy") && !isInvFull()) {
+    const sellableSlot = character.items.findIndex((item) =>
+      saleAble.includes(item?.name)
+    );
+
+    if (sellableSlot !== -1) {
+      if (sellableSlot === 0) {
+        use_skill("alchemy");
+      } else {
+        swap(0, sellableSlot).then(() => use_skill("alchemy"));
+      }
+    }
+  }
+
+  if (!smartmoveDebug) {
+    hitAndRun(target, rangeRate);
+    angle =
+      angle +
+      flipRotation *
+        Math.asin(
+          (character.speed * (1 / character.frequency)) /
+            4 /
+            (character.range * rangeRate)
+        ) *
+        2;
+  } else {
+    angle = undefined;
+  }
 }
 
-setInterval(function() {
-	loot();
-	buff();
-	
-	if(character.rip) {respawn(); return;}
-	
-	if(smart.moving && !smartmoveDebug) return;
-	
-	let target = getTarget();
-	
-	if (goToBoss()) return;
-	
-	//// EVENTS
-	target = changeToDailyEventTargets();
-	
-	//// Logic to targets and farm places
-	if(!smart.moving && !target && !get_entity(partyMems[0])) smart_move({
-		map, x: mapX, y: mapY,
-	}).catch(e => use_skill('use_town'));
-	
-	fight(target);
-}, (1 / character.frequency) * 1000 / 2);
+setInterval(function () {
+  loot();
+  buff();
+
+  if (character.rip) {
+    respawn();
+    return;
+  }
+
+  if (smart.moving && !smartmoveDebug) return;
+
+  let target = getTarget();
+
+  if (goToBoss()) return;
+
+  //// EVENTS
+  target = changeToDailyEventTargets();
+
+  //// Logic to targets and farm places
+  if (!smart.moving && !target && !get_entity(partyMems[0]))
+    smart_move({
+      map,
+      x: mapX,
+      y: mapY,
+    }).catch((e) => use_skill("use_town"));
+
+  fight(target);
+}, ((1 / character.frequency) * 1000) / 2);

--- a/basic_merchant.5.js
+++ b/basic_merchant.5.js
@@ -8,94 +8,105 @@ var onDuty = false;
 var isExeing = false;
 
 const fishingLocation = { map: "main", x: -1368, y: -82 };
-const miningLocation = { map: 'tunnel', x: -279 ,y: -148 };
+const miningLocation = { map: "tunnel", x: -279, y: -148 };
 
 function isInvFull(slots = 1) {
-	return character.items.filter(item => !item).length <= slots;
+  return character.items.filter((item) => !item).length <= slots;
 }
 
 function equipBroom() {
-	const currentWeapon = character.slots.mainhand;
-	if (!currentWeapon || currentWeapon.name !== 'broom') {	
-		const broom = locate_item('broom');
-		if (broom !== -1) equip(broom);
-	}
+  const currentWeapon = character.slots.mainhand;
+  if (!currentWeapon || currentWeapon.name !== "broom") {
+    const broom = locate_item("broom");
+    if (broom !== -1) equip(broom);
+  }
 }
 async function holidayExchange() {
-	if (onDuty || isInvFull(4) || character.q.exchange || smart.moving || (!is_on_cooldown("fishing") && locate_item('rod') !== -1) || (!is_on_cooldown("mining") && locate_item('pickaxe') !== -1) || character.c.mining || character.c.fishing) return;
-	
-	const holidayItems = [
-		{
-			name: 'mistletoe',
-			npc: 'mistletoe',
-			quantity: 1,
-			keep: 0,
-		},
-		{
-			name: 'ornament',
-			npc: 'ornaments',
-			quantity: 20,
-			keep: 10,
-		},
-		{
-			name: 'candycane',
-			npc: 'santa',
-			quantity: 1,
-			keep: 0,
-		},
-	];
-	
-	const exchangableItem = holidayItems.find((item) => {
-		const slot = locate_item(item.name);
-		if (slot === -1) return false;
-		return character.items[slot]?.q >= item.quantity + item.keep;
-	});
-	
-	if (!exchangableItem) return;
-	
-	if (get_nearest_npc()?.npc !== exchangableItem.npc) {
-		close_stand();
-		equipBroom();
-		await smart_move(find_npc(exchangableItem.npc));
-	}
-	
-	return exchange(locate_item(exchangableItem.name)).catch(e => {
-    	switch(e.response) {
-     		case "inventory_full":
-      		onDuty = true;
-      	}
-    });
-}
+  if (
+    onDuty ||
+    isInvFull(6) ||
+    character.q.exchange ||
+    smart.moving ||
+    (!is_on_cooldown("fishing") && locate_item("rod") !== -1) ||
+    (!is_on_cooldown("mining") && locate_item("pickaxe") !== -1) ||
+    character.c.mining ||
+    character.c.fishing
+  )
+    return;
 
-function exchangeXyn() {
-  // const itemName = ['candy1', 'candycane', 'candy0', 'mistletoe', 'gem0', 'weaponbox', 'armorbox'];
-  const itemName = ['candy1', 'candy0', 'gem0', 'weaponbox', 'armorbox'];
-  let slot = undefined;
-  itemName.map(name => {
-    if (locate_item(name) !== -1) slot = locate_item(name);
-  })
-  
-  if (slot !== undefined) exchange(slot).catch(e => {
-    switch(e.response) {
+  const holidayItems = [
+    {
+      name: "mistletoe",
+      npc: "mistletoe",
+      quantity: 1,
+      keep: 0,
+    },
+    {
+      name: "ornament",
+      npc: "ornaments",
+      quantity: 20,
+      keep: 10,
+    },
+    {
+      name: "candycane",
+      npc: "santa",
+      quantity: 1,
+      keep: 0,
+    },
+  ];
+
+  const exchangableItem = holidayItems.find((item) => {
+    const slot = locate_item(item.name);
+    if (slot === -1) return false;
+    return character.items[slot]?.q >= item.quantity + item.keep;
+  });
+
+  if (!exchangableItem) return;
+
+  if (get_nearest_npc()?.npc !== exchangableItem.npc) {
+    close_stand();
+    equipBroom();
+    await smart_move(find_npc(exchangableItem.npc));
+  }
+
+  return exchange(locate_item(exchangableItem.name)).catch((e) => {
+    switch (e.response) {
       case "inventory_full":
         onDuty = true;
     }
   });
 }
 
-async function exchangeMines() {
-  const itemName = ['gemfragment'];
+function exchangeXyn() {
+  // const itemName = ['candy1', 'candycane', 'candy0', 'mistletoe', 'gem0', 'weaponbox', 'armorbox'];
+  const itemName = ["candy1", "candy0", "gem0", "weaponbox", "armorbox"];
   let slot = undefined;
-  itemName.map(name => {
+  itemName.map((name) => {
     if (locate_item(name) !== -1) slot = locate_item(name);
-  })
-	
+  });
+
+  if (slot !== undefined)
+    exchange(slot).catch((e) => {
+      switch (e.response) {
+        case "inventory_full":
+          onDuty = true;
+      }
+    });
+}
+
+async function exchangeMines() {
+  const itemName = ["gemfragment"];
+  let slot = undefined;
+  itemName.map((name) => {
+    if (locate_item(name) !== -1) slot = locate_item(name);
+  });
+
   if (slot && character.items[slot].q >= 50) {
-	if (!smart.moving && character.map !== 'tunnel') {
-		await smart_move('tunnel');
-	}
-	await exchange(slot).catch(e => {
-      switch(e.response) {
+    if (!smart.moving && character.map !== "tunnel") {
+      await smart_move("tunnel");
+    }
+    await exchange(slot).catch((e) => {
+      switch (e.response) {
         case "inventory_full":
           onDuty = true;
       }
@@ -104,257 +115,318 @@ async function exchangeMines() {
 }
 
 function moveHome() {
-	if ((character.map === 'main' && character.real_x === -152 && character.real_y ===-137) || smart.moving || character.moving || character.q.exchange) return;
-	log('Moving back Town!')
-	return smart_move({map: 'main', x: -152, y: -137}).then(() => {
-		onDuty = false;
-		open_stand(locate_item('stand0'));
-	});
+  if (
+    (character.map === "main" &&
+      character.real_x === -152 &&
+      character.real_y === -137) ||
+    smart.moving ||
+    character.moving ||
+    character.q.exchange
+  )
+    return;
+  log("Moving back Town!");
+  return smart_move({ map: "main", x: -152, y: -137 }).then(() => {
+    onDuty = false;
+    open_stand(locate_item("stand0"));
+  });
 }
 
 async function goFishing() {
-	if (isInvFull()) return;
-	if (!smart.moving && !character.q.compound && !character.q.upgrade && !character.q.exchange && !character.c.mining &&  !character.c.fishing && !is_on_cooldown('fishing')) {
-		const currentWeapon = character.slots.mainhand;
-		
-		if (!currentWeapon || currentWeapon.name !== 'rod') {	
-			const fishRod = locate_item('rod');
-			if (fishRod !== -1) equip(fishRod);
-			else return moveHome();
-		}
-		if (character.real_x != fishingLocation.x && character.real_y != fishingLocation.y) 
-        {
-			close_stand()
-            await smart_move(fishingLocation);
-        }
-		if (character.mp > 120) {
-            if (!character.c.fishing) {
-                log("Fishin!");
-                use_skill('fishing');
-            }
-        }
-	}
+  if (isInvFull()) return;
+  if (
+    !smart.moving &&
+    !character.q.compound &&
+    !character.q.upgrade &&
+    !character.q.exchange &&
+    !character.c.mining &&
+    !character.c.fishing &&
+    !is_on_cooldown("fishing")
+  ) {
+    const currentWeapon = character.slots.mainhand;
+
+    if (!currentWeapon || currentWeapon.name !== "rod") {
+      const fishRod = locate_item("rod");
+      if (fishRod !== -1) equip(fishRod);
+      else return moveHome();
+    }
+    if (
+      character.real_x != fishingLocation.x &&
+      character.real_y != fishingLocation.y
+    ) {
+      close_stand();
+      await smart_move(fishingLocation);
+    }
+    if (character.mp > 120) {
+      if (!character.c.fishing) {
+        log("Fishin!");
+        use_skill("fishing");
+      }
+    }
+  }
 }
 
 async function goMining() {
-	if (isInvFull()) return;
-	if (!smart.moving && !character.q.compound && !character.q.upgrade && !character.q.exchange && !character.c.fishing && !character.c.mining && !is_on_cooldown('mining')) {
-		const currentWeapon = character.slots.mainhand;
-		
-		if (!currentWeapon || currentWeapon.name !== 'pickaxe') {	
-			const pickAxe = locate_item('pickaxe');
-			if (pickAxe !== -1) equip(pickAxe);
-			else return moveHome();
-		}
-		if (character.real_x != miningLocation.x && character.real_y != miningLocation.y) 
-        {
-			close_stand()
-            await smart_move(miningLocation);
-        }
-		if (character.mp > 120) {
-            if (!character.c.mining) {
-                log("Minin!");
-                use_skill('mining');
-            }
-        }
-	}
+  if (isInvFull()) return;
+  if (
+    !smart.moving &&
+    !character.q.compound &&
+    !character.q.upgrade &&
+    !character.q.exchange &&
+    !character.c.fishing &&
+    !character.c.mining &&
+    !is_on_cooldown("mining")
+  ) {
+    const currentWeapon = character.slots.mainhand;
+
+    if (!currentWeapon || currentWeapon.name !== "pickaxe") {
+      const pickAxe = locate_item("pickaxe");
+      if (pickAxe !== -1) equip(pickAxe);
+      else return moveHome();
+    }
+    if (
+      character.real_x != miningLocation.x &&
+      character.real_y != miningLocation.y
+    ) {
+      close_stand();
+      await smart_move(miningLocation);
+    }
+    if (character.mp > 120) {
+      if (!character.c.mining) {
+        log("Minin!");
+        use_skill("mining");
+      }
+    }
+  }
 }
 
 async function craft(item) {
-	// Check if craftable
-	if (onDuty || isInvFull(4) || character.q.exchange || smart.moving || (!is_on_cooldown("fishing") && locate_item('rod') !== -1) || (!is_on_cooldown("mining") && locate_item('pickaxe') !== -1) || character.c.mining || character.c.fishing) return;
-	
-	if (!G.craft[item]) {
-		log('Invalid craftable item id');
-		return;
-	}
-	const isEnoughIngredients = G.craft[item].items.every(([quantity, name]) => {
-		const slot = locate_item(name);
-		return slot !== -1 && character.items[slot]?.q >= quantity;
-	})
-	if (isEnoughIngredients) {
-		if (get_nearest_npc()?.name !== 'Leo') {
-			close_stand();
-			await smart_move(find_npc('craftsman'));
-		}
-		return auto_craft(item);
-	}
+  // Check if craftable
+  if (
+    onDuty ||
+    isInvFull(4) ||
+    character.q.exchange ||
+    smart.moving ||
+    (!is_on_cooldown("fishing") && locate_item("rod") !== -1) ||
+    (!is_on_cooldown("mining") && locate_item("pickaxe") !== -1) ||
+    character.c.mining ||
+    character.c.fishing
+  )
+    return;
+
+  if (!G.craft[item]) {
+    log("Invalid craftable item id");
+    return;
+  }
+  const isEnoughIngredients = G.craft[item].items.every(([quantity, name]) => {
+    const slot = locate_item(name);
+    return slot !== -1 && character.items[slot]?.q >= quantity;
+  });
+  if (isEnoughIngredients) {
+    if (get_nearest_npc()?.name !== "Leo") {
+      close_stand();
+      await smart_move(find_npc("craftsman"));
+    }
+    return auto_craft(item);
+  }
 }
 
-setInterval(async function(){
-	buff();
-	loot();
-	
-	if(character.rip) {respawn(); return;}
-	
-	await sortInv()
-	var inv = character.items;
-   	const invLength = inv.length;
-	
-	Promise.all([
-		compoundInv(),
-		upgradeInv(),
-		exchangeXyn(),
-		holidayExchange(),
-		craft('xbox'),
-		Promise.all(
-			Array.from({length: 42}, (_, i) => i)
-			.filter(i => {
-				if (!character.items[i]) return false;
-				return saleAble.includes(character.items[i].name) && !character.items[i].shiny;
-			})
-			.map(async i => sell(i))
-		),
-	]);
-	
-	if(!is_on_cooldown('fishing'))
-		goFishing();
-	else if(!is_on_cooldown('mining'))
-		goMining();
-	else if (locate_item('gemfragment') !== -1 && character.items[locate_item('gemfragment')]?.q >= 50)
-		exchangeMines();
-	else if (!smart.moving && !character.c.mining && !character.c.fishing && !character.q.exchanging)
-		await moveHome();
-	
-	if (isInvFull() && !smart.moving) {
-		if (!smart.move) await moveHome();
-		close_stand();
-		if (!smart.move) await smart_move('bank');
-		if (character.map === 'bank') Array.from({length: 42}, (_, i) => i).filter(index => inv[index] && !item_info(inv[index]).compound && !ignore.includes(inv[index].name)).map(i => bank_store(i));
-		if (!smart.move) await moveHome();
-		onDuty = false;
-	}
-	
-	
+setInterval(async function () {
+  buff();
+  loot();
+
+  if (character.rip) {
+    respawn();
+    return;
+  }
+
+  await sortInv();
+  var inv = character.items;
+  const invLength = inv.length;
+
+  Promise.all([
+    compoundInv(),
+    upgradeInv(),
+    exchangeXyn(),
+    holidayExchange(),
+    craft("xbox"),
+    Promise.all(
+      Array.from({ length: 42 }, (_, i) => i)
+        .filter((i) => {
+          if (!character.items[i]) return false;
+          return (
+            saleAble.includes(character.items[i].name) &&
+            !character.items[i].shiny
+          );
+        })
+        .map(async (i) => sell(i))
+    ),
+  ]);
+
+  if (!is_on_cooldown("fishing")) goFishing();
+  else if (!is_on_cooldown("mining")) goMining();
+  else if (
+    locate_item("gemfragment") !== -1 &&
+    character.items[locate_item("gemfragment")]?.q >= 50
+  )
+    exchangeMines();
+  else if (
+    !smart.moving &&
+    !character.c.mining &&
+    !character.c.fishing &&
+    !character.q.exchanging
+  )
+    await moveHome();
+
+  if (isInvFull() && !smart.moving) {
+    if (!smart.move) await moveHome();
+    close_stand();
+    if (!smart.move) await smart_move("bank");
+    if (character.map === "bank")
+      Array.from({ length: 42 }, (_, i) => i)
+        .filter(
+          (index) =>
+            inv[index] &&
+            !item_info(inv[index]).compound &&
+            !ignore.includes(inv[index].name)
+        )
+        .map((i) => bank_store(i));
+    if (!smart.move) await moveHome();
+    onDuty = false;
+  }
 }, 3000);
 
-setInterval(function() { onDuty = false; use_skill('mluck', character)}, 300000)
+setInterval(function () {
+  onDuty = false;
+  use_skill("mluck", character);
+}, 300000);
 
 function on_party_invite(name) {
-	if (name === partyMems[0]) accept_party_invite(name);
-	
-}; // called by the inviter's name
+  if (name === partyMems[0]) accept_party_invite(name);
+} // called by the inviter's name
 
 function handle_death() {
-	respawn();
+  respawn();
 }
 
-character.on("cm", async function({name, message}){
-	if (isInvFull()) {
-		return;
-	}
-	switch(message) {
-		case 'inv_ok':
-			onDuty = false;
-			moveHome();
-			break;
-	}
-	if (!onDuty) {onDuty = true; close_stand();}
-	else return;
-	
-	equipBroom();
-	// const sender = get_characters().find(character => character.name === name);
-	
-	switch(message.msg) {
-		case 'inv_full':
-			log(`Go collecting ${name} compoundables at ${message.map}`);
-			await smart_move({
-				...message,
-			});
-			send_cm(name, 'inv_full_merchant_near');
-			await sleep(5000);
-			onDuty = false;
-			moveHome();
-			break;
-			
-		case 'buy_mana':
-			log(`Buying some mana potions for ${name}`);
-			if(isInvFull()) {
-				if (!smart.move) await smart_move('bank');
-				if (character.map === 'bank') bank_store(0);
-			}
-			if(locate_item('mpot1') === -1) {
-				await smart_move(find_npc('fancypots'));
-				await buy('mpot1', 10000)
-			};
-			await smart_move({
-				...message
-			});
-			await send_item(name, locate_item('mpot1'), 10000);
-			send_cm(name, 'buy_mana_merchant_near');
-			await sleep(5000);
-			onDuty = false;
-			moveHome();
-			break;
-			
-		case 'buy_hp':
-			log(`Buying some health potions for ${name}`);
-			if(isInvFull()) {
-				if (!smart.move) await smart_move('bank');
-				if (character.map === 'bank') bank_store(0);
-			}
-			if(locate_item('hpot1') === -1) {
-				await smart_move(find_npc('fancypots'));
-				await buy('hpot1', 10000)
-			};
-			await smart_move({
-				...message,
-			});
-			await send_item(name, locate_item('hpot1'), 10000);
-			send_cm(name, 'buy_hp_merchant_near');
-			await sleep(5000);
-			onDuty = false;
-			moveHome();
-			break;
-			
-		case 'buff_mluck':
-			await smart_move({
-				...message,
-			});
-			if (!is_on_cooldown('mluck') && character.mp > 20) {
-				use_skill('mluck', get_entity(name))
-			}
-			onDuty = false;
-			moveHome();
-			break;
-			
-		case 'elixir':
-			if (locate_item(message.elixir) === -1) {
-				let itemBankSlot = undefined;
-				let itemSlot = undefined;
-				await smart_move('bank');
-				Object.keys(character.bank).filter(id => id !== 'gold').map((slot) => {
-					character.bank[slot]?.map((item, index)=> {
-						if (item && item.name === message.elixir) {
-							itemBankSlot = slot;
-							itemSlot = index;
-						}
-					})
-				})
-				if (itemBankSlot && itemSlot) {
-					bank_retrieve(itemBankSlot, itemSlot);
-				}
-				else {
-					await smart_move({map: find_npc('wbartender').map});
-					buy(message.elixir);
-				}
-			}
-			if (!locate_item(message.elixir)) {
-				onDuty = false; 
-				break;
-			}
-			await smart_move({
-				...message,
-			});
-			await send_item(name, locate_item(message.elixir), 10);
-			onDuty = false;
-			break;
-			
-		default:
-			onDuty = false;
-			log(`Unidentified '${message.msg}'`);
-	}
-})
+character.on("cm", async function ({ name, message }) {
+  if (isInvFull()) {
+    return;
+  }
+  switch (message) {
+    case "inv_ok":
+      onDuty = false;
+      moveHome();
+      break;
+  }
+  if (!onDuty) {
+    onDuty = true;
+    close_stand();
+  } else return;
+
+  equipBroom();
+  // const sender = get_characters().find(character => character.name === name);
+
+  switch (message.msg) {
+    case "inv_full":
+      log(`Go collecting ${name} compoundables at ${message.map}`);
+      await smart_move({
+        ...message,
+      });
+      send_cm(name, "inv_full_merchant_near");
+      await sleep(5000);
+      onDuty = false;
+      moveHome();
+      break;
+
+    case "buy_mana":
+      log(`Buying some mana potions for ${name}`);
+      if (isInvFull()) {
+        if (!smart.move) await smart_move("bank");
+        if (character.map === "bank") bank_store(0);
+      }
+      if (locate_item("mpot1") === -1) {
+        await smart_move(find_npc("fancypots"));
+        await buy("mpot1", 10000);
+      }
+      await smart_move({
+        ...message,
+      });
+      await send_item(name, locate_item("mpot1"), 10000);
+      send_cm(name, "buy_mana_merchant_near");
+      await sleep(5000);
+      onDuty = false;
+      moveHome();
+      break;
+
+    case "buy_hp":
+      log(`Buying some health potions for ${name}`);
+      if (isInvFull()) {
+        if (!smart.move) await smart_move("bank");
+        if (character.map === "bank") bank_store(0);
+      }
+      if (locate_item("hpot1") === -1) {
+        await smart_move(find_npc("fancypots"));
+        await buy("hpot1", 10000);
+      }
+      await smart_move({
+        ...message,
+      });
+      await send_item(name, locate_item("hpot1"), 10000);
+      send_cm(name, "buy_hp_merchant_near");
+      await sleep(5000);
+      onDuty = false;
+      moveHome();
+      break;
+
+    case "buff_mluck":
+      await smart_move({
+        ...message,
+      });
+      if (!is_on_cooldown("mluck") && character.mp > 20) {
+        use_skill("mluck", get_entity(name));
+      }
+      onDuty = false;
+      moveHome();
+      break;
+
+    case "elixir":
+      if (locate_item(message.elixir) === -1) {
+        let itemBankSlot = undefined;
+        let itemSlot = undefined;
+        await smart_move("bank");
+        Object.keys(character.bank)
+          .filter((id) => id !== "gold")
+          .map((slot) => {
+            character.bank[slot]?.map((item, index) => {
+              if (item && item.name === message.elixir) {
+                itemBankSlot = slot;
+                itemSlot = index;
+              }
+            });
+          });
+        if (itemBankSlot && itemSlot) {
+          bank_retrieve(itemBankSlot, itemSlot);
+        } else {
+          await smart_move({ map: find_npc("wbartender").map });
+          buy(message.elixir);
+        }
+      }
+      if (!locate_item(message.elixir)) {
+        onDuty = false;
+        break;
+      }
+      await smart_move({
+        ...message,
+      });
+      await send_item(name, locate_item(message.elixir), 10);
+      onDuty = false;
+      break;
+
+    default:
+      onDuty = false;
+      log(`Unidentified '${message.msg}'`);
+  }
+});
 
 // Learn Javascript: https://www.codecademy.com/learn/introduction-to-javascript
 // Write your own CODE: https://github.com/kaansoral/adventureland

--- a/basic_merchant.5.js
+++ b/basic_merchant.5.js
@@ -236,8 +236,6 @@ setInterval(async function () {
   }
 
   await sortInv();
-  var inv = character.items;
-  const invLength = inv.length;
 
   Promise.all([
     compoundInv(),
@@ -281,9 +279,8 @@ setInterval(async function () {
       Array.from({ length: 42 }, (_, i) => i)
         .filter(
           (index) =>
-            inv[index] &&
-            !item_info(inv[index]).compound &&
-            !ignore.includes(inv[index].name)
+            character.items[index] &&
+            !ignore.includes(character.items[index].name)
         )
         .map((i) => bank_store(i));
     if (!smart.move) await moveHome();

--- a/basic_merchant.5.js
+++ b/basic_merchant.5.js
@@ -10,10 +10,6 @@ var isExeing = false;
 const fishingLocation = { map: "main", x: -1368, y: -82 };
 const miningLocation = { map: "tunnel", x: -279, y: -148 };
 
-function isInvFull(slots = 1) {
-  return character.items.filter((item) => !item).length <= slots;
-}
-
 function equipBroom() {
   const currentWeapon = character.slots.mainhand;
   if (!currentWeapon || currentWeapon.name !== "broom") {
@@ -36,16 +32,16 @@ async function holidayExchange() {
 
   const holidayItems = [
     {
-      name: "mistletoe",
-      npc: "mistletoe",
-      quantity: 1,
-      keep: 0,
-    },
-    {
       name: "ornament",
       npc: "ornaments",
       quantity: 20,
       keep: 10,
+    },
+    {
+      name: "mistletoe",
+      npc: "mistletoe",
+      quantity: 1,
+      keep: 0,
     },
     {
       name: "candycane",
@@ -280,7 +276,7 @@ setInterval(async function () {
   if (isInvFull() && !smart.moving) {
     if (!smart.move) await moveHome();
     close_stand();
-    if (!smart.move) await smart_move("bank");
+    if (!smart.move) await smart_move(bankPosition);
     if (character.map === "bank")
       Array.from({ length: 42 }, (_, i) => i)
         .filter(
@@ -341,7 +337,7 @@ character.on("cm", async function ({ name, message }) {
     case "buy_mana":
       log(`Buying some mana potions for ${name}`);
       if (isInvFull()) {
-        if (!smart.move) await smart_move("bank");
+        if (!smart.move) await smart_move(bankPosition);
         if (character.map === "bank") bank_store(0);
       }
       if (locate_item("mpot1") === -1) {
@@ -361,7 +357,7 @@ character.on("cm", async function ({ name, message }) {
     case "buy_hp":
       log(`Buying some health potions for ${name}`);
       if (isInvFull()) {
-        if (!smart.move) await smart_move("bank");
+        if (!smart.move) await smart_move(bankPosition);
         if (character.map === "bank") bank_store(0);
       }
       if (locate_item("hpot1") === -1) {
@@ -393,7 +389,7 @@ character.on("cm", async function ({ name, message }) {
       if (locate_item(message.elixir) === -1) {
         let itemBankSlot = undefined;
         let itemSlot = undefined;
-        await smart_move("bank");
+        await smart_move(bankPosition);
         Object.keys(character.bank)
           .filter((id) => id !== "gold")
           .map((slot) => {

--- a/merchant_crafting.10.js
+++ b/merchant_crafting.10.js
@@ -115,10 +115,10 @@ function retrievedBankItemToUpgrade() {
       KEEP_THRESHOLD[ITEMS_HIGHEST_LEVEL[desiredItemId].type]
   );
 
-  let inventoryEmptySlots = character.items.filter((item) => !item).length - 5;
+  let inventoryEmptySlots = character.items.filter((item) => !item).length - 7;
 
   for (const itemSlot of desiredItems) {
-    if (inventoryEmptySlots === 0) break;
+    if (inventoryEmptySlots <= 0) break;
     else inventoryEmptySlots--;
 
     bank_retrieve(itemSlot.pack, itemSlot.slot);

--- a/merchant_crafting.10.js
+++ b/merchant_crafting.10.js
@@ -323,4 +323,4 @@ setInterval(() => {
       onDuty = false;
     });
   }
-}, 15000);
+}, 120000);

--- a/merchant_crafting.10.js
+++ b/merchant_crafting.10.js
@@ -1,6 +1,9 @@
 load_code(7);
 
 let BANK_CACHE = undefined;
+const bankPosition = { map: "bank", x: 0, y: -280 };
+
+const IGNORE_RARE_GOLD_THRESHOLD = 3e8;
 
 const KEEP_THRESHOLD = {
   // Every character needs
@@ -14,7 +17,7 @@ const KEEP_THRESHOLD = {
   // Class based
   weapon: 2,
   orb: 2,
-  shield: 1, // warrior, 0 if unneccessary
+  shield: 3, // warrior, 0 if unneccessary
   source: 2, // priest and mage
 
   // Class attribute based
@@ -24,6 +27,8 @@ const KEEP_THRESHOLD = {
   belt: 2,
 };
 const ITEMS_HIGHEST_LEVEL = {};
+
+const RETRIEVE_HISTORY = [];
 
 async function retrieveMaxItemsLevel() {
   if (character.map !== "bank") return;
@@ -36,7 +41,7 @@ async function retrieveMaxItemsLevel() {
   BANK_CACHE = character.bank;
 
   character.items
-    .filter((item) => item && !item.q)
+    .filter((item) => item && !item.q && !ignore.includes(item.name))
     .forEach((item) => {
       if (item.q) return;
 
@@ -44,22 +49,25 @@ async function retrieveMaxItemsLevel() {
         ITEMS_HIGHEST_LEVEL[item.name] = {
           level: item.level,
           quantity: 1,
+          count: 1,
           ...item_info(item),
         };
       } else {
-        if (item.level > ITEMS_HIGHEST_LEVEL[item.name].level)
+        if (item.level > ITEMS_HIGHEST_LEVEL[item.name].level) {
           ITEMS_HIGHEST_LEVEL[item.name].level = item.level;
-        else if (item.level === ITEMS_HIGHEST_LEVEL[item.name].level)
+          ITEMS_HIGHEST_LEVEL[item.name].quantity = 1;
+        } else if (item.level === ITEMS_HIGHEST_LEVEL[item.name].level)
           ITEMS_HIGHEST_LEVEL[item.name].quantity++;
+
+        ITEMS_HIGHEST_LEVEL[item.name].count++;
       }
     });
 
   for (slot in character.bank) {
     if (slot === "gold") continue;
 
-    log(slot);
     character.bank[slot]
-      .filter((item) => item && !item.q)
+      .filter((item) => item && !item.q && !ignore.includes(item.name))
       .forEach((item) => {
         if (item.q) return;
 
@@ -67,13 +75,17 @@ async function retrieveMaxItemsLevel() {
           ITEMS_HIGHEST_LEVEL[item.name] = {
             level: item.level,
             quantity: 1,
+            count: 1,
             ...item_info(item),
           };
         } else {
-          if (item.level > ITEMS_HIGHEST_LEVEL[item.name].level)
+          if (item.level > ITEMS_HIGHEST_LEVEL[item.name].level) {
             ITEMS_HIGHEST_LEVEL[item.name].level = item.level;
-          else if (item.level === ITEMS_HIGHEST_LEVEL[item.name].level)
+            ITEMS_HIGHEST_LEVEL[item.name].quantity = 1;
+          } else if (item.level === ITEMS_HIGHEST_LEVEL[item.name].level)
             ITEMS_HIGHEST_LEVEL[item.name].quantity++;
+
+          ITEMS_HIGHEST_LEVEL[item.name].count++;
         }
       });
   }
@@ -94,19 +106,30 @@ function getItemBankSlots(itemId) {
         });
     });
   }
+  if (character.gold < IGNORE_RARE_GOLD_THRESHOLD)
+    return result
+      .filter((item) => item_grade(item) < 2)
+      .sort((lhs, rhs) => lhs.level - rhs.level);
 
   return result.sort((lhs, rhs) => lhs.level - rhs.level);
 }
 
 function retrievedBankItemToUpgrade() {
   let desiredItemId = undefined;
-  let maxItemQuantity = 0;
+  let maxItemCount = 0;
   for (id in ITEMS_HIGHEST_LEVEL) {
-    if (ITEMS_HIGHEST_LEVEL[id].quantity > maxItemQuantity) {
-      maxItemQuantity = ITEMS_HIGHEST_LEVEL[id].quantity;
+    if (
+      ITEMS_HIGHEST_LEVEL[id].count > maxItemCount &&
+      !RETRIEVE_HISTORY.includes(id)
+    ) {
+      maxItemCount = ITEMS_HIGHEST_LEVEL[id].count;
       desiredItemId = id;
     }
   }
+
+  RETRIEVE_HISTORY.push(desiredItemId);
+  if (RETRIEVE_HISTORY.length > Object.keys(ITEMS_HIGHEST_LEVEL).length / 1.5)
+    RETRIEVE_HISTORY.shift();
 
   let desiredItems = getItemBankSlots(desiredItemId);
   desiredItems = desiredItems.splice(
@@ -115,7 +138,7 @@ function retrievedBankItemToUpgrade() {
       KEEP_THRESHOLD[ITEMS_HIGHEST_LEVEL[desiredItemId].type]
   );
 
-  let inventoryEmptySlots = character.items.filter((item) => !item).length - 7;
+  let inventoryEmptySlots = character.items.filter((item) => !item).length - 5;
 
   for (const itemSlot of desiredItems) {
     if (inventoryEmptySlots <= 0) break;
@@ -124,30 +147,6 @@ function retrievedBankItemToUpgrade() {
     bank_retrieve(itemSlot.pack, itemSlot.slot);
   }
 }
-
-if (Object.keys(ITEMS_HIGHEST_LEVEL).length === 0) {
-  close_stand();
-  smart_move("bank").then(() => {
-    retrieveMaxItemsLevel();
-    retrievedBankItemToUpgrade();
-  });
-}
-setInterval(() => {
-  if (
-    character.map === "main" &&
-    !onDuty &&
-    !smart.moving &&
-    !character.q.exchange &&
-    !character.c.fishing &&
-    !character.c.mining
-  ) {
-    close_stand();
-    smart_move("bank").then(() => {
-      retrieveMaxItemsLevel();
-      retrievedBankItemToUpgrade();
-    });
-  }
-}, 120000);
 
 async function compoundInv() {
   let inv = character.items;
@@ -172,6 +171,11 @@ async function compoundInv() {
       const scrollType = `cscroll${item_grade(inv[i])}`;
       let scrollSlot = locate_item(scrollType);
       if (scrollSlot === -1) {
+        if (
+          item_grade(inv[i]) >= 2 &&
+          character.gold < IGNORE_RARE_GOLD_THRESHOLD
+        )
+          continue;
         buy(scrollType, 1)
           .then(() => {
             scrollSlot = locate_item(scrollType);
@@ -229,6 +233,12 @@ async function upgradeInv() {
       const scrollType = `scroll${item_grade(inv[i])}`;
       let scrollSlot = locate_item(scrollType);
       if (scrollSlot === -1) {
+        if (
+          item_grade(inv[i]) >= 2 &&
+          character.gold < IGNORE_RARE_GOLD_THRESHOLD
+        )
+          continue;
+
         buy(scrollType, 1)
           .then(() => {
             scrollSlot = locate_item(scrollType);
@@ -239,6 +249,7 @@ async function upgradeInv() {
       }
       if (character.mp > 20 && !is_on_cooldown("massproduction"))
         use_skill("massproduction");
+
       upgrade(i, scrollSlot)
         .then(async (e) => {
           if (e?.success === true) {
@@ -251,7 +262,7 @@ async function upgradeInv() {
 
             if (e?.level >= ITEMS_HIGHEST_LEVEL[inv[i]?.name].level - 1) {
               close_stand();
-              smart_move("bank").then(() =>
+              smart_move(bankPosition).then(() =>
                 bank_store(
                   character.items.findIndex(
                     (item) =>
@@ -270,3 +281,46 @@ async function upgradeInv() {
     if (breakFlag) break;
   }
 }
+
+if (Object.keys(ITEMS_HIGHEST_LEVEL).length === 0) {
+  close_stand();
+  smart_move(bankPosition).then(() => {
+    retrieveMaxItemsLevel();
+    retrievedBankItemToUpgrade();
+  });
+}
+setInterval(() => {
+  if (
+    character.map === "main" &&
+    !onDuty &&
+    !character.q.exchange &&
+    !character.c.fishing &&
+    !character.c.mining
+  ) {
+    onDuty = true;
+    close_stand();
+    smart_move(bankPosition).then(() => {
+      character.items.forEach((item, index) => {
+        const isRareItem = item_grade(item) >= 2;
+        const isHighLevelItem =
+          item?.level >= (ITEMS_HIGHEST_LEVEL[item.name]?.level ?? 1) - 1;
+
+        const isStoreable = storeAble.includes(item.name);
+        const isEquipable = item_info(item).compound || item_info(item).upgrade;
+        const shouldItemBeIgnore = ignore.includes(item.name);
+
+        if (
+          item &&
+          ((!shouldItemBeIgnore &&
+            (isRareItem || (isEquipable && isHighLevelItem))) ||
+            isStoreable)
+        )
+          bank_store(index);
+      });
+      retrieveMaxItemsLevel();
+      retrievedBankItemToUpgrade();
+
+      onDuty = false;
+    });
+  }
+}, 15000);

--- a/merchant_crafting.10.js
+++ b/merchant_crafting.10.js
@@ -25,11 +25,6 @@ const KEEP_THRESHOLD = {
 };
 const ITEMS_HIGHEST_LEVEL = {};
 
-//// INVENTORY functions
-function item_info(item) {
-  return parent.G.items[item.name];
-}
-
 async function retrieveMaxItemsLevel() {
   if (character.map !== "bank") return;
 


### PR DESCRIPTION
Add some additional scripts and fixin for characters
 - Merchant
   - [x] Add a storable list to store items on rewriting item cache
   - [x] Add a logic to store item, which was previously taken out to upgrade/compound, to bank
   - [x] Using `character.items` instead of `inv = character.items` for realtime update, and prevent from wrongly swap/store/send_item
 - Mage
   - [x] Additional condition to activate `burst`, only the proficiency of it is 1 (meaning mobs have 50%/500 resistance)
   - [x] Add additional usage of `energize` to energize party leader (which often be `ranger` or `warrior`) to buff their attack frequency, whenever the skill is ready