### PR TITLE
feat(priest): priest can now pull mobs while being assigned as team leader (TANKER for magical mobs)

### DIFF
--- a/advance_smart_move.20.js
+++ b/advance_smart_move.20.js
@@ -50,10 +50,12 @@ async function scareAwayMobs() {
     !is_on_cooldown("scare") &&
     character.mp > 100
   ) {
-    await equipBatch({
-      orb: "jacko",
-    });
-    await use_skill("scare");
+    return Promise.all([
+      equipBatch({
+        orb: "jacko",
+      }),
+      use_skill("scare"),
+    ]);
   }
 }
 

--- a/advance_smart_move.20.js
+++ b/advance_smart_move.20.js
@@ -104,6 +104,7 @@ function resetSmartMove() {
 async function advanceSmartMove(props) {
   if (
     !smart.moving &&
+    !character.c &&
     !isAdvanceSmartMoving &&
     ["mage", "merchant"].includes(character.ctype) &&
     character.slots.mainhand?.name !== "broom"

--- a/bank_sort.49.js
+++ b/bank_sort.49.js
@@ -1,0 +1,169 @@
+al_items = {};
+const order = {};
+al_items.order = order;
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+order.names = [
+  "Helmets",
+  "Armors",
+  "Underarmors",
+  "Gloves",
+  "Shoes",
+  "Capes",
+  "Rings",
+  "Earrings",
+  "Amulets",
+  "Belts",
+  "Orbs",
+  "Weapons",
+  "Shields",
+  "Offhands",
+  "Elixirs",
+  "Potions",
+  "Scrolls",
+  "Crafting and Collecting",
+  "Exchangeables",
+  "Others",
+];
+order.ids = [
+  "helmet",
+  "chest",
+  "pants",
+  "gloves",
+  "shoes",
+  "cape",
+  "ring",
+  "earring",
+  "amulet",
+  "belt",
+  "orb",
+  "weapon",
+  "shield",
+  "offhand",
+  "elixir",
+  "pot",
+  "scroll",
+  "material",
+  "exchange",
+  "",
+];
+order.item_ids = order.ids.map((_id) => []);
+object_sort(G.items, "gold_value").forEach(function (b) {
+  if (!b[1].ignore)
+    for (var c = 0; c < order.ids.length; c++)
+      if (
+        !order.ids[c] ||
+        b[1].type == order.ids[c] ||
+        ("offhand" == order.ids[c] &&
+          in_arr(b[1].type, ["source", "quiver", "misc_offhand"])) ||
+        ("scroll" == order.ids[c] &&
+          in_arr(b[1].type, ["cscroll", "uscroll", "pscroll", "offering"])) ||
+        ("exchange" == order.ids[c] && G.items[b[0]].e)
+      ) {
+        order.item_ids[c].push(b[0]);
+        break;
+      }
+});
+order.flat_iids = order.item_ids.flat();
+order.comparator = function (a, b) {
+  return (
+    (a == null) - (b == null) ||
+    (a != null &&
+      (order.flat_iids.indexOf(a.name) - order.flat_iids.indexOf(b.name) ||
+        (a.name < b.name && -1) ||
+        +(a.name > b.name) ||
+        b.level - a.level))
+  );
+};
+
+function sort_all_bank(inv_indices, sorted_bank, i_running) {
+  if (!character.bank) return log("Not inside the bank");
+  if (!inv_indices) {
+    inv_indices = [];
+    for (let i = 0; i < 42; i++) {
+      if (!character.items[i]) inv_indices.push(i);
+    }
+  }
+  if (inv_indices.length == 0) return log("Make some space in inventory");
+  if (!sorted_bank) {
+    let bank_array = [];
+    for (let bank_pack in character.bank) {
+      if (bank_pack == "gold") continue;
+      bank_array = bank_array.concat(character.bank[bank_pack]);
+    }
+    bank_array.sort(al_items.order.comparator);
+    sorted_bank = {};
+    for (let bank_pack in character.bank) {
+      if (bank_pack == "gold") continue;
+      sorted_bank[bank_pack] = bank_array.slice(0, 42);
+      bank_array = bank_array.slice(42);
+    }
+  }
+  if (i_running == null) i_running = 0;
+  else i_running = (i_running + 1) % inv_indices.length;
+  const inv_pointer = inv_indices[i_running];
+  const inv_itm = character.items[inv_pointer];
+  //check every
+  if (!inv_itm) {
+    for (let bank_pack in character.bank) {
+      if (bank_pack == "gold") continue;
+      for (let i = 0; i < 42; i++) {
+        if (
+          character.bank[bank_pack][i] &&
+          al_items.order.comparator(
+            character.bank[bank_pack][i],
+            sorted_bank[bank_pack][i],
+          )
+        ) {
+          log("Swapping empty " + inv_pointer + " with " + i + bank_pack);
+          parent.socket.emit("bank", {
+            operation: "swap",
+            pack: bank_pack,
+            str: i,
+            inv: inv_pointer,
+          });
+          return sleep(150).then((x) =>
+            sort_all_bank(inv_indices, sorted_bank, i_running),
+          );
+        }
+      }
+    }
+    inv_indices.splice(i_running, 1);
+    return sleep(150).then((x) =>
+      sort_all_bank(inv_indices, sorted_bank, i_running),
+    );
+
+    //good to go. slice off this party of shit and go on
+  } else {
+    for (let bank_pack in character.bank) {
+      if (bank_pack == "gold") continue;
+      for (let i = 0; i < 42; i++) {
+        if (
+          !al_items.order.comparator(inv_itm, sorted_bank[bank_pack][i]) &&
+          al_items.order.comparator(
+            character.bank[bank_pack][i],
+            sorted_bank[bank_pack][i],
+          )
+        ) {
+          log({ operation: "swap", pack: bank_pack, str: i, inv: inv_pointer });
+          parent.socket.emit("bank", {
+            operation: "swap",
+            inv: inv_pointer,
+            pack: bank_pack,
+            str: i,
+          });
+          return sleep(150).then((x) =>
+            sort_all_bank(inv_indices, sorted_bank, i_running),
+          );
+        }
+      }
+    }
+  }
+
+  //if is empty pull misplaced item
+  //else if is full place misplaced item
+  return sorted_bank;
+}

--- a/basic_archer.3.js
+++ b/basic_archer.3.js
@@ -75,16 +75,16 @@ async function fight(target) {
 
     const potentialTargets = Object.values(parent.entities)
       .filter(
-        (mobs) =>
-          is_in_range(mobs, "attack") &&
+        (entity) =>
+          is_in_range(entity, "attack") &&
           // distance(mobs, character) < character.range + character.xrange &&
-          mobs.type === "monster" &&
-          !mobs.s?.fullguardx &&
-          (mobs.attack * (mobs.frequency > 1 ? mobs.frequency : 1) < 500 ||
-            (mobs.cooperative &&
-              mobs.target &&
-              (!partyMems.includes(mobs.target) || mobs["1hp"])) ||
-            mobs.target),
+          entity.type === "monster" && entity.hp && !entity.rip &&
+          !entity.s?.fullguardx &&
+          (entity.attack * (entity.frequency > 1 ? entity.frequency : 1) < 500 ||
+            (entity.cooperative &&
+              entity.target &&
+              (!partyMems.includes(entity.target) || entity["1hp"])) ||
+            entity.target),
       )
       .sort((lhs, rhs) => {
         if (lhs.cooperative || lhs.target) return -1;

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -73,17 +73,17 @@ const MELEE_IGNORE_LIST = ["porcupine"];
 // var mapX = 423;
 // var mapY = -2614;
 
-// var map = "desertland";
-// var mapX = 223;
-// var mapY = -708;
+var map = "desertland";
+var mapX = 223;
+var mapY = -708;
 
 // var map = "tunnel";
 // var mapX = 0;
 // var mapY = -775;
 
-var map = "halloween";
-var mapX = -219;
-var mapY = 681;
+// var map = "halloween";
+// var mapX = -219;
+// var mapY = 681;
 
 // var map = "main";
 // var mapX = 676;
@@ -104,9 +104,11 @@ var mapY = 681;
 // var mobsToFarm = ["grinch", "phoenix", "spider", "bigbird", "scorpion"];
 // var mobsToFarm = ["goldenbot", "sparkbot", "sparkbot"];
 // var mobsToFarm = ["phoenix", "stompy", "wolf"];
-// var mobsToFarm = ["fireroamer"];
+var mobsToFarm = ["fireroamer"];
 // var mobsToFarm = ["grinch", "phoenix", "mole"];
-var mobsToFarm = ["phoenix", "xscorpion", "minimush"];
+
+// var mobsToFarm = ["phoenix", "xscorpion", "minimush"];
+
 // var mobsToFarm = ["phoenix", "croc", "armadillo"];
 // var mobsToFarm = ["fvampire", "grinch", "phoenix", "ghost"];
 // var mobsToFarm = [
@@ -1512,9 +1514,14 @@ async function changeToDailyEventTargets() {
     }
   }
 
+  const partyHealer = get_entity(HEALER);
+  const partyTanker = get_entity(TANKER);
+
   if (
-    get_entity(HEALER) &&
-    !get_entity(HEALER).rip &&
+    partyTanker &&
+    partyTanker.hp > partyTanker.max_hp * 0.3 &&
+    partyHealer &&
+    !partyHealer.rip &&
     character.ping < 600 &&
     (get_targeted_monster()?.level < 5 || get_targeted_monster()?.attack < 500)
   )

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -157,7 +157,7 @@ function filterCompoundableAndStackable() {
     (i) =>
       inv[i] &&
       (item_info(inv[i]).compound || inv[i].q) &&
-      !["hpot1", "mpot1"].includes(inv[i].name)
+      !["hpot1", "mpot1"].includes(inv[i].name),
   );
   return res;
 }
@@ -492,7 +492,7 @@ function getMonstersOnDeclares() {
 
 async function withTimeout(
   promise,
-  timeoutInterval = Math.max(...parent.pings)
+  timeoutInterval = Math.max(...parent.pings),
 ) {
   return Promise.race([
     promise,
@@ -561,10 +561,10 @@ function getTarget() {
         .filter(
           (entity) =>
             entity.type === "monster" &&
-            (entity.target === HEALER || entity.target === MAGE)
+            (entity.target === HEALER || entity.target === MAGE),
         )
         .sort(
-          (lhs, rhs) => distance(rhs, character) - distance(lhs, character)
+          (lhs, rhs) => distance(rhs, character) - distance(lhs, character),
         );
       if (
         mobsTargetingNonTanker.length &&
@@ -581,7 +581,7 @@ function getTarget() {
         (mob) =>
           mob.type === "monster" &&
           [...partyMems, partyMerchant].includes(mob.target) &&
-          is_in_range(mob, "attack")
+          is_in_range(mob, "attack"),
       );
       if (leader)
         target =
@@ -603,16 +603,16 @@ function getTarget() {
         !isAdvanceSmartMoving &&
         Math.sqrt(
           (character.x - leader.x) * (character.x - leader.x) +
-            (character.y - leader.y) * (character.y - leader.y)
+            (character.y - leader.y) * (character.y - leader.y),
         ) > spacial &&
         can_move_to(
           character.x + (leader.x - character.x) / 2,
-          character.y + (leader.y - character.y) / 2
+          character.y + (leader.y - character.y) / 2,
         )
       )
         move(
           character.x + (leader.x - character.x) / 2,
-          character.y + (leader.y - character.y) / 2
+          character.y + (leader.y - character.y) / 2,
         );
       return;
     }
@@ -624,7 +624,7 @@ function getTarget() {
 const INTERVAL_BREAKPOINTS = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1];
 function getLoopInterval() {
   const dynamicInterval = INTERVAL_BREAKPOINTS.map(
-    (breakpoint) => (1 / character.frequency / breakpoint) * 1000
+    (breakpoint) => (1 / character.frequency / breakpoint) * 1000,
   ).find((loopInterval) => loopInterval > 250);
   const frequencyInterval = (1 / character.frequency) * 1000;
 
@@ -773,7 +773,7 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
           //   target ? get_height(target) ?? 0 : 0
           // ))
           extraRangeByMobHitbox +
-          extraRangeBySelfHitbox)
+          extraRangeBySelfHitbox),
     ) *
     2;
   return setTimeout(hitAndRun, getLoopInterval());
@@ -802,7 +802,7 @@ function getPlayersToHeal() {
         (player.max_hp >
           minimumHealingModifier * (character.heal ?? character.attack) +
             player.hp ||
-          player.hp < player.max_hp * 0.8)
+          player.hp < player.max_hp * 0.8),
     )
     .sort((lhs, rhs) => lhs.hp / lhs.max_hp - rhs.hp / rhs.max_hp);
 
@@ -817,7 +817,7 @@ function getPlayersToHeal() {
               minimumHealingModifier * (character.heal ?? character.attack) +
                 entity.hp ||
               entity.hp < 0.8 * entity.max_hp)
-          : !entity.s.healed && entity.hp < 7000)
+          : !entity.s.healed && entity.hp < 7000),
     )
     .sort((lhs, rhs) => {
       if (lhs.mtype === "ghost" && rhs.mtype !== "ghost") return 9999;
@@ -995,7 +995,7 @@ async function cupidHeal() {
         entity.hp <
           entity.max_hp -
             character.attack *
-              dps_multiplier(entity.armor - (character.apiercing ?? 0))
+              dps_multiplier(entity.armor - (character.apiercing ?? 0)),
     )
     .sort((lhs, rhs) => {
       if ([...partyMems, partyMerchant].includes(lhs.name)) return -1;
@@ -1010,7 +1010,7 @@ async function cupidHeal() {
     promises.push(
       equipBatch({
         mainhand: "cupid",
-      })
+      }),
     );
 
     await Promise.all(promises);
@@ -1027,10 +1027,10 @@ async function cupidHeal() {
         `Healing ${lowHealthPlayers
           .slice(0, 5)
           .map((player) => player.name)
-          .join(", ")}`
+          .join(", ")}`,
       );
       use_skill("5shot", lowHealthPlayers.slice(0, 5)).then(() =>
-        reduce_cooldown("attack", Math.min(...parent.pings))
+        reduce_cooldown("attack", Math.min(...parent.pings)),
       );
       reduce_cooldown("attack", -(1 / character.frequency) * 1000);
     } else if (
@@ -1045,10 +1045,10 @@ async function cupidHeal() {
         `Healing ${lowHealthPlayers
           .slice(0, 3)
           .map((player) => player.name)
-          .join(", ")}`
+          .join(", ")}`,
       );
       use_skill("3shot", lowHealthPlayers.slice(0, 3)).then(() =>
-        reduce_cooldown("attack", Math.min(...parent.pings))
+        reduce_cooldown("attack", Math.min(...parent.pings)),
       );
       reduce_cooldown("attack", -(1 / character.frequency) * 1000);
     } else if (
@@ -1062,7 +1062,7 @@ async function cupidHeal() {
       set_message("Single Cupid");
       log(`Healing ${lowHealthPlayers[0].name}`);
       attack(lowHealthPlayers[0]).then(() =>
-        reduce_cooldown("attack", Math.min(...parent.pings))
+        reduce_cooldown("attack", Math.min(...parent.pings)),
       );
       reduce_cooldown("attack", -(1 / character.frequency) * 1000);
     }
@@ -1152,7 +1152,7 @@ setInterval(async function () {
         )
           return;
         await send_item(partyMerchant, index, 1000);
-      })
+      }),
     );
   }
 
@@ -1335,7 +1335,7 @@ async function changeToDailyEventTargets() {
               : 1
             : lhs.hp === rhs.hp
             ? distance(rhs, character) - distance(lhs, character)
-            : lhs.hp - rhs.hp
+            : lhs.hp - rhs.hp,
         )
         .pop();
 
@@ -1475,7 +1475,7 @@ async function changeToDailyEventTargets() {
 
       const currentCharacterTarget = {
         priority: priority.findIndex(
-          (element) => element === currentCharacter.ctype
+          (element) => element === currentCharacter.ctype,
         ),
         entity: currentCharacter,
         sqrDistance:
@@ -1519,7 +1519,7 @@ async function changeToDailyEventTargets() {
 
   if (
     partyTanker &&
-    partyTanker.hp > partyTanker.max_hp * 0.3 &&
+    partyTanker.hp > partyTanker.max_hp * 0.35 &&
     partyHealer &&
     !partyHealer.rip &&
     character.ping < 600 &&

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -312,6 +312,7 @@ const STORE_ABLE = [
   "feather0",
   "essenceofnature",
   "essenceoffrost",
+  "essenceoffire",
   "dexscroll",
   "cshell",
   "carrot",
@@ -328,6 +329,9 @@ const STORE_ABLE = [
   "orboffrost",
   "orbofplague",
   "orbofresolve",
+  "orba",
+  "orbofstr",
+  "orbofdex",
 ];
 
 const SALE_ABLE = [
@@ -447,7 +451,7 @@ async function sortInv() {
 function calculateRangeRate() {
   switch (character.ctype) {
     case "priest":
-      return character.name === TANKER && currentStrategy === usePullStrategies
+      return isAssignedAsTanker() && currentStrategy === usePullStrategies
         ? 0.2
         : 0.5;
     default:

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -10,13 +10,15 @@ var attack_mode = true;
 var partyMems = ["MooohMoooh", "CowTheMooh", "MowTheCooh"];
 // var partyMems = ["CowTheMooh", "MowTheCooh", "MoohThatCow"];
 
-var TANKER = "MooohMoooh";
-// var TANKER = "CowTheMooh";
-
 const MAGE = "MowTheCooh";
 var HEALER = "CowTheMooh";
 // const HEALER = "CupidCow";
 const RANGER = "MoohThatCow";
+const WARRIOR = "MooohMoooh";
+
+var TANKER =
+  partyMems.find((id) => [HEALER, WARRIOR].includes(id)) ?? partyMems[0];
+// var TANKER = "CowTheMooh";
 
 const MIDAS_CHARACTER = [MAGE];
 
@@ -153,7 +155,7 @@ function filterCompoundableAndStackable() {
     (i) =>
       inv[i] &&
       (item_info(inv[i]).compound || inv[i].q) &&
-      !["hpot1", "mpot1"].includes(inv[i].name),
+      !["hpot1", "mpot1"].includes(inv[i].name)
   );
   return res;
 }
@@ -488,7 +490,7 @@ function getMonstersOnDeclares() {
 
 async function withTimeout(
   promise,
-  timeoutInterval = Math.max(...parent.pings),
+  timeoutInterval = Math.max(...parent.pings)
 ) {
   return Promise.race([
     promise,
@@ -557,10 +559,10 @@ function getTarget() {
         .filter(
           (entity) =>
             entity.type === "monster" &&
-            (entity.target === HEALER || entity.target === MAGE),
+            (entity.target === HEALER || entity.target === MAGE)
         )
         .sort(
-          (lhs, rhs) => distance(rhs, character) - distance(lhs, character),
+          (lhs, rhs) => distance(rhs, character) - distance(lhs, character)
         );
       if (
         mobsTargetingNonTanker.length &&
@@ -577,7 +579,7 @@ function getTarget() {
         (mob) =>
           mob.type === "monster" &&
           [...partyMems, partyMerchant].includes(mob.target) &&
-          is_in_range(mob, "attack"),
+          is_in_range(mob, "attack")
       );
       if (leader)
         target =
@@ -599,16 +601,16 @@ function getTarget() {
         !isAdvanceSmartMoving &&
         Math.sqrt(
           (character.x - leader.x) * (character.x - leader.x) +
-            (character.y - leader.y) * (character.y - leader.y),
+            (character.y - leader.y) * (character.y - leader.y)
         ) > spacial &&
         can_move_to(
           character.x + (leader.x - character.x) / 2,
-          character.y + (leader.y - character.y) / 2,
+          character.y + (leader.y - character.y) / 2
         )
       )
         move(
           character.x + (leader.x - character.x) / 2,
-          character.y + (leader.y - character.y) / 2,
+          character.y + (leader.y - character.y) / 2
         );
       return;
     }
@@ -620,7 +622,7 @@ function getTarget() {
 const INTERVAL_BREAKPOINTS = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1];
 function getLoopInterval() {
   const dynamicInterval = INTERVAL_BREAKPOINTS.map(
-    (breakpoint) => (1 / character.frequency / breakpoint) * 1000,
+    (breakpoint) => (1 / character.frequency / breakpoint) * 1000
   ).find((loopInterval) => loopInterval > 250);
   const frequencyInterval = (1 / character.frequency) * 1000;
 
@@ -769,7 +771,7 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
           //   target ? get_height(target) ?? 0 : 0
           // ))
           extraRangeByMobHitbox +
-          extraRangeBySelfHitbox),
+          extraRangeBySelfHitbox)
     ) *
     2;
   return setTimeout(hitAndRun, getLoopInterval());
@@ -798,7 +800,7 @@ function getPlayersToHeal() {
         (player.max_hp >
           minimumHealingModifier * (character.heal ?? character.attack) +
             player.hp ||
-          player.hp < player.max_hp * 0.8),
+          player.hp < player.max_hp * 0.8)
     )
     .sort((lhs, rhs) => lhs.hp / lhs.max_hp - rhs.hp / rhs.max_hp);
 
@@ -813,7 +815,7 @@ function getPlayersToHeal() {
               minimumHealingModifier * (character.heal ?? character.attack) +
                 entity.hp ||
               entity.hp < 0.8 * entity.max_hp)
-          : !entity.s.healed && entity.hp < 7000),
+          : !entity.s.healed && entity.hp < 7000)
     )
     .sort((lhs, rhs) => {
       if (lhs.mtype === "ghost" && rhs.mtype !== "ghost") return 9999;
@@ -991,7 +993,7 @@ async function cupidHeal() {
         entity.hp <
           entity.max_hp -
             character.attack *
-              dps_multiplier(entity.armor - (character.apiercing ?? 0)),
+              dps_multiplier(entity.armor - (character.apiercing ?? 0))
     )
     .sort((lhs, rhs) => {
       if ([...partyMems, partyMerchant].includes(lhs.name)) return -1;
@@ -1006,7 +1008,7 @@ async function cupidHeal() {
     promises.push(
       equipBatch({
         mainhand: "cupid",
-      }),
+      })
     );
 
     await Promise.all(promises);
@@ -1023,10 +1025,10 @@ async function cupidHeal() {
         `Healing ${lowHealthPlayers
           .slice(0, 5)
           .map((player) => player.name)
-          .join(", ")}`,
+          .join(", ")}`
       );
       use_skill("5shot", lowHealthPlayers.slice(0, 5)).then(() =>
-        reduce_cooldown("attack", Math.min(...parent.pings)),
+        reduce_cooldown("attack", Math.min(...parent.pings))
       );
       reduce_cooldown("attack", -(1 / character.frequency) * 1000);
     } else if (
@@ -1041,10 +1043,10 @@ async function cupidHeal() {
         `Healing ${lowHealthPlayers
           .slice(0, 3)
           .map((player) => player.name)
-          .join(", ")}`,
+          .join(", ")}`
       );
       use_skill("3shot", lowHealthPlayers.slice(0, 3)).then(() =>
-        reduce_cooldown("attack", Math.min(...parent.pings)),
+        reduce_cooldown("attack", Math.min(...parent.pings))
       );
       reduce_cooldown("attack", -(1 / character.frequency) * 1000);
     } else if (
@@ -1058,7 +1060,7 @@ async function cupidHeal() {
       set_message("Single Cupid");
       log(`Healing ${lowHealthPlayers[0].name}`);
       attack(lowHealthPlayers[0]).then(() =>
-        reduce_cooldown("attack", Math.min(...parent.pings)),
+        reduce_cooldown("attack", Math.min(...parent.pings))
       );
       reduce_cooldown("attack", -(1 / character.frequency) * 1000);
     }
@@ -1148,7 +1150,7 @@ setInterval(async function () {
         )
           return;
         await send_item(partyMerchant, index, 1000);
-      }),
+      })
     );
   }
 
@@ -1331,7 +1333,7 @@ async function changeToDailyEventTargets() {
               : 1
             : lhs.hp === rhs.hp
             ? distance(rhs, character) - distance(lhs, character)
-            : lhs.hp - rhs.hp,
+            : lhs.hp - rhs.hp
         )
         .pop();
 
@@ -1471,7 +1473,7 @@ async function changeToDailyEventTargets() {
 
       const currentCharacterTarget = {
         priority: priority.findIndex(
-          (element) => element === currentCharacter.ctype,
+          (element) => element === currentCharacter.ctype
         ),
         entity: currentCharacter,
         sqrDistance:

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -80,8 +80,8 @@ const movementHistory = [];
 var flipRotation = 1;
 var flipRotationCooldown = 0;
 var angle; // Your desired angle from the monster, in radians
-var flip_cooldown = 0;
-var stuck_threshold = 2;
+var flipCooldown = 0;
+var stuckThreshold = 2;
 var basicRangeRate = 0.5; // Is used to reset
 var rangeRate = basicRangeRate; // Variate range rate
 
@@ -310,7 +310,7 @@ var IGNORE = [
   "orbofplague",
   "orbofresolve",
   "gphelmet",
-  "bowofthedead",
+  // "bowofthedead",
   "daggerofthedead",
   "maceofthedead",
   "pmaceofthedead",
@@ -409,8 +409,8 @@ const SALE_ABLE = [
   "carrotsword",
   // "wcap",
   // "wshoes",
-  "wgloves",
-  "wbreeches",
+  // "wgloves",
+  // "wbreeches",
   "cclaw",
   "dagger",
   "rednose",
@@ -458,7 +458,7 @@ const SALE_ABLE = [
   "dexbelt",
   "intbelt",
   // Halloween temp for gold
-  "bowofthedead",
+  // "bowofthedead",
   "daggerofthedead",
 ];
 var maxUpgrade = 7;
@@ -475,6 +475,7 @@ if (parent.caracAL) {
 }
 // Pre-set function
 var isSortingInventory = false;
+
 async function sortInv() {
   if (
     isSortingInventory ||
@@ -485,38 +486,52 @@ async function sortInv() {
     return;
 
   isSortingInventory = true;
-  var inv = character.items;
-  const invLength = inv.length;
+
+  // Snapshot items with their original slot
+  const inv = character.items.map((item, slot) => ({ item, slot }));
+
+  // Sorting name -> level -> slot order -> null
+  inv.sort((lhs, rhs) => {
+    const lhsItem = lhs.item;
+    const rhsItem = rhs.item;
+
+    if (!lhsItem && !rhsItem) return 0;
+    if (!lhsItem) return 1; // nulls last
+    if (!rhsItem) return -1;
+
+    const nameOrder = lhsItem.name.localeCompare(rhsItem.name);
+    if (nameOrder !== 0) return nameOrder;
+
+    const levelOrder = (lhsItem.level ?? 0) - (rhsItem.level ?? 0);
+    if (levelOrder !== 0) return levelOrder;
+
+    // same name + same level — preserve original slot order for stability
+    return lhs.slot - rhs.slot;
+  });
+
+  // We’ll create a mapping from target slot → original slot
   const promises = [];
-  for (let i = 0; i < invLength; i++) {
-    for (let j = i; j < invLength; j++) {
-      const lhs = inv[i];
-      const rhs = inv[j];
-      if (rhs === null) continue;
-      if (lhs === null) {
-        const temp = inv[i];
-        inv[i] = inv[j];
-        inv[j] = temp;
-        promises.push(swap(i, j));
-        continue;
-      }
-      if (lhs.name.localeCompare(rhs.name) === -1) {
-        const temp = inv[i];
-        inv[i] = inv[j];
-        inv[j] = temp;
-        promises.push(swap(i, j));
-        continue;
-      }
-      if (lhs.name === rhs.name) {
-        if ((lhs?.level ?? 0) > (rhs?.level ?? 0)) {
-          const temp = inv[i];
-          inv[i] = inv[j];
-          inv[j] = temp;
-          promises.push(swap(i, j));
-        }
-      }
+  const usedSlots = new Set();
+
+  for (let index = 0; index < inv.length; index++) {
+    const desired = inv[index];
+    const targetItem = character.items[index];
+
+    // skip if already correct
+    if (desired.item === targetItem) continue;
+
+    // find the specific matching slot by identity
+    const fromSlot = character.items.findIndex(
+      (x, idx) => x === desired.item && !usedSlots.has(idx),
+    );
+
+    if (fromSlot !== -1 && fromSlot !== index) {
+      usedSlots.add(fromSlot);
+      usedSlots.add(index);
+      promises.push(swap(fromSlot, index));
     }
   }
+
   return Promise.all(promises).finally(() => {
     isSortingInventory = false;
   });
@@ -561,11 +576,6 @@ function getMonstersOnDeclares() {
       return get_nearest_monster({ min_xp, type: monster });
     }
   }
-  // return (
-  //   get_nearest_monster({ min_xp, max_att, type }) ??
-  //   get_nearest_monster({ min_xp, max_att, type: altType1 }) ??
-  //   get_nearest_monster({ min_xp, max_att, type: altType2 })
-  // );
 }
 
 async function withTimeout(
@@ -753,113 +763,148 @@ function extraDistanceWithinHitbox(target) {
   return Math.min(get_height(target), get_width(target) / 2) / 2;
 }
 
+var lastKitingTarget = undefined;
 async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
-  const loopInterval = Math.max(150, getLoopInterval());
+  const loopInterval = Math.max(200, getLoopInterval());
+
+  // --- 1. Early exits and sanity checks ---
+  if (character.cc > 150) return setTimeout(hitAndRun, loopInterval);
   if (!target || smart.moving || isAdvanceSmartMoving) {
     angle = undefined;
     return setTimeout(hitAndRun, loopInterval);
   }
 
-  if (!angle) {
-    const diff_x = character.real_x - target.real_x;
-    const diff_y = character.real_y - target.real_y;
-    angle = Math.atan2(diff_y, diff_x);
+  if (
+    character.ctype === "warrior" &&
+    distance(character, target) > character.range * 0.5 &&
+    distance(character, target) < character.range * rangeRate + character.xrange
+  ) {
+    const allEntities = Object.values(parent.entities);
+    const noAggro = allEntities
+      .filter((entity) => entity.type === "monster")
+      .every((mob) => mob.target !== character.name);
+    const noNearbyPlayers = allEntities
+      .filter((entity) => entity.type === "character" && !entity.moving)
+      .every((char) => distance(character, char) >= 8);
+
+    if (noAggro && noNearbyPlayers) {
+      const dx = character.real_x - target.real_x;
+      const dy = character.real_y - target.real_y;
+      angle = Math.atan2(dy, dx);
+      return setTimeout(hitAndRun, loopInterval);
+    }
   }
 
-  let cosA = Math.cos(angle);
-  let sinA = Math.sin(angle);
+  // Reset angle when switching or losing target
+  const targetChanged =
+    !lastKitingTarget || distance(lastKitingTarget, target) > 30;
+  if (targetChanged) angle = undefined;
 
+  // --- 2. Initialize angle if needed ---
+  if (!angle) {
+    const dx = character.real_x - target.real_x;
+    const dy = character.real_y - target.real_y;
+    angle = Math.atan2(dy, dx);
+  }
+
+  const cosA = Math.cos(angle);
+  const sinA = Math.sin(angle);
+
+  // --- 3. Track recent movement to detect being stuck ---
   movementHistory.push({ x: character.real_x, y: character.real_y });
   if (movementHistory.length > 5) movementHistory.shift();
 
   let totalMovement = 0;
   for (let i = 1; i < movementHistory.length; i++) {
-    let dx = movementHistory[i].x - movementHistory[i - 1].x;
-    let dy = movementHistory[i].y - movementHistory[i - 1].y;
-    totalMovement += Math.sqrt(dx * dx + dy * dy);
+    const dx = movementHistory[i].x - movementHistory[i - 1].x;
+    const dy = movementHistory[i].y - movementHistory[i - 1].y;
+    totalMovement += Math.hypot(dx, dy);
   }
 
-  if (totalMovement < stuck_threshold * movementHistory.length) {
+  const averageMovement = totalMovement / movementHistory.length;
+  if (averageMovement < stuckThreshold) {
     if (flipRotationCooldown <= 0) {
       flipRotation *= -1;
       flipRotationCooldown = 4;
-      angle += (flipRotation * Math.PI) / 2;
+      angle += (flipRotation * Math.PI) / 2; // turn 90°
     }
   }
 
-  // const extraRangeByMobHitbox = extraDistanceWithinHitbox(
-  //   angle,
-  //   target ? get_width(target) ?? 0 : 0,
-  //   target ? get_height(target) ?? 0 : 0
-  // );
+  // --- 4. Calculate range offsets ---
+  const extraRangeTarget = extraDistanceWithinHitbox(target);
+  const extraRangeSelf = extraDistanceWithinHitbox(character);
+  const totalExtraRange = extraRangeTarget + extraRangeSelf;
+  const rangeRadius = character.range * rangeRateFn;
+  const extendedRadius = character.xrange * 0.9 + totalExtraRange;
 
-  const extraRangeByMobHitbox = extraDistanceWithinHitbox(target);
-  const extraRangeBySelfHitbox = extraDistanceWithinHitbox(character);
+  // --- 5. Desired destination based on current orbit angle ---
+  let new_x = target.x + (rangeRadius + extendedRadius) * cosA;
+  let new_y = target.y + (rangeRadius + extendedRadius) * sinA;
 
-  let new_x =
-    target.x +
-    character.range * rangeRateFn * cosA +
-    (character.xrange * 0.9 + extraRangeByMobHitbox + extraRangeBySelfHitbox) *
-      cosA;
-
-  let new_y =
-    target.y +
-    character.range * rangeRateFn * sinA +
-    (character.xrange * 0.9 + extraRangeByMobHitbox + extraRangeBySelfHitbox) *
-      sinA;
-
-  if (flip_cooldown > 9) {
-    if (
+  // --- 6. Smooth micro-rotation when close to target ---
+  if (flipCooldown > 9) {
+    const closeToTarget =
       distance(character, target) <=
-      (character.range + character.xrange) * 0.1 * rangeRateFn
-    ) {
-      angle += (flipRotation * Math.PI) / 16;
+      (character.range + character.xrange) * 0.1 * rangeRateFn;
+
+    if (closeToTarget) {
+      angle += (flipRotation * Math.PI) / 16; // subtle orbit shift
     }
-    flip_cooldown = 0;
+
+    flipCooldown = 0;
   }
-  flip_cooldown--;
+
+  flipCooldown--;
   flipRotationCooldown--;
 
+  // --- 7. Collision handling and alternative movement path ---
+  let destinationX, destinationY;
+
   if (!can_move_to(new_x, new_y)) {
-    for (let i = 1; i <= 8; i++) {
-      let adjustedAngle = angle + (flipRotation * Math.PI) / (16 / i);
-      let alt_x =
-        target.x +
-        (character.range * rangeRateFn + character.xrange) *
-          Math.cos(adjustedAngle);
-      let alt_y =
-        target.y +
-        (character.range * rangeRateFn + character.xrange) *
-          Math.sin(adjustedAngle);
+    // Try small angular adjustments in the current flip direction
+    flipRotation *= -1;
+    for (let i = 2; i <= 8; i++) {
+      const adjustedAngle = angle + (flipRotation * Math.PI) / (16 / i);
+      const alt_x =
+        target.x + (rangeRadius + character.xrange) * Math.cos(adjustedAngle);
+      const alt_y =
+        target.y + (rangeRadius + character.xrange) * Math.sin(adjustedAngle);
 
       if (can_move_to(alt_x, alt_y)) {
         angle = adjustedAngle;
-        move(alt_x, alt_y);
+        destinationX = alt_x;
+        destinationY = alt_y;
+        break;
       }
     }
-    flipRotation *= -1;
   } else {
-    move(new_x, new_y);
+    destinationX = new_x;
+    destinationY = new_y;
   }
 
-  angle +=
+  // --- 8. Execute movement or retry later ---
+  if (destinationX && destinationY) {
+    move(destinationX, destinationY);
+    lastKitingTarget = target;
+  } else {
+    return setTimeout(hitAndRun, loopInterval);
+  }
+
+  // --- 9. Advance orbit angle for next iteration ---
+  const radiusTotal = rangeRadius + extendedRadius;
+  const rotationStep =
     flipRotation *
-    Math.asin(
-      (character.speed * loopInterval) /
-        1000 /
-        2 /
-        (character.range * rangeRateFn +
-          character.xrange * 0.9 +
-          // extraDistanceWithinHitbox(
-          //   angle,
-          //   target ? get_width(target) ?? 0 : 0,
-          //   target ? get_height(target) ?? 0 : 0
-          // ))
-          extraRangeByMobHitbox +
-          extraRangeBySelfHitbox),
-    ) *
+    Math.asin((character.speed * loopInterval) / 1000 / 2 / radiusTotal) *
     2;
-  return setTimeout(hitAndRun, loopInterval);
+
+  angle += rotationStep;
+
+  const moveTime =
+    (distance(character, { x: destinationX, y: destinationY }) /
+      character.speed) *
+    1000;
+
+  setTimeout(hitAndRun, Math.max(moveTime, 200));
 }
 hitAndRun();
 
@@ -869,7 +914,7 @@ function prioritizedNames() {
   return [...new Set([...partyMems, partyMerchant, ...parent.party_list])];
 }
 
-function getPlayersToHeal(ignoreGhost = false) {
+function getPlayersToHeal() {
   const minHealMod = 0.9;
   const healPower = character.heal || character.attack;
   const prioritizedNamesList = prioritizedNames();
@@ -890,7 +935,7 @@ function getPlayersToHeal(ignoreGhost = false) {
     .filter((entity) => {
       if (!entity) return false;
       if (entity.mtype === "ghost") {
-        if (ignoreGhost) return false;
+        if (character.ctype !== "priest") return false;
         return !entity.s.healed && entity.hp < 7000;
       }
 
@@ -1071,17 +1116,18 @@ async function cupidHeal() {
     return;
 
   const characterRange = character.range + character.xrange;
-  const prioritized = prioritizedNames();
+  // const prioritized = prioritizedNames();
 
-  const lowHealthPlayers = getPlayersToHeal(true).filter(
+  const lowHealthPlayers = getPlayersToHeal().filter(
     (player) => player.name !== character.name && player.ctype !== "priest",
   );
   const lowHealthPlayersInRange = lowHealthPlayers.filter(
     (player) => distance(player, character) < characterRange,
   );
-  const prioritizedPlayers = lowHealthPlayers.filter((player) =>
-    prioritized.includes(player.name),
-  );
+
+  // const prioritizedPlayers = lowHealthPlayers.filter((player) =>
+  //   prioritized.includes(player.name),
+  // );
 
   const promisesToAwait = [];
 
@@ -1111,6 +1157,11 @@ async function cupidHeal() {
   // }
 
   if (lowHealthPlayersInRange.length > 0) {
+    console.log(
+      lowHealthPlayersInRange
+        .map((player) => `${player.name} (${player.hp}/${player.max_hp})`)
+        .join(", "),
+    );
     promisesToAwait.push(
       equipBatch({
         mainhand: "cupid",
@@ -1157,7 +1208,7 @@ async function cupidHeal() {
       set_message("Single Cupid");
       log(`Healing ${lowHealthPlayersInRange[0].name}`);
       promisesToAwait.push(
-        attack(lowHealthPlayersInRange[0]).then(() =>
+        use_skill("attack", lowHealthPlayersInRange[0]).then(() =>
           reduce_cooldown("attack", Math.min(...parent.pings)),
         ),
       );
@@ -1202,16 +1253,17 @@ setInterval(async function () {
   ) {
     smartmoveDebug = true;
     log("Debug being stuck while kiting");
-    await advanceSmartMove({
-      map: character.map,
-      x: currentTarget.x,
-      y: currentTarget.y,
-    });
+    if (can_move_to(currentTarget.x, currentTarget.y))
+      await move(currentTarget.x, currentTarget.y);
+    else
+      await advanceSmartMove({
+        map: character.map,
+        x: currentTarget.x,
+        y: currentTarget.y,
+      });
 
     smartmoveDebug = false;
   }
-
-  // Re-equip
 
   const obj = {
     map: character.map,
@@ -1396,6 +1448,7 @@ setInterval(dynamicParty, 3000);
 // var pinkGooVisitedBoundary = [];
 async function changeToDailyEventTargets() {
   let target = getTarget();
+  rangeRate = calculateRangeRate() ?? originRangeRate ?? basicRangeRate;
 
   if (
     (parent.S.goobrawl || get_nearest_monster({ type: "bgoo" })) &&
@@ -1712,7 +1765,6 @@ async function changeToDailyEventTargets() {
     changeToPullStrategies();
   else changeToNormalStrategies();
 
-  rangeRate = calculateRangeRate() ?? originRangeRate ?? basicRangeRate;
   return target;
 }
 

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -246,6 +246,7 @@ var IGNORE = [
   "ornament",
   "mistletoe",
   "candy1",
+  "candypop",
   "candycane",
   "candy0",
   "stand0",
@@ -258,6 +259,7 @@ var IGNORE = [
   "orboffrost",
   "orbofplague",
   "orbofresolve",
+  "gphelmet",
   ...BUYABLE,
 ];
 
@@ -331,6 +333,10 @@ const STORE_ABLE = [
   "orba",
   "orbofstr",
   "orbofdex",
+  "mysterybox",
+  "weaponbox",
+  "armorbox",
+  "fury",
 ];
 
 const SALE_ABLE = [
@@ -346,6 +352,8 @@ const SALE_ABLE = [
   "carrotsword",
   // "wcap",
   // "wshoes",
+  "wgloves",
+  "wbreeches",
   "cclaw",
   "dagger",
   "rednose",
@@ -361,11 +369,10 @@ const SALE_ABLE = [
   "lantern",
   "hpbelt",
   "hpamulet",
-  "gphelmet",
   "phelmet",
+  "gphelmet",
   "maceofthedead",
   "pmaceofthedead",
-  "maceofthedead",
   "staffofthedead",
   "swordofthedead",
   "throwingstars",
@@ -375,6 +382,8 @@ const SALE_ABLE = [
   "hgloves",
   "harmor",
   "hpants",
+  "glolipop",
+  "whiteegg",
   "hboots",
   "smoke",
   "sword",
@@ -387,7 +396,10 @@ const SALE_ABLE = [
   "strearring",
   "dexring",
   "intring",
+  "intamulet",
+  "stramulet",
   "dexbelt",
+  "intbelt",
 ];
 var maxUpgrade = 7;
 var maxCompound = 3;
@@ -630,16 +642,17 @@ function getTarget() {
 const INTERVAL_BREAKPOINTS = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1];
 function getLoopInterval() {
   const dynamicInterval = INTERVAL_BREAKPOINTS.map(
-    (breakpoint) => (1 / character.frequency / breakpoint) * 1000,
+    (breakpoint) =>
+      Math.max(
+        (1 / character.frequency) * 1000,
+        character.s.penalty_cd?.ms ?? 0,
+      ) / breakpoint,
   ).find((loopInterval) => loopInterval > 250);
   const frequencyInterval = (1 / character.frequency) * 1000;
 
-  return Math.max(
-    ms_to_next_skill("attack") <= 300
-      ? Math.max(ms_to_next_skill("attack"), 100)
-      : dynamicInterval ?? frequencyInterval,
-    character.s.penalty_cd?.ms ?? 0,
-  );
+  return ms_to_next_skill("attack") <= dynamicInterval
+    ? Math.max(ms_to_next_skill("attack"), 50)
+    : dynamicInterval ?? frequencyInterval;
 }
 
 function ms_to_next_skill(skill) {
@@ -1264,8 +1277,9 @@ setInterval(async function () {
   );
 
   if (
+    !isMerchant() &&
     whitelistPartyMembers.length &&
-    whitelistPartyMembers.length <= 6 &&
+    whitelistPartyMembers.length < 6 &&
     (!parent.party_list.length || !hasWhitelistedMember)
   ) {
     send_party_request(whitelistPartyMembers[0].name);
@@ -1315,6 +1329,7 @@ async function changeToDailyEventTargets() {
       change_target(rgooInstance || bgooInstance);
       return rgooInstance || bgooInstance;
     }
+    return target || rgooInstance || bgooInstance;
   }
 
   if (parent.S.dragold?.live) {
@@ -1361,29 +1376,53 @@ async function changeToDailyEventTargets() {
     }
   }
 
+  const activeBosses = [];
+
   if (
     parent.S.mrpumpkin &&
     parent.S.mrpumpkin.live &&
     parent.S.mrpumpkin.target
   ) {
-    changeToPullStrategies();
-
-    const mrPumpkinInstance = get_nearest_monster({ type: "mrpumpkin" });
-    if (!mrPumpkinInstance) advanceSmartMove(parent.S.mrpumpkin);
-    else {
-      change_target(mrPumpkinInstance);
-      return mrPumpkinInstance;
-    }
+    activeBosses.push({
+      ...parent.S.mrpumpkin,
+      type: "mrpumpkin",
+      strategy: changeToPullStrategies,
+    });
   }
 
   if (parent.S.mrgreen?.live && parent.S.mrgreen.target) {
-    changeToPullStrategies();
+    activeBosses.push({
+      ...parent.S.mrgreen,
+      type: "mrgreen",
+      strategy: changeToPullStrategies,
+    });
+  }
 
-    const mrGreenInstance = get_nearest_monster({ type: "mrgreen" });
-    if (!mrGreenInstance) advanceSmartMove(parent.S.mrgreen);
-    else {
-      change_target(mrGreenInstance);
-      return mrGreenInstance;
+  if (parent.S.icegolem?.live) {
+    activeBosses.push({
+      ...parent.S.icegolem,
+      type: "icegolem",
+      strategy: changeToNormalStrategies,
+    });
+  }
+
+  if (activeBosses.length) {
+    const bossToFight = activeBosses
+      .sort(
+        (lhs, rhs) =>
+          lhs.hp / parent.G.monsters[lhs.type].hp -
+          rhs.hp / parent.G.monsters[rhs.type].hp,
+      )
+      .shift();
+
+    if (bossToFight) {
+      const bossInstance = get_nearest_monster({ type: bossToFight.type });
+      bossToFight.strategy();
+      if (!bossInstance) advanceSmartMove(bossToFight);
+      else {
+        change_target(bossInstance);
+        return bossInstance;
+      }
     }
   }
 
@@ -1477,20 +1516,6 @@ async function changeToDailyEventTargets() {
 
     change_target(targetCrab);
     return targetCrab;
-  }
-
-  if (parent.S.icegolem?.live) {
-    changeToNormalStrategies();
-    const iceGolemInstance = get_nearest_monster({ type: "icegolem" });
-    if (!iceGolemInstance) {
-      await advanceSmartMove({ map: "winterland", x: 792, y: 416 });
-    }
-    change_target(get_nearest_monster({ type: "icegolem" }));
-    return get_nearest_monster({ type: "icegolem" });
-  } else if (get_nearest_monster({ type: "icegolem" })) {
-    changeToNormalStrategies();
-    change_target(target);
-    return get_nearest_monster({ type: "icegolem" });
   }
 
   if (

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -400,6 +400,9 @@ const SALE_ABLE = [
   "stramulet",
   "dexbelt",
   "intbelt",
+  // Halloween temp for gold
+  "bowofthedead",
+  "daggerofthedead",
 ];
 var maxUpgrade = 7;
 var maxCompound = 3;
@@ -694,9 +697,10 @@ function extraDistanceWithinHitbox(target) {
 }
 
 async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
+  const loopInterval = Math.max(150, getLoopInterval());
   if (!target || smart.moving || isAdvanceSmartMoving) {
     angle = undefined;
-    return setTimeout(hitAndRun, getLoopInterval());
+    return setTimeout(hitAndRun, loopInterval);
   }
 
   if (!angle) {
@@ -784,7 +788,7 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
   angle +=
     flipRotation *
     Math.asin(
-      (character.speed * getLoopInterval()) /
+      (character.speed * loopInterval) /
         1000 /
         2 /
         (character.range * rangeRateFn +
@@ -798,7 +802,7 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
           extraRangeBySelfHitbox),
     ) *
     2;
-  return setTimeout(hitAndRun, getLoopInterval());
+  return setTimeout(hitAndRun, loopInterval);
 }
 hitAndRun();
 

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -128,7 +128,23 @@ var desiredElixir = "elixirluck";
 //// INVENTORY functions
 function item_info(item) {
   if (!item) return undefined;
-  return parent.G.items[item.name];
+
+  const baseInfo = parent.G.items[item.name];
+  if (!baseInfo) return undefined;
+
+  // Clone to avoid mutating global data
+  const itemInfo = JSON.parse(JSON.stringify(baseInfo));
+  const levelBonuses = itemInfo.upgrade ?? itemInfo.compound ?? undefined;
+
+  if (item.level && levelBonuses) {
+    for (const [key, value] of Object.entries(levelBonuses)) {
+      if (typeof value === "number") {
+        itemInfo[key] = (itemInfo[key] ?? 0) + value * item.level;
+      }
+    }
+  }
+
+  return itemInfo;
 }
 
 function isInvFull(slots = 1) {
@@ -260,6 +276,12 @@ var IGNORE = [
   "orbofplague",
   "orbofresolve",
   "gphelmet",
+  "bowofthedead",
+  "daggerofthedead",
+  "maceofthedead",
+  "pmaceofthedead",
+  "staffofthedead",
+  "swordofthedead",
   ...BUYABLE,
 ];
 
@@ -375,7 +397,6 @@ const SALE_ABLE = [
   "pmaceofthedead",
   "staffofthedead",
   "swordofthedead",
-  "throwingstars",
   "ringsj",
   "mshield",
   "hhelmet",
@@ -396,7 +417,7 @@ const SALE_ABLE = [
   "strearring",
   "dexring",
   "intring",
-  "intamulet",
+  "dexamulet",
   "stramulet",
   "dexbelt",
   "intbelt",
@@ -569,7 +590,7 @@ buff();
 
 function getTarget() {
   const leader = get_entity(partyMems[0]);
-  var target = get_targeted_monster();
+  let target = get_targeted_monster();
 
   if (target && !get_nearest_monster({ type: target.mtype }))
     target = undefined;
@@ -806,12 +827,14 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
 }
 hitAndRun();
 
+const HEAL_IGNORE = ["Geoffriel", "CrownPriest"];
 function getLowestHealth() {
   const allies = parent.party_list.map((name) => get_entity(name));
-  allies.filter((entity) => entity);
+  allies.filter((entity) => entity && !HEAL_IGNORE.includes(entity.name));
   allies.sort((lhs, rhs) => lhs.hp / lhs.max_hp - rhs.hp / rhs.max_hp);
   return allies[0] || character;
 }
+
 function healingPrioritizedNames() {
   return [...new Set([...partyMems, partyMerchant, ...parent.party_list])];
 }
@@ -837,6 +860,7 @@ function getPlayersToHeal() {
       (entity) =>
         entity &&
         (entity.type === "character" || entity.mtype === "ghost") &&
+        !HEAL_IGNORE.includes(entity.name) &&
         (entity.mtype !== "ghost"
           ? !prioritizedName.includes(entity.name) &&
             (entity.max_hp >
@@ -1185,7 +1209,7 @@ setInterval(async function () {
   }
 
   // Inventory check and potions
-  if (isInvFull(10)) {
+  if (isInvFull(6)) {
     log("Inventory full! Calling our merchant!");
     send_cm(partyMerchant, { msg: "inv_full", ...obj });
   } else if (

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -251,7 +251,6 @@ var IGNORE = [
   "stand0",
   "pickaxe",
   "rod",
-  "broom",
   "tracker",
   "sword",
   "throwingstars",
@@ -388,6 +387,7 @@ const SALE_ABLE = [
   "strearring",
   "dexring",
   "intring",
+  "dexbelt",
 ];
 var maxUpgrade = 7;
 var maxCompound = 3;
@@ -1200,10 +1200,32 @@ setInterval(async function () {
   }
 }, 10000);
 
+/**
+ * Get all character in the server
+ * @author earthiverse
+ * @returns list of character in server
+ */
+async function getServerPlayers() {
+  const playersData = new Promise((resolve, reject) => {
+    const dataCheck = (data) => {
+      resolve(data);
+    };
+
+    setTimeout(() => {
+      parent.socket.off("players", dataCheck);
+      reject(`getServerPlayers timeout (2500ms)`);
+    }, 2500);
+    parent.socket.once("players", dataCheck);
+  });
+  parent.socket.emit("players");
+  return playersData;
+}
+
 // Party Setups
 setInterval(async function () {
   //// Deploy characters which arent active
   const loadedCharacters = get_active_characters();
+  const serverCharacters = await getServerPlayers();
   const allCharacters = [...partyMems, partyMerchant];
 
   if (parent.caracAL && caracALconfig.characters[character.name].enabled) {
@@ -1231,13 +1253,27 @@ setInterval(async function () {
     //   }
     // });
   }
+  const partyWhitelistRegex = [/^earth/];
+  const whitelistPartyMembers = serverCharacters.filter(
+    (char) =>
+      !partyMems.includes(char.name) &&
+      partyWhitelistRegex.some((regex) => regex.test(char.party)),
+  );
+  const hasWhitelistedMember = parent.party_list.some((member) =>
+    whitelistPartyMembers.some((whitelisted) => whitelisted.name === member),
+  );
 
-  // if (!parent.party_list.length || !parent.party_list.includes("earthPri"))
-  //   send_party_request("earthPri");
+  if (
+    whitelistPartyMembers.length &&
+    whitelistPartyMembers.length <= 6 &&
+    (!parent.party_list.length || !hasWhitelistedMember)
+  ) {
+    send_party_request(whitelistPartyMembers[0].name);
+  }
 
   if (partyMems.length !== parent.party_list.length) {
     if (character.name === partyMems[0]) {
-      partyMems.map((member) => {
+      partyMems.forEach((member) => {
         send_party_invite(member);
       });
     }
@@ -1325,18 +1361,22 @@ async function changeToDailyEventTargets() {
     }
   }
 
-  if (parent.S.mrpumpkin?.live) {
+  if (
+    parent.S.mrpumpkin &&
+    parent.S.mrpumpkin.live &&
+    parent.S.mrpumpkin.target
+  ) {
     changeToPullStrategies();
 
     const mrPumpkinInstance = get_nearest_monster({ type: "mrpumpkin" });
-    if (!mrPumpkinInstance) advanceSmartMove(parent.S.pumpkin);
+    if (!mrPumpkinInstance) advanceSmartMove(parent.S.mrpumpkin);
     else {
       change_target(mrPumpkinInstance);
       return mrPumpkinInstance;
     }
   }
 
-  if (parent.S.mrgreen?.live) {
+  if (parent.S.mrgreen?.live && parent.S.mrgreen.target) {
     changeToPullStrategies();
 
     const mrGreenInstance = get_nearest_monster({ type: "mrgreen" });

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -409,8 +409,8 @@ const SALE_ABLE = [
   "carrotsword",
   // "wcap",
   // "wshoes",
-  // "wgloves",
-  // "wbreeches",
+  "wgloves",
+  "wbreeches",
   "cclaw",
   "dagger",
   "rednose",
@@ -441,7 +441,6 @@ const SALE_ABLE = [
   "glolipop",
   "whiteegg",
   "hboots",
-  "smoke",
   "sword",
   "spear",
   "throwingstars",
@@ -509,7 +508,7 @@ async function sortInv() {
     return lhs.slot - rhs.slot;
   });
 
-  // We’ll create a mapping from target slot → original slot
+  // Create a mapping from target slot → original slot
   const promises = [];
   const usedSlots = new Set();
 
@@ -721,7 +720,7 @@ function getLoopInterval() {
   const frequencyInterval = (1 / character.frequency) * 1000;
 
   return ms_to_next_skill("attack") <= dynamicInterval
-    ? Math.max(ms_to_next_skill("attack"), 50)
+    ? Math.max(ms_to_next_skill("attack"), 25)
     : dynamicInterval ?? frequencyInterval;
 }
 
@@ -863,7 +862,7 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
   if (!can_move_to(new_x, new_y)) {
     // Try small angular adjustments in the current flip direction
     flipRotation *= -1;
-    for (let i = 2; i <= 8; i++) {
+    for (let i = 1; i <= 16; i++) {
       const adjustedAngle = angle + (flipRotation * Math.PI) / (16 / i);
       const alt_x =
         target.x + (rangeRadius + character.xrange) * Math.cos(adjustedAngle);
@@ -916,7 +915,7 @@ function prioritizedNames() {
 
 function getPlayersToHeal() {
   const minHealMod = 0.9;
-  const healPower = character.heal || character.attack;
+  const healPower = character.heal || character.attack * 1.5;
   const prioritizedNamesList = prioritizedNames();
 
   const shouldHeal = (entity) => {
@@ -925,35 +924,44 @@ function getPlayersToHeal() {
   };
 
   // Prioritized characters
-  const prioritized = prioritizedNamesList
-    .map((name) => get_player(name))
-    .filter((player) => player && shouldHeal(player))
-    .sort((lhs, rhs) => lhs.hp / lhs.max_hp - rhs.hp / rhs.max_hp);
+  // const prioritized = prioritizedNamesList
+  //   .map((name) => get_entity(name))
+  //   .filter(
+  //     (player) => player && !player.dead && !player.rip && shouldHeal(player),
+  //   )
+  //   .sort((lhs, rhs) => lhs.hp / lhs.max_hp - rhs.hp / rhs.max_hp);
 
   // Other healable entities
-  const others = Object.values(parent.entities)
+  const potentialHealees = Object.values(parent.entities)
     .filter((entity) => {
       if (!entity) return false;
-      if (entity.mtype === "ghost") {
-        if (character.ctype !== "priest") return false;
+      if (entity.dead || entity.rip) return false;
+
+      if (character.ctype === "priest" && entity.mtype === "ghost") {
         return !entity.s.healed && entity.hp < 7000;
       }
 
-      if (entity.type === "monster") return false;
+      if (entity.type === "monster" || entity.citizen) return false;
       if (HEAL_IGNORE.includes(entity.name)) return false;
-      if (prioritizedNamesList.includes(entity.name)) return false;
 
       return shouldHeal(entity);
     })
-    .sort((a, b) => {
+    .sort((lhs, rhs) => {
       // Ghosts first if both exist
-      const ghostA = a.mtype === "ghost";
-      const ghostB = b.mtype === "ghost";
-      if (ghostA !== ghostB) return ghostA ? -1 : 1;
-      return a.hp / a.max_hp - b.hp / b.max_hp;
+
+      const isLhsPrioritized = prioritizedNamesList.includes(lhs.name);
+      const isRhsPrioritized = prioritizedNamesList.includes(rhs.name);
+
+      if (isLhsPrioritized !== isRhsPrioritized)
+        return isLhsPrioritized ? -1 : 1;
+
+      const ghostLhs = lhs.mtype === "ghost";
+      const ghostRhs = rhs.mtype === "ghost";
+      if (ghostLhs !== ghostRhs) return ghostLhs ? -1 : 1;
+      return lhs.hp / lhs.max_hp - rhs.hp / rhs.max_hp;
     });
 
-  return [...prioritized, ...others];
+  return potentialHealees;
 }
 
 function getLowestMana() {
@@ -1107,122 +1115,6 @@ setInterval(() => {
   }
 }, 100);
 
-async function cupidHeal() {
-  if (
-    (locate_item("cupid") === -1 &&
-      character.slots.mainhand?.name !== "cupid") ||
-    ms_to_next_skill("attack") > 0
-  )
-    return;
-
-  const characterRange = character.range + character.xrange;
-  // const prioritized = prioritizedNames();
-
-  const lowHealthPlayers = getPlayersToHeal().filter(
-    (player) => player.name !== character.name && player.ctype !== "priest",
-  );
-  const lowHealthPlayersInRange = lowHealthPlayers.filter(
-    (player) => distance(player, character) < characterRange,
-  );
-
-  // const prioritizedPlayers = lowHealthPlayers.filter((player) =>
-  //   prioritized.includes(player.name),
-  // );
-
-  const promisesToAwait = [];
-
-  // if (
-  //   prioritizedPlayers.length &&
-  //   prioritizedPlayers.some(
-  //     (player) =>
-  //       distance(character, player) > characterRange &&
-  //       distance(character, player) < 300,
-  //   )
-  // ) {
-  //   const prioritizedPlayersLength = prioritizedPlayers.length;
-  //   const sumsPosition = prioritizedPlayers.reduce(
-  //     (accumulator, currentPlayer) => {
-  //       accumulator.sumX += currentPlayer.x;
-  //       accumulator.sumY += currentPlayer.y;
-  //       return accumulator;
-  //     },
-  //     { sumX: 0, sumY: 0 },
-  //   );
-  //   promisesToAwait.push(
-  //     move(
-  //       sumsPosition.sumX / prioritizedPlayersLength,
-  //       sumsPosition.sumY / prioritizedPlayersLength,
-  //     ),
-  //   );
-  // }
-
-  if (lowHealthPlayersInRange.length > 0) {
-    console.log(
-      lowHealthPlayersInRange
-        .map((player) => `${player.name} (${player.hp}/${player.max_hp})`)
-        .join(", "),
-    );
-    promisesToAwait.push(
-      equipBatch({
-        mainhand: "cupid",
-      }),
-    );
-
-    if (
-      character.level >= G.skills["5shot"].level &&
-      lowHealthPlayersInRange.length >= 4 &&
-      character.mp > G.skills["5shot"].mp + G.skills["huntersmark"].mp &&
-      !character.fear
-    ) {
-      set_message("5shot Cupid");
-      log(
-        `Healing ${lowHealthPlayersInRange
-          .slice(0, 5)
-          .map((player) => player.name)
-          .join(", ")}`,
-      );
-      promisesToAwait.push(
-        use_skill("5shot", lowHealthPlayersInRange.slice(0, 5)).then(() =>
-          reduce_cooldown("attack", Math.min(...parent.pings)),
-        ),
-      );
-    } else if (
-      character.level >= G.skills["3shot"].level &&
-      lowHealthPlayersInRange.length >= 2 &&
-      character.mp > G.skills["3shot"].mp + G.skills["huntersmark"].mp &&
-      !character.fear
-    ) {
-      set_message("3shot Cupid");
-      log(
-        `Healing ${lowHealthPlayersInRange
-          .slice(0, 3)
-          .map((player) => player.name)
-          .join(", ")}`,
-      );
-      promisesToAwait.push(
-        use_skill("3shot", lowHealthPlayersInRange.slice(0, 3)).then(() =>
-          reduce_cooldown("attack", Math.min(...parent.pings)),
-        ),
-      );
-    } else if (lowHealthPlayersInRange.length) {
-      set_message("Single Cupid");
-      log(`Healing ${lowHealthPlayersInRange[0].name}`);
-      promisesToAwait.push(
-        use_skill("attack", lowHealthPlayersInRange[0]).then(() =>
-          reduce_cooldown("attack", Math.min(...parent.pings)),
-        ),
-      );
-    }
-  }
-
-  try {
-    await withTimeout(Promise.all(promisesToAwait), 1000);
-  } catch (e) {
-    attackErrorHandler(e);
-    console.error("Error while Cupiding!", e);
-  }
-}
-
 //// Interval threads
 // Code Messaging
 setInterval(async function () {
@@ -1245,7 +1137,7 @@ setInterval(async function () {
     currentTarget &&
     distance(currentTarget, character) >
       character.range +
-        character.xrange +
+        character.xrange * 0.9 +
         extraDistanceWithinHitbox(currentTarget) +
         extraDistanceWithinHitbox(character) &&
     !smart.moving &&
@@ -1400,14 +1292,14 @@ setInterval(async function () {
   if (
     !isMerchant() &&
     whitelistPartyMembers.length &&
-    whitelistPartyMembers.length < 6 &&
+    whitelistPartyMembers.length <= 6 &&
     (!parent.party_list.length || !hasWhitelistedMember)
   ) {
     send_party_request(whitelistPartyMembers[0].name);
   }
 
-  if (partyMems.length !== parent.party_list.length) {
-    if (character.name === partyMems[0]) {
+  if (partyMems.every((id) => !parent.party_list.includes(id))) {
+    if (character.name === TANKER) {
       partyMems.forEach((member) => {
         send_party_invite(member);
       });
@@ -1777,10 +1669,6 @@ function on_magiport(name) {
 function attackErrorHandler(error) {
   if (error.failed && error.response === "cooldown") {
     reduce_cooldown("attack", -error.ms);
-  }
-
-  if (error.failed && error.reason === "not_there") {
-    parent.socket.emit("send_updates", {});
   }
 }
 

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -11,9 +11,10 @@ var partyMems = ["MooohMoooh", "CowTheMooh", "MowTheCooh"];
 // var partyMems = ["CowTheMooh", "MowTheCooh", "MoohThatCow"];
 
 const MAGE = "MowTheCooh";
+const WARRIOR = "MooohMoooh";
+const ROGUE = "MooohSteak";
 var HEALER = "CowTheMooh";
 var RANGER = "MoohThatCow";
-const WARRIOR = "MooohMoooh";
 
 var TANKER =
   partyMems.find((id) => [HEALER, WARRIOR].includes(id)) ?? partyMems[0];
@@ -107,9 +108,9 @@ const MELEE_IGNORE_LIST = ["porcupine"];
 // var mapX = 423;
 // var mapY = -2614;
 
-var map = "desertland";
-var mapX = 223;
-var mapY = -708;
+// var map = "desertland";
+// var mapX = 223;
+// var mapY = -708;
 
 // var map = "tunnel";
 // var mapX = 0;
@@ -131,14 +132,14 @@ var mapY = -708;
 // var mapX = -1111;
 // var mapY = 132;
 
-// var map = "desertland";
-// var mapX = -800;
-// var mapY = -354;
+var map = "desertland";
+var mapX = -800;
+var mapY = -354;
 
 // var mobsToFarm = ["grinch", "phoenix", "spider", "bigbird", "scorpion"];
 // var mobsToFarm = ["goldenbot", "sparkbot", "sparkbot"];
 // var mobsToFarm = ["phoenix", "stompy", "wolf"];
-var mobsToFarm = ["fireroamer"];
+// var mobsToFarm = ["fireroamer"];
 // var mobsToFarm = ["grinch", "phoenix", "mole"];
 
 // var mobsToFarm = ["phoenix", "xscorpion", "minimush"];
@@ -154,7 +155,7 @@ var mobsToFarm = ["fireroamer"];
 //   "turtle",
 //   "crabx",
 // ];
-// var mobsToFarm = ["plantoid"];
+var mobsToFarm = ["plantoid"];
 
 // desired elixir named
 var desiredElixir = "elixirluck";
@@ -311,7 +312,7 @@ var IGNORE = [
   "orbofresolve",
   "gphelmet",
   // "bowofthedead",
-  "daggerofthedead",
+  // "daggerofthedead",
   "maceofthedead",
   "pmaceofthedead",
   "staffofthedead",
@@ -397,6 +398,7 @@ const STORE_ABLE = [
 ];
 
 const SALE_ABLE = [
+  "smoke",
   "vgloves",
   "mcape",
   "wbook0",
@@ -458,7 +460,7 @@ const SALE_ABLE = [
   "intbelt",
   // Halloween temp for gold
   // "bowofthedead",
-  "daggerofthedead",
+  // "daggerofthedead",
 ];
 var maxUpgrade = 7;
 var maxCompound = 3;
@@ -668,26 +670,40 @@ function getTarget() {
         (mob) =>
           mob.type === "monster" &&
           [...partyMems, partyMerchant].includes(mob.target) &&
-          is_in_range(mob, "attack"),
+          distance(mob, character) < character.range + character.xrange,
       );
-      if (leader)
+      if (leader) {
+        let tempTarget =
+          get_target_of(leader) ||
+          get_nearest_monster({ target: partyMems[0] });
+        const tempTargetIsPartyMember =
+          tempTarget &&
+          tempTarget.name &&
+          [...partyMems, ...parent.party_list].includes(tempTarget.name);
+
+        if (tempTarget && tempTargetIsPartyMember) {
+          tempTarget = undefined;
+        }
+
         target =
-          get_target_of(leader) ?? aggroedMobs.length > 0
+          tempTarget ?? aggroedMobs.length > 0
             ? aggroedMobs[0]
             : mob && mob.attack < 200
             ? mob
             : undefined;
-      else target = mob;
+      } else target = mob;
     }
 
     if (target) change_target(target);
     else {
       set_message("No Monsters");
       if (
+        !character.moving &&
         character.map !== "crypt" &&
         leader &&
         !smart.moving &&
         !isAdvanceSmartMoving &&
+        character.cc < 125 &&
         Math.sqrt(
           (character.x - leader.x) * (character.x - leader.x) +
             (character.y - leader.y) * (character.y - leader.y),
@@ -759,7 +775,7 @@ async function leaveJail() {
 
 function extraDistanceWithinHitbox(target) {
   if (!target) return 0;
-  return Math.min(get_height(target), get_width(target) / 2) / 2;
+  return Math.min(get_height(target) / 2, get_width(target) / 2) / 2;
 }
 
 var lastKitingTarget = undefined;
@@ -767,7 +783,7 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
   const loopInterval = Math.max(200, getLoopInterval());
 
   // --- 1. Early exits and sanity checks ---
-  if (character.cc > 150) return setTimeout(hitAndRun, loopInterval);
+  if (character.cc >= 125) return setTimeout(hitAndRun, loopInterval);
   if (!target || smart.moving || isAdvanceSmartMoving) {
     angle = undefined;
     return setTimeout(hitAndRun, loopInterval);
@@ -832,9 +848,10 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
   // --- 4. Calculate range offsets ---
   const extraRangeTarget = extraDistanceWithinHitbox(target);
   const extraRangeSelf = extraDistanceWithinHitbox(character);
-  const totalExtraRange = extraRangeTarget + extraRangeSelf;
+  // const totalExtraRange = extraRangeTarget + extraRangeSelf;
   const rangeRadius = character.range * rangeRateFn;
-  const extendedRadius = character.xrange * 0.9 + totalExtraRange;
+  const extendedRadius = character.xrange;
+  // + totalExtraRange;
 
   // --- 5. Desired destination based on current orbit angle ---
   let new_x = target.x + (rangeRadius + extendedRadius) * cosA;
@@ -853,7 +870,7 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
     flipCooldown = 0;
   }
 
-  flipCooldown--;
+  flipCooldown++;
   flipRotationCooldown--;
 
   // --- 7. Collision handling and alternative movement path ---
@@ -861,7 +878,10 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
 
   if (!can_move_to(new_x, new_y)) {
     // Try small angular adjustments in the current flip direction
-    flipRotation *= -1;
+    if (flipRotationCooldown < 0) {
+      flipRotation *= -1;
+      flipRotationCooldown = 6;
+    }
     for (let i = 1; i <= 16; i++) {
       const adjustedAngle = angle + (flipRotation * Math.PI) / (16 / i);
       const alt_x =
@@ -915,12 +935,16 @@ function prioritizedNames() {
 
 function getPlayersToHeal() {
   const minHealMod = 0.9;
-  const healPower = character.heal || character.attack * 1.5;
+  const healThreshold = character.ctype === "priest" ? 0.8 : 0.65;
+  const healPower = character.heal || character.attack * 2.5;
   const prioritizedNamesList = prioritizedNames();
 
   const shouldHeal = (entity) => {
     const missing = entity.max_hp - entity.hp;
-    return missing > minHealMod * healPower || entity.hp < 0.8 * entity.max_hp;
+    return (
+      missing > minHealMod * healPower ||
+      entity.hp < healThreshold * entity.max_hp
+    );
   };
 
   // Prioritized characters
@@ -932,7 +956,10 @@ function getPlayersToHeal() {
   //   .sort((lhs, rhs) => lhs.hp / lhs.max_hp - rhs.hp / rhs.max_hp);
 
   // Other healable entities
-  const potentialHealees = Object.values(parent.entities)
+  const potentialHealees = [
+    ...Object.values(parent.entities),
+    ...(character.ctype === "priest" ? [character] : []),
+  ]
     .filter((entity) => {
       if (!entity) return false;
       if (entity.dead || entity.rip) return false;
@@ -1173,7 +1200,7 @@ setInterval(async function () {
     send_cm(partyMerchant, { msg: "buff_mluck", ...obj });
   }
 
-  // Send gold to merchant if he's nearby
+  // Send things to merchant if he's nearby
   if (get_entity(partyMerchant)) {
     send_gold(partyMerchant, character.gold - 1000000);
     await Promise.all(
@@ -1265,6 +1292,11 @@ setInterval(async function () {
   const allCharacters = [...partyMems, partyMerchant];
 
   if (parent.caracAL && caracALconfig.characters[character.name].enabled) {
+    if (character.ctype === "merchant" && parent.caracAL.siblings.length)
+      parent.caracAL.siblings
+        .filter((id) => id !== character.name && !partyMems.includes(id))
+        .forEach((id) => parent.caracAL.shutdown(id));
+
     allCharacters
       .filter((id) => parent.caracAL && !parent.caracAL.siblings.includes(id))
       .forEach((id) => {
@@ -1298,8 +1330,8 @@ setInterval(async function () {
     send_party_request(whitelistPartyMembers[0].name);
   }
 
-  if (partyMems.every((id) => !parent.party_list.includes(id))) {
-    if (character.name === TANKER) {
+  if (partyMems.some((id) => !parent.party_list.includes(id))) {
+    if (character.name === partyMems[0]) {
       partyMems.forEach((member) => {
         send_party_invite(member);
       });
@@ -1315,23 +1347,59 @@ function on_party_invite(name) {
   if (name === partyMems[0]) accept_party_invite(name);
 }
 
-function dynamicParty() {
-  if (parent.S.mrgreen?.live || parent.S.mrpumpkin?.live) {
-    const currentServer = `${server.region}${server.id}`;
-    if (currentServer === "USI") {
-      partyMems = ["MooohMoooh", "CowTheMooh", "MooohSteak"];
-    } else if (currentServer === "EUII") {
+const DYNAMIC_PARTY_PRESETS = {
+  snowman: [WARRIOR, RANGER, MAGE],
+  mrgreen: {
+    USI: [WARRIOR, HEALER, ROGUE],
+    EUII: () => {
       RANGER = "MoohThatCow";
-      partyMems = [WARRIOR, RANGER, MAGE];
-    } else if (currentServer === "USII") {
+      return [WARRIOR, RANGER, MAGE];
+    },
+    USII: () => {
       RANGER = "CupidCow";
-      partyMems = [WARRIOR, RANGER, MAGE];
-    } else {
-      partyMems = ["MooohMoooh", "CowTheMooh", "MowTheCooh"];
-    }
-  } else {
-    partyMems = ["MooohMoooh", "CowTheMooh", "MowTheCooh"];
-  }
+      return [WARRIOR, RANGER, MAGE];
+    },
+    default: [WARRIOR, HEALER, MAGE],
+  },
+  mrpumpkin: "mrgreen", // share config
+  franky: () => {
+    const isAggroed = !!parent.S.franky?.target;
+    return [WARRIOR, HEALER, isAggroed ? ROGUE : MAGE];
+  },
+
+  crabxx: () => {
+    const isAggroed = !!parent.S.crabxx?.target;
+    return [
+      WARRIOR,
+      isAggroed ? RANGER : HEALER,
+      isAggroed ? "CupidCow" : MAGE,
+    ];
+  },
+  default: [WARRIOR, HEALER, MAGE],
+};
+
+function getPresetMembers(preset, currentServer) {
+  if (typeof preset === "function") return preset();
+  if (Array.isArray(preset)) return preset;
+  if (typeof preset === "string")
+    return getPresetMembers(DYNAMIC_PARTY_PRESETS[preset], currentServer);
+
+  const value = preset[currentServer] ?? DYNAMIC_PARTY_PRESETS.default;
+  return typeof value === "function" ? value() : value;
+}
+
+function dynamicParty() {
+  const currentServer = `${server.region}${server.id}`;
+  const activeEvent =
+    Object.keys(DYNAMIC_PARTY_PRESETS).find((name) => parent.S[name]?.live) ??
+    "default";
+
+  if (!activeEvent) return;
+
+  const preset = DYNAMIC_PARTY_PRESETS[activeEvent];
+  const members = getPresetMembers(preset, currentServer);
+
+  if (members) partyMems = members;
 }
 dynamicParty();
 setInterval(dynamicParty, 3000);
@@ -1667,9 +1735,31 @@ function on_magiport(name) {
 }
 
 function attackErrorHandler(error) {
-  if (error.failed && error.response === "cooldown") {
-    reduce_cooldown("attack", -error.ms);
-  }
+  if (error.failed) {
+    if (error.response === "cooldown")
+      reduce_cooldown("attack", -error.ms + Math.min(...parent.pings) / 2);
+    else if (
+      error.reason === "too_far" &&
+      character.cc < 125 &&
+      !character.moving
+    ) {
+      const currentX = character.x;
+      const currentY = character.y;
+
+      const target = get_target();
+      const targetX = target.going_x ?? target.x;
+      const targetY = target.going_y ?? target.y;
+
+      const newX = currentX + 0.4 * (targetX - currentX);
+      const newY = currentY + 0.4 * (targetY - currentY);
+      console.log(
+        `Too far, ${Math.round(error.distance)} distance / ${
+          character.range + character.xrange
+        } range`,
+      );
+      move(newX, newY);
+    }
+  } else console.log("Error while attacking:", error);
 }
 
 setInterval(() => parent.socket.emit("send_updates", {}), 30000);

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -386,6 +386,8 @@ const SALE_ABLE = [
   // Sell and replace by crypts's drops
   "intearring",
   "strearring",
+  "dexring",
+  "intring",
 ];
 var maxUpgrade = 7;
 var maxCompound = 3;
@@ -632,9 +634,12 @@ function getLoopInterval() {
   ).find((loopInterval) => loopInterval > 250);
   const frequencyInterval = (1 / character.frequency) * 1000;
 
-  return ms_to_next_skill("attack") <= 300
-    ? Math.max(ms_to_next_skill("attack"), 100)
-    : dynamicInterval ?? frequencyInterval;
+  return Math.max(
+    ms_to_next_skill("attack") <= 300
+      ? Math.max(ms_to_next_skill("attack"), 100)
+      : dynamicInterval ?? frequencyInterval,
+    character.s.penalty_cd?.ms ?? 0,
+  );
 }
 
 function ms_to_next_skill(skill) {
@@ -963,7 +968,9 @@ function suicide() {
   if (
     !character.rip &&
     character.hp < Math.max(0.15 * character.max_hp, 2000) &&
-    (avgDmgTaken(character) > character.hp || character.ping > 600)
+    (avgDmgTaken(character) > character.hp ||
+      character.ping > 600 ||
+      character.s.burned)
   ) {
     parent.socket.emit("harakiri");
     game_log("Harakiri");
@@ -1249,11 +1256,9 @@ function on_party_invite(name) {
 // var pinkGooVisitedBoundary = [];
 async function changeToDailyEventTargets() {
   let target = getTarget();
-  const isFightingBoss = boss.includes(getTarget()?.mtype);
 
   if (
     (parent.S.goobrawl || get_nearest_monster({ type: "bgoo" })) &&
-    !isFightingBoss &&
     !character.s["hopsickness"]
   ) {
     changeToPullStrategies();
@@ -1276,8 +1281,8 @@ async function changeToDailyEventTargets() {
     }
   }
 
-  if (parent.S.dragold?.live && !isFightingBoss) {
-    changeToNormalStrategies();
+  if (parent.S.dragold?.live) {
+    changeToPullStrategies();
 
     const dragoldInstance = get_nearest_monster({ type: "dragold" });
     if (!dragoldInstance) advanceSmartMove(parent.S.dragold);
@@ -1288,7 +1293,7 @@ async function changeToDailyEventTargets() {
     }
   }
 
-  if (parent.S.pinkgoo?.live && !isFightingBoss) {
+  if (parent.S.pinkgoo?.live) {
     changeToNormalStrategies();
     let pinkgooInstance = get_nearest_monster({ type: "pinkgoo" });
     if (!pinkgooInstance) {
@@ -1304,7 +1309,7 @@ async function changeToDailyEventTargets() {
     }
   }
 
-  if (parent.S.snowman?.live && !isFightingBoss) {
+  if (parent.S.snowman?.live) {
     changeToNormalStrategies();
 
     const snowmanInstance = get_nearest_monster({ type: "snowman" });
@@ -1320,10 +1325,31 @@ async function changeToDailyEventTargets() {
     }
   }
 
+  if (parent.S.mrpumpkin?.live) {
+    changeToPullStrategies();
+
+    const mrPumpkinInstance = get_nearest_monster({ type: "mrpumpkin" });
+    if (!mrPumpkinInstance) advanceSmartMove(parent.S.pumpkin);
+    else {
+      change_target(mrPumpkinInstance);
+      return mrPumpkinInstance;
+    }
+  }
+
+  if (parent.S.mrgreen?.live) {
+    changeToPullStrategies();
+
+    const mrGreenInstance = get_nearest_monster({ type: "mrgreen" });
+    if (!mrGreenInstance) advanceSmartMove(parent.S.mrgreen);
+    else {
+      change_target(mrGreenInstance);
+      return mrGreenInstance;
+    }
+  }
+
   if (
     parent.S.crabxx?.live &&
     parent.S.crabxx.hp < parent.S.crabxx.max_hp &&
-    !isFightingBoss &&
     parent.S.crabxx?.target &&
     !partyMems.includes(parent.S.crabxx.target)
   ) {
@@ -1413,7 +1439,7 @@ async function changeToDailyEventTargets() {
     return targetCrab;
   }
 
-  if (parent.S.icegolem?.live && !isFightingBoss) {
+  if (parent.S.icegolem?.live) {
     changeToNormalStrategies();
     const iceGolemInstance = get_nearest_monster({ type: "icegolem" });
     if (!iceGolemInstance) {
@@ -1430,8 +1456,7 @@ async function changeToDailyEventTargets() {
   if (
     parent.S.franky?.live &&
     parent.S.franky?.target &&
-    parent.S.franky?.hp < 0.97 * parent.S.franky?.max_hp &&
-    !isFightingBoss
+    parent.S.franky?.hp < 0.97 * parent.S.franky?.max_hp
   ) {
     changeToNormalStrategies();
     let frankyInstance = get_nearest_monster({ type: "franky" });
@@ -1500,7 +1525,7 @@ async function changeToDailyEventTargets() {
     return pvpTarget.entity;
   }
 
-  if (parent.S.wabbit?.live && !isFightingBoss) {
+  if (parent.S.wabbit?.live) {
     changeToNormalStrategies();
     if (character.range < 100) rangeRate = 0.1;
     else rangeRate = 0.4;

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -12,8 +12,7 @@ var partyMems = ["MooohMoooh", "CowTheMooh", "MowTheCooh"];
 
 const MAGE = "MowTheCooh";
 var HEALER = "CowTheMooh";
-// const HEALER = "CupidCow";
-const RANGER = "MoohThatCow";
+var RANGER = "MoohThatCow";
 const WARRIOR = "MooohMoooh";
 
 var TANKER =
@@ -23,6 +22,41 @@ var TANKER =
 const MIDAS_CHARACTER = [MAGE];
 
 // var partyCodeSlot = [4, 15, 3, 5];
+const CODE_SLOTS = {
+  MoohThatCow: {
+    homeServer: "EUII",
+    script: 32,
+  },
+  CowTheMooh: {
+    homeServer: "ASIAI",
+    script: 2,
+  },
+  MooohMoooh: {
+    homeServer: "ASIAI",
+    script: 9,
+  },
+  MowTheCooh: {
+    homeServer: "ASIAI",
+    script: 4,
+  },
+  MerchantMooh: {
+    homeServer: "ASIAI",
+    script: 5,
+  },
+  MoohChan: {
+    homeServer: "USIII",
+    script: 5,
+  },
+  CupidCow: {
+    homeServer: "USII",
+    script: 32,
+  },
+  MooohSteak: {
+    homeServer: "USI",
+    script: 31,
+  },
+};
+
 var partyCodeSlot = [9, 2, 4, 5];
 // var caracALPartyCodeSlot = [
 //   "adventure-land-scripts-backup/basic_mage.4.js",
@@ -348,6 +382,7 @@ const STORE_ABLE = [
   "cscale",
   "spiderkey",
   "svenom",
+  "vblood",
   "orboffire",
   "orboffrost",
   "orbofplague",
@@ -409,6 +444,7 @@ const SALE_ABLE = [
   "smoke",
   "sword",
   "spear",
+  "throwingstars",
   // Easter's loots
   // "eears",
   // "eslippers",
@@ -828,54 +864,51 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
 hitAndRun();
 
 const HEAL_IGNORE = ["Geoffriel", "CrownPriest"];
-function getLowestHealth() {
-  const allies = parent.party_list.map((name) => get_entity(name));
-  allies.filter((entity) => entity && !HEAL_IGNORE.includes(entity.name));
-  allies.sort((lhs, rhs) => lhs.hp / lhs.max_hp - rhs.hp / rhs.max_hp);
-  return allies[0] || character;
-}
 
-function healingPrioritizedNames() {
+function prioritizedNames() {
   return [...new Set([...partyMems, partyMerchant, ...parent.party_list])];
 }
 
-function getPlayersToHeal() {
-  const minimumHealingModifier = 0.9;
-  const prioritizedName = healingPrioritizedNames();
+function getPlayersToHeal(ignoreGhost = false) {
+  const minHealMod = 0.9;
+  const healPower = character.heal || character.attack;
+  const prioritizedNamesList = prioritizedNames();
 
-  const prioritizedTarget = prioritizedName
-    .map((id) => get_player(id))
-    .filter(
-      (player) =>
-        player &&
-        (player.max_hp >
-          minimumHealingModifier * (character.heal ?? character.attack) +
-            player.hp ||
-          player.hp < player.max_hp * 0.8),
-    )
+  const shouldHeal = (entity) => {
+    const missing = entity.max_hp - entity.hp;
+    return missing > minHealMod * healPower || entity.hp < 0.8 * entity.max_hp;
+  };
+
+  // Prioritized characters
+  const prioritized = prioritizedNamesList
+    .map((name) => get_player(name))
+    .filter((player) => player && shouldHeal(player))
     .sort((lhs, rhs) => lhs.hp / lhs.max_hp - rhs.hp / rhs.max_hp);
 
-  const otherEntities = Object.values(parent.entities)
-    .filter(
-      (entity) =>
-        entity &&
-        (entity.type === "character" || entity.mtype === "ghost") &&
-        !HEAL_IGNORE.includes(entity.name) &&
-        (entity.mtype !== "ghost"
-          ? !prioritizedName.includes(entity.name) &&
-            (entity.max_hp >
-              minimumHealingModifier * (character.heal ?? character.attack) +
-                entity.hp ||
-              entity.hp < 0.8 * entity.max_hp)
-          : !entity.s.healed && entity.hp < 7000),
-    )
-    .sort((lhs, rhs) => {
-      if (lhs.mtype === "ghost" && rhs.mtype !== "ghost") return 9999;
-      if (rhs.mtype === "ghost" && lhs.mtype !== "ghost") return -9999;
-      return lhs.hp / lhs.max_hp - rhs.hp / rhs.max_hp;
+  // Other healable entities
+  const others = Object.values(parent.entities)
+    .filter((entity) => {
+      if (!entity) return false;
+      if (entity.mtype === "ghost") {
+        if (ignoreGhost) return false;
+        return !entity.s.healed && entity.hp < 7000;
+      }
+
+      if (entity.type === "monster") return false;
+      if (HEAL_IGNORE.includes(entity.name)) return false;
+      if (prioritizedNamesList.includes(entity.name)) return false;
+
+      return shouldHeal(entity);
+    })
+    .sort((a, b) => {
+      // Ghosts first if both exist
+      const ghostA = a.mtype === "ghost";
+      const ghostB = b.mtype === "ghost";
+      if (ghostA !== ghostB) return ghostA ? -1 : 1;
+      return a.hp / a.max_hp - b.hp / b.max_hp;
     });
 
-  return [...prioritizedTarget, ...otherEntities];
+  return [...prioritized, ...others];
 }
 
 function getLowestMana() {
@@ -1037,87 +1070,105 @@ async function cupidHeal() {
   )
     return;
 
-  const lowHealthPlayers = Object.values(parent.entities)
-    .filter(
-      (entity) =>
-        entity &&
-        entity.player &&
-        is_in_range(entity, "attack") &&
-        entity.hp < entity.max_hp * 0.8 &&
-        entity.hp <
-          entity.max_hp -
-            character.attack *
-              dps_multiplier(entity.armor - (character.apiercing ?? 0)),
-    )
-    .sort((lhs, rhs) => {
-      if ([...partyMems, partyMerchant].includes(lhs.name)) return -1;
-      if ([...partyMems, partyMerchant].includes(rhs.name)) return 1;
+  const characterRange = character.range + character.xrange;
+  const prioritized = prioritizedNames();
 
-      return lhs.hp / lhs.max_hp - rhs.hp / rhs.max_hp;
-    });
+  const lowHealthPlayers = getPlayersToHeal(true).filter(
+    (player) => player.name !== character.name && player.ctype !== "priest",
+  );
+  const lowHealthPlayersInRange = lowHealthPlayers.filter(
+    (player) => distance(player, character) < characterRange,
+  );
+  const prioritizedPlayers = lowHealthPlayers.filter((player) =>
+    prioritized.includes(player.name),
+  );
 
-  const promises = [];
+  const promisesToAwait = [];
 
-  if (lowHealthPlayers.length > 0) {
-    promises.push(
+  // if (
+  //   prioritizedPlayers.length &&
+  //   prioritizedPlayers.some(
+  //     (player) =>
+  //       distance(character, player) > characterRange &&
+  //       distance(character, player) < 300,
+  //   )
+  // ) {
+  //   const prioritizedPlayersLength = prioritizedPlayers.length;
+  //   const sumsPosition = prioritizedPlayers.reduce(
+  //     (accumulator, currentPlayer) => {
+  //       accumulator.sumX += currentPlayer.x;
+  //       accumulator.sumY += currentPlayer.y;
+  //       return accumulator;
+  //     },
+  //     { sumX: 0, sumY: 0 },
+  //   );
+  //   promisesToAwait.push(
+  //     move(
+  //       sumsPosition.sumX / prioritizedPlayersLength,
+  //       sumsPosition.sumY / prioritizedPlayersLength,
+  //     ),
+  //   );
+  // }
+
+  if (lowHealthPlayersInRange.length > 0) {
+    promisesToAwait.push(
       equipBatch({
         mainhand: "cupid",
       }),
     );
 
-    await Promise.all(promises);
-
     if (
       character.level >= G.skills["5shot"].level &&
-      lowHealthPlayers.length >= 4 &&
-      character.mp > 400 &&
-      !character.fear &&
-      ms_to_next_skill("attack") === 0
+      lowHealthPlayersInRange.length >= 4 &&
+      character.mp > G.skills["5shot"].mp + G.skills["huntersmark"].mp &&
+      !character.fear
     ) {
       set_message("5shot Cupid");
       log(
-        `Healing ${lowHealthPlayers
+        `Healing ${lowHealthPlayersInRange
           .slice(0, 5)
           .map((player) => player.name)
           .join(", ")}`,
       );
-      use_skill("5shot", lowHealthPlayers.slice(0, 5)).then(() =>
-        reduce_cooldown("attack", Math.min(...parent.pings)),
+      promisesToAwait.push(
+        use_skill("5shot", lowHealthPlayersInRange.slice(0, 5)).then(() =>
+          reduce_cooldown("attack", Math.min(...parent.pings)),
+        ),
       );
-      reduce_cooldown("attack", -(1 / character.frequency) * 1000);
     } else if (
       character.level >= G.skills["3shot"].level &&
-      lowHealthPlayers.length >= 2 &&
-      character.mp > 300 &&
-      !character.fear &&
-      ms_to_next_skill("attack") === 0
+      lowHealthPlayersInRange.length >= 2 &&
+      character.mp > G.skills["3shot"].mp + G.skills["huntersmark"].mp &&
+      !character.fear
     ) {
       set_message("3shot Cupid");
       log(
-        `Healing ${lowHealthPlayers
+        `Healing ${lowHealthPlayersInRange
           .slice(0, 3)
           .map((player) => player.name)
           .join(", ")}`,
       );
-      use_skill("3shot", lowHealthPlayers.slice(0, 3)).then(() =>
-        reduce_cooldown("attack", Math.min(...parent.pings)),
+      promisesToAwait.push(
+        use_skill("3shot", lowHealthPlayersInRange.slice(0, 3)).then(() =>
+          reduce_cooldown("attack", Math.min(...parent.pings)),
+        ),
       );
-      reduce_cooldown("attack", -(1 / character.frequency) * 1000);
-    } else if (
-      ms_to_next_skill("attack") === 0 &&
-      distance(lowHealthPlayers[0], character) <
-        character.range +
-          character.xrange +
-          extraDistanceWithinHitbox(lowHealthPlayers[0]) +
-          extraDistanceWithinHitbox(character)
-    ) {
+    } else if (lowHealthPlayersInRange.length) {
       set_message("Single Cupid");
-      log(`Healing ${lowHealthPlayers[0].name}`);
-      attack(lowHealthPlayers[0]).then(() =>
-        reduce_cooldown("attack", Math.min(...parent.pings)),
+      log(`Healing ${lowHealthPlayersInRange[0].name}`);
+      promisesToAwait.push(
+        attack(lowHealthPlayersInRange[0]).then(() =>
+          reduce_cooldown("attack", Math.min(...parent.pings)),
+        ),
       );
-      reduce_cooldown("attack", -(1 / character.frequency) * 1000);
     }
+  }
+
+  try {
+    await withTimeout(Promise.all(promisesToAwait), 1000);
+  } catch (e) {
+    attackErrorHandler(e);
+    console.error("Error while Cupiding!", e);
   }
 }
 
@@ -1270,29 +1321,19 @@ setInterval(async function () {
   const allCharacters = [...partyMems, partyMerchant];
 
   if (parent.caracAL && caracALconfig.characters[character.name].enabled) {
-    for (const [index, id] of allCharacters.entries()) {
-      if (
-        parent.caracAL &&
-        !parent.caracAL.siblings.find((sibling) => sibling === id)
-      ) {
-        parent.caracAL.deploy(id, null, caracALPartyCodeSlot[index]);
-      }
-    }
+    allCharacters
+      .filter((id) => parent.caracAL && !parent.caracAL.siblings.includes(id))
+      .forEach((id) => {
+        parent.caracAL.deploy(id, null, caracALconfig.characters[id].script);
+      });
   } else if (
     !character.controller &&
     allCharacters.filter((characterId) => characterId !== character.name)
       .length !== loadedCharacters.length
   ) {
-    for (const [index, id] of allCharacters.entries()) {
-      if (!loadedCharacters[id]) {
-        start_character(id, partyCodeSlot[index]);
-      }
-    }
-    // allCharacters.forEach((characterId, index) => {
-    //   if (!loadedCharacters[characterId]) {
-    //     start_character(characterId, partyCodeSlot[index]);
-    //   }
-    // });
+    allCharacters
+      .filter((id) => !loadedCharacters[id])
+      .forEach((id) => start_character(id, CODE_SLOTS[id].script));
   }
   const partyWhitelistRegex = [/^earth/];
   const whitelistPartyMembers = serverCharacters.filter(
@@ -1329,6 +1370,27 @@ setInterval(async function () {
 function on_party_invite(name) {
   if (name === partyMems[0]) accept_party_invite(name);
 }
+
+function dynamicParty() {
+  if (parent.S.mrgreen?.live || parent.S.mrpumpkin?.live) {
+    const currentServer = `${server.region}${server.id}`;
+    if (currentServer === "USI") {
+      partyMems = ["MooohMoooh", "CowTheMooh", "MooohSteak"];
+    } else if (currentServer === "EUII") {
+      RANGER = "MoohThatCow";
+      partyMems = [WARRIOR, RANGER, MAGE];
+    } else if (currentServer === "USII") {
+      RANGER = "CupidCow";
+      partyMems = [WARRIOR, RANGER, MAGE];
+    } else {
+      partyMems = ["MooohMoooh", "CowTheMooh", "MowTheCooh"];
+    }
+  } else {
+    partyMems = ["MooohMoooh", "CowTheMooh", "MowTheCooh"];
+  }
+}
+dynamicParty();
+setInterval(dynamicParty, 3000);
 
 //// Daily Events
 // var pinkGooVisitedBoundary = [];
@@ -1659,3 +1721,15 @@ function on_magiport(name) {
     accept_magiport(name);
   }
 }
+
+function attackErrorHandler(error) {
+  if (error.failed && error.response === "cooldown") {
+    reduce_cooldown("attack", -error.ms);
+  }
+
+  if (error.failed && error.reason === "not_there") {
+    parent.socket.emit("send_updates", {});
+  }
+}
+
+setInterval(() => parent.socket.emit("send_updates", {}), 30000);

--- a/basic_mage.4.js
+++ b/basic_mage.4.js
@@ -57,6 +57,8 @@ async function fight(target) {
 
   if (!target) return;
 
+  const promisesToAwait = [];
+
   if (!is_on_cooldown("energize")) {
     const buffee = getLowestMana();
     if (
@@ -67,13 +69,23 @@ async function fight(target) {
       is_in_range(buffee, "energize")
     ) {
       log("Energize " + buffee.name);
-      use_skill("energize", buffee).then(() =>
-        reduce_cooldown("energize", character.ping * 0.95),
+      promisesToAwait.push(
+        withTimeout(
+          use_skill("energize", buffee).then(() =>
+            reduce_cooldown("energize", character.ping * 0.95),
+          ),
+          2500,
+        ),
       );
-    } else if (ms_to_next_skill("attack") < 10 && !character.s.penalty_cd) {
+    } else if (ms_to_next_skill("attack") <= 0 && !character.s.penalty_cd) {
       log("Energize " + character.name);
-      use_skill("energize", character).then(() =>
-        reduce_cooldown("energize", character.ping * 0.95),
+      promisesToAwait.push(
+        withTimeout(
+          use_skill("energize", character).then(() =>
+            reduce_cooldown("energize", character.ping * 0.95),
+          ),
+          2500,
+        ),
       );
     }
   }
@@ -88,10 +100,11 @@ async function fight(target) {
         extraDistanceWithinHitbox(character) &&
     shouldAttack()
   ) {
-    currentStrategy(target);
+    promisesToAwait.push(currentStrategy(target), attack(target));
+
     set_message("Attacking");
     try {
-      await withTimeout(attack(target), 2500);
+      await Promise.all(promisesToAwait);
       reduce_cooldown("attack", Math.min(...parent.pings));
     } catch (e) {
       if (e.failed && e.response !== "cooldown") {
@@ -188,7 +201,7 @@ async function mainLoop() {
           y: mapY,
         });
       }
-    } else fight(target);
+    } else await fight(target);
   } catch (e) {
     console.error(e);
   }

--- a/basic_mage.4.js
+++ b/basic_mage.4.js
@@ -27,10 +27,6 @@ async function fight(target) {
     const attackRange = character.range + character.xrange;
     const blastRadius = character.blast / 3.6 || BLAST_RADIUS;
 
-    // Define the maximum distance for a mob to be considered "pullable"
-    const maxPullDistance =
-      attackRange * 0.9 + extraDistanceWithinHitbox(character);
-
     // Filter: Find all aggroed mobs within a reasonable pull distance, excluding formidable ones
     const aggroedMobs = Object.values(parent.entities)
       .filter(
@@ -39,8 +35,7 @@ async function fight(target) {
           entity.target && // Must be aggroed
           !entity.dead &&
           !haveFormidableMonsterAroundTarget(entity) &&
-          distance(entity, character) <
-            maxPullDistance + extraDistanceWithinHitbox(entity),
+          distance(entity, character) <= attackRange,
       )
       // Map: Pre-calculate the cluster count (The performance optimization)
       .map((mob) => {
@@ -73,6 +68,10 @@ async function fight(target) {
 
   // --- Energize Logic ---
   const canEnergize = !is_on_cooldown("energize");
+  const isAttackReady =
+    ms_to_next_skill("attack") === 0 && !character.s.penalty_cd;
+  const isTargetInAttackRange =
+    distance(target, character) <= character.range + character.xrange;
   if (canEnergize) {
     let energizeTarget = null;
 
@@ -84,42 +83,27 @@ async function fight(target) {
       character.mp > character.max_mp * 0.75 &&
       is_in_range(buffee, "energize");
 
-    const shouldEnergizeSelf =
-      ms_to_next_skill("attack") <= 0 && !character.s.penalty_cd;
-
     if (shouldEnergizeBuffee) {
       energizeTarget = buffee;
-    } else if (shouldEnergizeSelf) {
+    } else if (isAttackReady && isTargetInAttackRange) {
       energizeTarget = character;
     }
 
     if (energizeTarget) {
       promisesToAwait.push(
-        use_skill("energize", energizeTarget).then(
-          () => reduceCd("energize"), // <-- Now uses reduceCd()
-        ),
+        use_skill("energize", energizeTarget).then(() => reduceCd("energize")),
       );
     }
   }
 
   // --- Attack Logic ---
-  const isAttackReady =
-    ms_to_next_skill("attack") === 0 && !character.s.penalty_cd;
-  const isTargetInAttackRange =
-    distance(target, character) <
-    character.range +
-      character.xrange +
-      extraDistanceWithinHitbox(target) +
-      extraDistanceWithinHitbox(character);
 
   if (isAttackReady && isTargetInAttackRange && shouldAttack()) {
     set_message("Attacking");
     promisesToAwait.push(
       currentStrategy(target), // Assumes currentStrategy includes moving/kiting logic
       attack(target)
-        .then(() => {
-          reduceCd("attack");
-        })
+        .then(() => reduceCd("attack"))
         .catch((e) => {
           attackErrorHandler(e);
         }),
@@ -129,7 +113,9 @@ async function fight(target) {
   // --- Await and Error Handling ---
   try {
     await withTimeout(Promise.allSettled(promisesToAwait), 1000);
-  } catch (e) {}
+  } catch (e) {
+    console.log(e);
+  }
 
   // --- Reflection Logic ---
   const isMagicalTarget = target["damage_type"] === "magical";
@@ -174,7 +160,7 @@ async function mainLoop() {
     }
 
     // Save location data for other characters/storage once high level
-    if (character.level > G.skills['magiport'].level) {
+    if (character.max_mp > G.skills["magiport"].mp * 1.5) {
       set("mageLocation", {
         mp: character.mp,
         map: character.map,

--- a/basic_mage.4.js
+++ b/basic_mage.4.js
@@ -19,112 +19,127 @@ var originRangeRate = 0.85;
 rangeRate = originRangeRate;
 const loopInterval = Math.floor(((1 / character.frequency) * 1000) / 4);
 
+const reduceCd = (skillName) =>
+  reduce_cooldown(skillName, Math.min(...parent.pings));
+
 async function fight(target) {
   if (currentStrategy === usePullStrategies) {
-    aggroedMobs = Object.values(parent.entities).filter((mob) => {
-      return (
-        !haveFormidableMonsterAroundTarget(mob) &&
-        distance(mob, character) <
-          character.range +
-            character.xrange * 0.4 +
-            extraDistanceWithinHitbox(mob) +
-            extraDistanceWithinHitbox(character) &&
-        mob.target &&
-        mob.type === "monster"
-      );
-    });
+    const attackRange = character.range + character.xrange;
+    const blastRadius = character.blast / 3.6 || BLAST_RADIUS;
+
+    // Define the maximum distance for a mob to be considered "pullable"
+    const maxPullDistance =
+      attackRange * 0.9 + extraDistanceWithinHitbox(character);
+
+    // Filter: Find all aggroed mobs within a reasonable pull distance, excluding formidable ones
+    const aggroedMobs = Object.values(parent.entities)
+      .filter(
+        (entity) =>
+          entity.type === "monster" &&
+          entity.target && // Must be aggroed
+          !entity.dead &&
+          !haveFormidableMonsterAroundTarget(entity) &&
+          distance(entity, character) <
+            maxPullDistance + extraDistanceWithinHitbox(entity),
+      )
+      // Map: Pre-calculate the cluster count (The performance optimization)
+      .map((mob) => {
+        mob.cluster_count = numberOfMonsterAroundTarget(mob, blastRadius);
+        return mob;
+      });
 
     if (aggroedMobs.length) {
-      target =
-        aggroedMobs
-          .sort((lhs, rhs) => {
-            const lhsNumberOfSurrounding = numberOfMonsterAroundTarget(
-              lhs,
-              character.blast / 3.6 || BLAST_RADIUS,
-            );
-            const rhsNumberOfSurrounding = numberOfMonsterAroundTarget(
-              rhs,
-              character.blast / 3.6 || BLAST_RADIUS,
-            );
-            if (lhsNumberOfSurrounding === rhsNumberOfSurrounding)
-              return rhs.hp - lhs.hp;
-            return rhsNumberOfSurrounding - lhsNumberOfSurrounding;
-          })
-          .shift() ?? target;
+      // Sort: Find the best mob to target for cluster damage
+      const bestPullTarget = aggroedMobs
+        .sort((lhs, rhs) => {
+          // 1. Prioritize highest cluster count
+          if (lhs.cluster_count !== rhs.cluster_count) {
+            return rhs.cluster_count - lhs.cluster_count;
+          }
+          // 2. If cluster counts are equal, prioritize highest HP to apply max damage
+          return rhs.hp - lhs.hp;
+        })
+        .shift(); // Get the first (best) target
+
+      target = bestPullTarget ?? target;
       change_target(target);
     }
   }
 
+  // --- Early Exit ---
   if (!target) return;
 
   const promisesToAwait = [];
 
-  if (!is_on_cooldown("energize")) {
+  // --- Energize Logic ---
+  const canEnergize = !is_on_cooldown("energize");
+  if (canEnergize) {
+    let energizeTarget = null;
+
     const buffee = getLowestMana();
-    if (
+    const shouldEnergizeBuffee =
       buffee &&
       buffee.max_mp - buffee.mp > 500 &&
       buffee.mp < buffee.max_mp * 0.65 &&
       character.mp > character.max_mp * 0.75 &&
-      is_in_range(buffee, "energize")
-    ) {
-      log("Energize " + buffee.name);
+      is_in_range(buffee, "energize");
+
+    const shouldEnergizeSelf =
+      ms_to_next_skill("attack") <= 0 && !character.s.penalty_cd;
+
+    if (shouldEnergizeBuffee) {
+      energizeTarget = buffee;
+    } else if (shouldEnergizeSelf) {
+      energizeTarget = character;
+    }
+
+    if (energizeTarget) {
       promisesToAwait.push(
-        withTimeout(
-          use_skill("energize", buffee).then(() =>
-            reduce_cooldown("energize", character.ping * 0.95),
-          ),
-          2500,
-        ),
-      );
-    } else if (ms_to_next_skill("attack") <= 0 && !character.s.penalty_cd) {
-      log("Energize " + character.name);
-      promisesToAwait.push(
-        withTimeout(
-          use_skill("energize", character).then(() =>
-            reduce_cooldown("energize", character.ping * 0.95),
-          ),
-          2500,
+        use_skill("energize", energizeTarget).then(
+          () => reduceCd("energize"), // <-- Now uses reduceCd()
         ),
       );
     }
   }
 
-  if (
-    ms_to_next_skill("attack") === 0 &&
-    !character.s.penalty_cd &&
+  // --- Attack Logic ---
+  const isAttackReady =
+    ms_to_next_skill("attack") === 0 && !character.s.penalty_cd;
+  const isTargetInAttackRange =
     distance(target, character) <
-      character.range +
-        character.xrange +
-        extraDistanceWithinHitbox(target) +
-        extraDistanceWithinHitbox(character) &&
-    shouldAttack()
-  ) {
+    character.range +
+      character.xrange +
+      extraDistanceWithinHitbox(target) +
+      extraDistanceWithinHitbox(character);
+
+  if (isAttackReady && isTargetInAttackRange && shouldAttack()) {
+    set_message("Attacking");
     promisesToAwait.push(
-      currentStrategy(target),
-      withTimeout(attack(target), 2500)
+      currentStrategy(target), // Assumes currentStrategy includes moving/kiting logic
+      attack(target)
         .then(() => {
-          reduce_cooldown("attack", Math.min(...parent.pings));
+          reduceCd("attack");
         })
         .catch((e) => {
           attackErrorHandler(e);
         }),
     );
-
-    set_message("Attacking");
   }
 
+  // --- Await and Error Handling ---
   try {
-    await Promise.all(promisesToAwait);
+    await withTimeout(Promise.allSettled(promisesToAwait), 1000);
   } catch (e) {}
 
-  if (
-    target["damage_type"] === "magical" &&
-    !is_on_cooldown("reflection") &&
-    partyMems.includes(target.target) &&
-    character.mp > 1000
-  ) {
-    use_skill("reflection", get_entity(target.target));
+  // --- Reflection Logic ---
+  const isMagicalTarget = target["damage_type"] === "magical";
+  const canReflect = !is_on_cooldown("reflection") && character.mp > 1000;
+  const targetAggroesParty = partyMems.includes(target.target);
+
+  if (isMagicalTarget && canReflect && targetAggroesParty) {
+    use_skill("reflection", get_entity(target.target)).then(() =>
+      reduceCd("reflection"),
+    );
   }
 
   // if (character.mp > 2000 && !is_on_cooldown("alchemy") && !isInvFull()) {
@@ -146,11 +161,11 @@ async function fight(target) {
 
 async function mainLoop() {
   try {
+    // --- Initialization and Status Checks ---
     desiredElixir = "pumpkinspice";
     assignRoles();
 
-    // buff();
-
+    // Handle immediate death state
     if (character.rip) {
       respawn();
       throw new Error("Character's down", {
@@ -158,7 +173,8 @@ async function mainLoop() {
       });
     }
 
-    if (character.level > 50) {
+    // Save location data for other characters/storage once high level
+    if (character.level > G.skills['magiport'].level) {
       set("mageLocation", {
         mp: character.mp,
         map: character.map,
@@ -167,35 +183,42 @@ async function mainLoop() {
       });
     }
 
-    if ((smart.moving || isAdvanceSmartMoving) && !smartmoveDebug)
+    // Halt logic if character is performing a controlled move
+    const isMovingControlled =
+      (smart.moving || isAdvanceSmartMoving) && !smartmoveDebug;
+    if (isMovingControlled) {
       throw new Error("Smart moving", {
         cause: "smart_move",
       });
+    }
 
+    // --- Target Selection ---
     let target = getTarget();
 
-    //// THE CRYPT & EVENTS
-    if (get("cryptInstance")) target = await useCryptStrategy(target);
-    else target = await changeToDailyEventTargets();
+    // Prioritize Crypt/Event targets
+    if (get("cryptInstance")) {
+      target = await useCryptStrategy(target);
+    } else {
+      target = await changeToDailyEventTargets();
+    }
 
-    //// Logic to targets and farm places
+    // --- Movement Logic ---
     if (!target) {
-      if (
-        !smart.moving &&
-        !isAdvanceSmartMoving &&
-        get("cryptInstance") &&
-        character.map !== "crypt"
-      ) {
-        changeToNormalStrategies();
+      const cryptKey = get("cryptInstance");
+      const needsToEnterCrypt = cryptKey && character.map !== "crypt";
+      const isPartyLeaderOrAlone =
+        TANKER === character.name || !get_entity(TANKER);
+      const isFarFromPartyLeader =
+        distance(character, { x: mapX, y: mapY, map }) > 500;
+
+      const needsToMoveToFarmLocation =
+        !cryptKey && (isPartyLeaderOrAlone || isFarFromPartyLeader);
+
+      if (needsToEnterCrypt) {
+        // Move to Crypt start if a crypt instance is active but we aren't there
         advanceSmartMove(CRYPT_STARTING_LOCATION);
-      } else if (
-        !smart.moving &&
-        !isAdvanceSmartMoving &&
-        !get("cryptInstance") &&
-        (partyMems[0] == character.name ||
-          !get_entity(partyMems[0]) ||
-          distance(character, { x: mapX, y: mapY, map }) > 500)
-      ) {
+      } else if (needsToMoveToFarmLocation) {
+        // Move to the designated farming spot
         log("Moving to farming location");
         changeToNormalStrategies();
         advanceSmartMove({
@@ -204,11 +227,19 @@ async function mainLoop() {
           y: mapY,
         });
       }
-    } else await fight(target);
+    } else {
+      // Target found, chilling with my staff :cow2:
+      await fight(target);
+    }
   } catch (e) {
-    console.error(e);
+    // If the error is 'smart_move' or 'death', it was handled internally (by the throw)
+    // If it's a real runtime error, log it
+    if (e.cause !== "smart_move" && e.cause !== "death") {
+      console.error(e);
+    }
   }
 
+  // Schedule the next loop execution
   setTimeout(mainLoop, getLoopInterval());
 }
 

--- a/basic_mage.4.js
+++ b/basic_mage.4.js
@@ -60,16 +60,18 @@ async function fight(target) {
   if (!is_on_cooldown("energize")) {
     const buffee = getLowestMana();
     if (
+      buffee &&
       buffee.max_mp - buffee.mp > 500 &&
       buffee.mp < buffee.max_mp * 0.65 &&
       character.mp > character.max_mp * 0.75 &&
       is_in_range(buffee, "energize")
     ) {
-      log("Energize " + buffee?.name);
+      log("Energize " + buffee.name);
       use_skill("energize", buffee).then(() =>
         reduce_cooldown("energize", character.ping * 0.95),
       );
     } else if (ms_to_next_skill("attack") < 10 && !character.s.penalty_cd) {
+      log("Energize " + character.name);
       use_skill("energize", character).then(() =>
         reduce_cooldown("energize", character.ping * 0.95),
       );
@@ -176,7 +178,6 @@ async function mainLoop() {
         !get("cryptInstance") &&
         (partyMems[0] == character.name ||
           !get_entity(partyMems[0]) ||
-          character.map === "crypt" ||
           distance(character, { x: mapX, y: mapY, map }) > 500)
       ) {
         log("Moving to farming location");

--- a/basic_mage.4.js
+++ b/basic_mage.4.js
@@ -107,9 +107,7 @@ async function fight(target) {
           reduce_cooldown("attack", Math.min(...parent.pings));
         })
         .catch((e) => {
-          if (e.failed && e.response !== "cooldown") {
-            reduce_cooldown("attack", -e.ms);
-          }
+          attackErrorHandler(e);
         }),
     );
 
@@ -176,8 +174,6 @@ async function mainLoop() {
 
     let target = getTarget();
 
-    // if (goToBoss()) return;
-
     //// THE CRYPT & EVENTS
     if (get("cryptInstance")) target = await useCryptStrategy(target);
     else target = await changeToDailyEventTargets();
@@ -217,69 +213,3 @@ async function mainLoop() {
 }
 
 if (!parent.caracAL) mainLoop();
-
-// setInterval(async function () {
-//   desiredElixir = "pumpkinspice";
-//   assignRoles();
-
-//   buff();
-
-//   if (character.rip) {
-//     respawn();
-//     return;
-//   }
-
-//   if (character.level > 50) {
-//     set("mageLocation", {
-//       mp: character.mp,
-//       map: character.map,
-//       x: character.x,
-//       y: character.y,
-//     });
-//   }
-
-//   if ((smart.moving || isAdvanceSmartMoving) && !smartmoveDebug) return;
-
-//   let target = getTarget();
-
-//   if (goToBoss()) return;
-
-//   //// THE CRYPT & EVENTS
-//   if (get("cryptInstance")) target = await useCryptStrategy(target);
-//   else target = await changeToDailyEventTargets();
-
-//   //// Logic to targets and farm places
-//   if (
-//     !smart.moving &&
-//     !isAdvanceSmartMoving &&
-//     get("cryptInstance") &&
-//     character.map !== "crypt" &&
-//     !target
-//   ) {
-//     changeToNormalStrategies();
-//     await advanceSmartMove(CRYPT_STARTING_LOCATION);
-//   } else if (
-//     !smart.moving &&
-//     !isAdvanceSmartMoving &&
-//     !target &&
-//     !get("cryptInstance") &&
-//     (partyMems[0] == character.name ||
-//       !get_entity(partyMems[0]) ||
-//       character.map === "crypt" ||
-//       distance(character, { x: mapX, y: mapY, map }) > 500)
-//   ) {
-//     log("Moving to farming location");
-//     changeToNormalStrategies();
-//     const scareInterval = setInterval(() => {
-//       scareAwayMobs();
-//     }, 5000);
-//     await advanceSmartMove({
-//       map,
-//       x: mapX,
-//       y: mapY,
-//     });
-//     clearInterval(scareInterval);
-//   }
-
-//   await fight(target);
-// }, loopInterval);

--- a/basic_mage.4.js
+++ b/basic_mage.4.js
@@ -100,18 +100,25 @@ async function fight(target) {
         extraDistanceWithinHitbox(character) &&
     shouldAttack()
   ) {
-    promisesToAwait.push(currentStrategy(target), attack(target));
+    promisesToAwait.push(
+      currentStrategy(target),
+      withTimeout(attack(target), 2500)
+        .then(() => {
+          reduce_cooldown("attack", Math.min(...parent.pings));
+        })
+        .catch((e) => {
+          if (e.failed && e.response !== "cooldown") {
+            reduce_cooldown("attack", -e.ms);
+          }
+        }),
+    );
 
     set_message("Attacking");
-    try {
-      await Promise.all(promisesToAwait);
-      reduce_cooldown("attack", Math.min(...parent.pings));
-    } catch (e) {
-      if (e.failed && e.response !== "cooldown") {
-        reduce_cooldown("attack", -e.ms);
-      }
-    }
   }
+
+  try {
+    await Promise.all(promisesToAwait);
+  } catch (e) {}
 
   if (
     target["damage_type"] === "magical" &&

--- a/basic_merchant.5.js
+++ b/basic_merchant.5.js
@@ -420,7 +420,6 @@ setInterval(async function () {
         character.items
           .filter((item) => item && !IGNORE.includes(item.name))
           .map((item, index) => {
-            console.log(item);
             bank_store(index);
           });
       } catch (e) {

--- a/basic_merchant.5.js
+++ b/basic_merchant.5.js
@@ -180,87 +180,123 @@ function moveHome() {
 }
 
 async function goFishing() {
-  if (isInvFull()) return;
   if (
-    !smart.moving &&
-    !isAdvanceSmartMoving &&
-    !character.q.compound &&
-    !character.q.upgrade &&
-    !character.q.exchange &&
-    !character.c.mining &&
-    !character.c.fishing &&
-    !is_on_cooldown("fishing")
+    isInvFull() ||
+    smart.moving ||
+    isAdvanceSmartMoving ||
+    character.c.mining ||
+    character.c.fishing ||
+    is_on_cooldown("fishing")
+  )
+    return;
+
+  const rodItemId = "rod";
+  const availableRodsInBank = getItemBankSlots(rodItemId);
+
+  if (
+    availableRodsInBank.length > 0 &&
+    character.slots.mainhand?.name !== rodItemId &&
+    !isInvFull(2) &&
+    locate_item(rodItemId) === -1
   ) {
-    if (character.slots.mainhand?.name !== "rod" && locate_item("rod") === -1)
-      moveHome();
+    return retrieveBankItem(rodItemId);
+  }
 
-    if (
-      character.real_x != fishingLocation.x &&
-      character.real_y != fishingLocation.y
-    ) {
-      close_stand();
-      equipBroom();
-      await smart_move(fishingLocation);
-    }
-    if (character.mp > 120) {
-      if (!character.c.fishing) {
-        if (
-          character.slots.mainhand?.name !== "rod" &&
-          locate_item("rod") !== -1
-        )
-          await equipBatch({
-            mainhand: "rod",
-            offhand: undefined,
-          });
+  if (
+    locate_item(rodItemId) === -1 &&
+    character.slots.mainhand?.name !== rodItemId &&
+    availableRodsInBank.length === 0 &&
+    !isInvFull(4)
+  ) {
+    return craft(rodItemId);
+  }
 
-        log("Fishin!");
-        use_skill("fishing");
-      }
-    }
+  if (
+    character.slots.mainhand?.name !== rodItemId &&
+    locate_item(rodItemId) === -1
+  )
+    moveHome();
+
+  if (
+    character.real_x != fishingLocation.x &&
+    character.real_y != fishingLocation.y
+  ) {
+    close_stand();
+    equipBroom();
+    await smart_move(fishingLocation);
+  }
+
+  if (character.mp > 120) {
+    log("Fishin!");
+    return Promise.all([
+      equipBatch({
+        mainhand: rodItemId,
+        offhand: undefined,
+      }),
+      use_skill("fishing"),
+    ]);
   }
 }
 
 async function goMining() {
-  if (isInvFull()) return;
   if (
-    !smart.moving &&
-    !isAdvanceSmartMoving &&
-    !character.q.compound &&
-    !character.q.upgrade &&
-    !character.q.exchange &&
-    !character.c.fishing &&
-    !character.c.mining &&
-    !is_on_cooldown("mining")
+    isInvFull() ||
+    smart.moving ||
+    isAdvanceSmartMoving ||
+    character.q.compound ||
+    character.q.upgrade ||
+    character.q.exchange ||
+    character.c.mining ||
+    character.c.fishing ||
+    is_on_cooldown("mining")
+  )
+    return;
+
+  const pickaxeItemId = "pickaxe";
+  const availablePickaxesInBank = getItemBankSlots(pickaxeItemId);
+
+  if (
+    availablePickaxesInBank.length > 0 &&
+    character.slots.mainhand?.name !== pickaxeItemId &&
+    !isInvFull(2) &&
+    locate_item(pickaxeItemId) === -1
   ) {
-    if (
-      character.slots.mainhand?.name !== "pickaxe" &&
-      locate_item("pickaxe") === -1
-    )
-      moveHome();
+    return retrieveBankItem(pickaxeItemId);
+  }
 
-    if (
-      character.real_x != miningLocation.x &&
-      character.real_y != miningLocation.y
-    ) {
-      close_stand();
-      equipBroom();
-      await smart_move(miningLocation);
-    }
-    if (character.mp > 120) {
-      if (!character.c.mining) {
-        if (
-          character.slots.mainhand?.name !== "pickaxe" &&
-          locate_item("pickaxe") !== -1
-        )
-          await equipBatch({
-            mainhand: "pickaxe",
-            offhand: undefined,
-          });
+  if (
+    locate_item(pickaxeItemId) === -1 &&
+    character.slots.mainhand?.name !== pickaxeItemId &&
+    availablePickaxesInBank.length === 0 &&
+    !isInvFull(4)
+  ) {
+    return craft(pickaxeItemId);
+  }
 
-        log("Minin!");
-        use_skill("mining");
-      }
-    }
+  if (
+    character.slots.mainhand?.name !== pickaxeItemId &&
+    locate_item(pickaxeItemId) === -1
+  )
+    moveHome();
+
+  if (
+    character.real_x != miningLocation.x &&
+    character.real_y != miningLocation.y
+  ) {
+    close_stand();
+    equipBroom();
+    await smart_move(miningLocation);
+  }
+
+  if (character.mp > 120) {
+    log("Mining!");
+    return Promise.all([
+      equipBatch({
+        mainhand: pickaxeItemId,
+        offhand: undefined,
+      }),
+      use_skill("mining"),
+    ]);
   }
 }
 
@@ -378,6 +414,7 @@ setInterval(async function () {
     craft("froststaff", 1, { map: "main", x: -2, y: 295 }),
     craft("carrotsword", 1, { map: "main", x: -2, y: 295 }),
     // craft("firestaff", character.esize - 6, { map: "main", x: -2, y: 295 }),
+    craft("firestars", character.esize - 6, { map: "main", x: -2, y: 295 }),
     !isSortingInventory &&
       Promise.all(
         Array.from({ length: 42 }, (_, i) => i)
@@ -393,17 +430,8 @@ setInterval(async function () {
       ),
   ]);
 
-  if (
-    !is_on_cooldown("mining") &&
-    (locate_item("pickaxe") !== -1 ||
-      character.slots.mainhand?.name === "pickaxe")
-  )
-    goMining();
-  else if (
-    !is_on_cooldown("fishing") &&
-    (locate_item("rod") !== -1 || character.slots.mainhand?.name === "rod")
-  )
-    goFishing();
+  if (!is_on_cooldown("mining")) goMining();
+  else if (!is_on_cooldown("fishing")) goFishing();
   else if (
     locate_item("gemfragment") !== -1 &&
     character.items[locate_item("gemfragment")]?.q >= 50
@@ -452,25 +480,28 @@ function handle_death() {
 }
 
 // Handler to buy from Ponty
+const ITEM_NEEDED = [
+  "strring",
+  "dexearring",
+  "bataxe",
+  "ololipop",
+  "fireblade",
+  "firebow",
+  "firestaff",
+  "firestars",
+  "jacko",
+  "intamulet",
+];
+
 function secondhandsHandler(events) {
   if (isInvFull(6)) return false;
-  const ITEM_NEEDED = [
-    "strring",
-    "dexearring",
-    "bataxe",
-    "glolipop",
-    "ololipop",
-    "fireblade",
-    "firebow",
-    "firestaff",
-    "firestars",
-    "daggerofthedead",
-    "jacko",
-    "intamulet",
-    "dexamulet",
-  ];
   for (const item of events) {
-    if (item && ITEM_NEEDED.includes(item.name)) {
+    if (
+      item &&
+      ITEM_NEEDED.filter((item) => !SALE_ABLE.includes(item)).includes(
+        item.name,
+      )
+    ) {
       parent.socket.emit("sbuy", { rid: item.rid });
     }
   }

--- a/basic_merchant.5.js
+++ b/basic_merchant.5.js
@@ -270,7 +270,8 @@ async function craft(item, craftQuantity = 1, place = find_npc("craftsman")) {
     (!is_on_cooldown("fishing") && locate_item("rod") !== -1) ||
     (!is_on_cooldown("mining") && locate_item("pickaxe") !== -1) ||
     character.c.mining ||
-    character.c.fishing
+    character.c.fishing ||
+    !craftQuantity
   )
     return;
 
@@ -371,6 +372,7 @@ setInterval(async function () {
     craft("orba", 1, { map: "main", x: -152, y: -137 }),
     craft("froststaff", 1, { map: "main", x: -2, y: 295 }),
     craft("carrotsword", 1, { map: "main", x: -2, y: 295 }),
+    // craft("firestaff", character.esize - 6, { map: "main", x: -2, y: 295 }),
     !isSortingInventory &&
       Promise.all(
         Array.from({ length: 42 }, (_, i) => i)
@@ -450,8 +452,6 @@ function secondhandsHandler(events) {
   const ITEM_NEEDED = [
     "strring",
     "dexearring",
-    "dexamulet",
-    "intamulet",
     "bataxe",
     "glolipop",
     "ololipop",

--- a/basic_merchant.5.js
+++ b/basic_merchant.5.js
@@ -92,8 +92,7 @@ async function holidayExchange() {
   });
 }
 
-function exchangeXyn() {
-  // const itemName = ['candy1', 'candycane', 'candy0', 'mistletoe', 'gem0', 'weaponbox', 'armorbox'];
+async function exchangeXyn() {
   if (isInvFull(6)) return;
 
   const itemName = [
@@ -111,13 +110,17 @@ function exchangeXyn() {
     { name: "basketofeggs", quantity: 1 },
   ];
   let slot = undefined;
-  itemName.map((item) => {
-    if (
-      locate_item(item.name) !== -1 &&
-      character.items[locate_item(item.name)].q >= item.quantity
-    )
-      slot = locate_item(item.name);
-  });
+  for (const item of itemName) {
+    if (getItemBankSlots(item.name).length && locate_item(item.name) === -1) {
+      await retrieveBankItem(item.name);
+    }
+
+    const slotIndex = locate_item(item.name);
+    if (slotIndex !== -1 && character.items[slotIndex].q >= item.quantity) {
+      slot = slotIndex;
+      break;
+    }
+  }
 
   if (slot !== undefined)
     exchange(slot).catch((e) => {
@@ -167,7 +170,9 @@ function moveHome() {
   return smart_move({ map: "main", x: -152, y: -137 })
     .then(() => {
       onDuty = false;
-      open_stand(locate_item("stand0"));
+      if (locate_item("stand0") === -1) {
+        retrieveBankItem("stand0");
+      } else open_stand(locate_item("stand0"));
     })
     .catch((e) => {
       if (e.reason === "failed" && e.failed) use_skill("use_town");
@@ -381,7 +386,7 @@ setInterval(async function () {
             return (
               SALE_ABLE.includes(character.items[i].name) &&
               !character.items[i].shiny &&
-              (character.items[i].level || 0) <= 1
+              (character.items[i].level || 0) <= 2
             );
           })
           .map(async (i) => sell(i, 1000)),
@@ -461,6 +466,8 @@ function secondhandsHandler(events) {
     "firestars",
     "daggerofthedead",
     "jacko",
+    "intamulet",
+    "dexamulet",
   ];
   for (const item of events) {
     if (item && ITEM_NEEDED.includes(item.name)) {

--- a/basic_merchant.5.js
+++ b/basic_merchant.5.js
@@ -215,7 +215,7 @@ async function goFishing() {
     character.slots.mainhand?.name !== rodItemId &&
     locate_item(rodItemId) === -1
   )
-    moveHome();
+    return moveHome();
 
   if (
     character.real_x != fishingLocation.x &&
@@ -277,7 +277,7 @@ async function goMining() {
     character.slots.mainhand?.name !== pickaxeItemId &&
     locate_item(pickaxeItemId) === -1
   )
-    moveHome();
+    return moveHome();
 
   if (
     character.real_x != miningLocation.x &&
@@ -402,32 +402,35 @@ setInterval(async function () {
 
   await sortInv();
 
-  Promise.all([
-    compoundInv(),
-    upgradeInv(),
-    exchangeXyn(),
-    // holidayExchange(),
-    craft("xbox"),
-    craft("basketofeggs"),
-    craft("orba", 1, { map: "main", x: -152, y: -137 }),
-    craft("froststaff", 1, { map: "main", x: -2, y: 295 }),
-    craft("carrotsword", 1, { map: "main", x: -2, y: 295 }),
-    craft("pouchbow", character.esize - 6, { map: "main", x: -2, y: 295 }),
-    // craft("firestaff", character.esize - 6, { map: "main", x: -2, y: 295 }),
-    !isSortingInventory &&
-      Promise.all(
-        Array.from({ length: 42 }, (_, i) => i)
-          .filter((i) => {
-            if (!character.items[i]) return false;
-            return (
-              SALE_ABLE.includes(character.items[i].name) &&
-              !character.items[i].shiny &&
-              (character.items[i].level || 0) <= 2
-            );
-          })
-          .map(async (i) => sell(i, 1000)),
-      ),
-  ]);
+  await withTimeout(
+    Promise.allSettled([
+      compoundInv(),
+      upgradeInv(),
+      exchangeXyn(),
+      // holidayExchange(),
+      craft("xbox"),
+      craft("basketofeggs"),
+      craft("orba", 1, { map: "main", x: -152, y: -137 }),
+      craft("froststaff", 1, { map: "main", x: -2, y: 295 }),
+      craft("carrotsword", 1, { map: "main", x: -2, y: 295 }),
+      craft("pouchbow", character.esize - 8, { map: "main", x: -2, y: 295 }),
+      // craft("firestaff", character.esize - 6, { map: "main", x: -2, y: 295 }),
+      !isSortingInventory &&
+        Promise.all(
+          Array.from({ length: 42 }, (_, i) => i)
+            .filter((i) => {
+              if (!character.items[i]) return false;
+              return (
+                SALE_ABLE.includes(character.items[i].name) &&
+                !character.items[i].shiny &&
+                (character.items[i].level || 0) <= 2
+              );
+            })
+            .map(async (i) => sell(i, 1000)),
+        ),
+    ]),
+    300000,
+  );
 
   if (!is_on_cooldown("mining")) goMining();
   else if (!is_on_cooldown("fishing")) goFishing();

--- a/basic_merchant.5.js
+++ b/basic_merchant.5.js
@@ -412,6 +412,7 @@ setInterval(async function () {
     craft("orba", 1, { map: "main", x: -152, y: -137 }),
     craft("froststaff", 1, { map: "main", x: -2, y: 295 }),
     craft("carrotsword", 1, { map: "main", x: -2, y: 295 }),
+    craft("pouchbow", character.esize - 6, { map: "main", x: -2, y: 295 }),
     // craft("firestaff", character.esize - 6, { map: "main", x: -2, y: 295 }),
     !isSortingInventory &&
       Promise.all(

--- a/basic_merchant.5.js
+++ b/basic_merchant.5.js
@@ -305,7 +305,6 @@ async function craft(item, craftQuantity = 1, place = find_npc("craftsman")) {
   if (
     onDuty ||
     isInvFull(4) ||
-    character.q.exchange ||
     smart.moving ||
     isAdvanceSmartMoving ||
     (!is_on_cooldown("fishing") && locate_item("rod") !== -1) ||
@@ -414,7 +413,6 @@ setInterval(async function () {
     craft("froststaff", 1, { map: "main", x: -2, y: 295 }),
     craft("carrotsword", 1, { map: "main", x: -2, y: 295 }),
     // craft("firestaff", character.esize - 6, { map: "main", x: -2, y: 295 }),
-    craft("firestars", character.esize - 6, { map: "main", x: -2, y: 295 }),
     !isSortingInventory &&
       Promise.all(
         Array.from({ length: 42 }, (_, i) => i)

--- a/basic_priest.2.js
+++ b/basic_priest.2.js
@@ -36,10 +36,10 @@ async function fight(target) {
                 !mob.target &&
                 is_in_range(mob, "attack") &&
                 partyDmgRecieved + calculateDamage(mob, character) <
-                  character.heal * 0.9
+                  character.heal * 0.9 * character.frequency,
             )
             .sort(
-              (lhs, rhs) => distance(lhs, character) - distance(rhs, character)
+              (lhs, rhs) => distance(lhs, character) - distance(rhs, character),
             )
             .shift()
         : null;
@@ -52,7 +52,7 @@ async function fight(target) {
                 mob.type === "monster" &&
                 !mob.s.poisoned &&
                 is_in_range(mob, "attack") &&
-                partyMems.includes(mob.target)
+                partyMems.includes(mob.target),
             )
             .sort((lhs, rhs) => lhs.attack - rhs.attack)
             .pop() ?? target
@@ -132,7 +132,7 @@ async function priestBuff() {
           healingPrioritizedNames().includes(buffee.name)
         ) {
           promises.push(
-            move((buffee.x + character.x) / 2, (buffee.y + character.y) / 2)
+            move((buffee.x + character.x) / 2, (buffee.y + character.y) / 2),
           );
           continue;
         }
@@ -141,13 +141,15 @@ async function priestBuff() {
           distance(buffee, character) <
           character.range + character.xrange * 0.9
         ) {
+          try {
+            promises.push(currentStrategy(buffee));
+          } catch (e) {}
           promises.push(
-            currentStrategy(buffee),
             withTimeout(
               heal(buffee).then(() => {
                 reduce_cooldown("attack", Math.min(...parent.pings));
-              })
-            )
+              }),
+            ),
           );
 
           set_message("Heal " + buffee.name);
@@ -166,13 +168,13 @@ async function priestBuff() {
       (ally) =>
         (ally.hp < ally.max_hp - character.level * 10 * 2 &&
           !is_in_range(ally, "heal")) ||
-        ally.hp < ally.max_hp * 0.3
+        ally.hp < ally.max_hp * 0.3,
     ) ||
       allies.every((ally) => ally.hp < ally.max_hp - character.level * 10 * 2))
   ) {
     if (!is_on_cooldown("partyheal") && character.mp > 1000) {
       use_skill("partyheal").then(() =>
-        reduce_cooldown("partyheal", Math.min(...parent.pings))
+        reduce_cooldown("partyheal", Math.min(...parent.pings)),
       );
       set_message("Party Heal");
     }
@@ -183,7 +185,7 @@ async function priestBuff() {
     .map((member) => {
       if (
         Object.values(parent.entities).some(
-          (entity) => entity.target === member
+          (entity) => entity.target === member,
         )
       )
         if (
@@ -191,7 +193,7 @@ async function priestBuff() {
           !is_on_cooldown("absorb") &&
           character.mp > G.skills["absorb"].mp &&
           Object.values(parent.entities).filter(
-            (entity) => entity.type === "monster" && entity.target === member
+            (entity) => entity.type === "monster" && entity.target === member,
           ).length >= (character.name === TANKER ? 1 : 2)
         ) {
           use_skill("absorb", get_entity(member));

--- a/basic_priest.2.js
+++ b/basic_priest.2.js
@@ -28,7 +28,7 @@ async function fight(target) {
     const partyDmgRecieved = avgPartyDmgTaken(partyMems);
 
     const targetToTaunt =
-      character.name === TANKER && currentStrategy === usePullStrategies
+      isAssignedAsTanker() && currentStrategy === usePullStrategies
         ? Object.values(parent.entities)
             .filter(
               (mob) =>
@@ -104,11 +104,11 @@ async function priestBuff() {
       //   promises.push(
       //     equipBatch({
       //       mainhand:
-      //         character.name === TANKER || character.map === "crypt"
+      //         isAssignedAsTanker() || character.map === "crypt"
       //           ? "pmace"
       //           : "oozingterror",
       //       orb:
-      //         character.name === TANKER && character.s.burned
+      //         isAssignedAsTanker() && character.s.burned
       //           ? "orba"
       //           : "jacko",
       //     }),
@@ -117,7 +117,7 @@ async function priestBuff() {
       //   promises.push(
       //     equipBatch({
       //       orb:
-      //         character.name === TANKER && character.s.burned
+      //         isAssignedAsTanker() && character.s.burned
       //           ? "orba"
       //           : "jacko",
       //     }),
@@ -194,7 +194,7 @@ async function priestBuff() {
           character.mp > G.skills["absorb"].mp &&
           Object.values(parent.entities).filter(
             (entity) => entity.type === "monster" && entity.target === member,
-          ).length >= (character.name === TANKER ? 1 : 2)
+          ).length >= (isAssignedAsTanker() ? 1 : 2)
         ) {
           use_skill("absorb", get_entity(member));
 

--- a/basic_priest.2.js
+++ b/basic_priest.2.js
@@ -25,14 +25,22 @@ async function fight(target) {
     currentStrategy(target);
 
     // Make Priest prior mobs without poison effect that attacking the party, to reduce their attack spped
+    const partyDmgRecieved = avgPartyDmmgTaken(partyMems);
     const targetToTaunt =
       character.name === TANKER && currentStrategy === usePullStrategt
-        ? Object.values(parent.entities).filter(
-            (mob) =>
-              mob.type === "monster" &&
-              !mob.target &&
-              is_in_range(mob, "attack")
-          )
+        ? Object.values(parent.entities)
+            .filter(
+              (mob) =>
+                mob.type === "monster" &&
+                !mob.target &&
+                is_in_range(mob, "attack") &&
+                partyDmgRecieved + calculateDamage(mob, character) <
+                  character.heal,
+            )
+            .sort(
+              (lhs, rhs) => distance(lhs, character) - distance(rhs, character),
+            )
+            .shift()
         : null;
     const targetToAttack =
       character.slots.orb?.name === "test_orb"
@@ -42,7 +50,7 @@ async function fight(target) {
                 mob.type === "monster" &&
                 !mob.s.poisoned &&
                 is_in_range(mob, "attack") &&
-                partyMems.includes(mob.target)
+                partyMems.includes(mob.target),
             )
             .sort((lhs, rhs) => lhs.attack - rhs.attack)
             .pop() ?? target
@@ -84,29 +92,35 @@ async function priestBuff() {
     const buffees = getPlayersToHeal();
 
     if (buffees.length) {
-      if (
-        !character.slots.mainhand ||
-        ["broom", "froststaff", "pinkies"].includes(
-          character.slots.mainhand?.name
-        ) ||
-        !character.slots.mainhand.level
-      ) {
-        promises.push(
-          equipBatch({
-            mainhand:
-              character.name === TANKER || character.map === "crypt"
-                ? "pmace"
-                : "oozingterror",
-            orb: "jacko",
-          })
-        );
-      } else if (character.slots.orb?.name !== "jacko") {
-        promises.push(
-          equipBatch({
-            orb: "jacko",
-          })
-        );
-      }
+      // if (
+      //   !character.slots.mainhand ||
+      //   ["broom", "froststaff", "pinkies"].includes(
+      //     character.slots.mainhand?.name,
+      //   ) ||
+      //   !character.slots.mainhand.level
+      // ) {
+      //   promises.push(
+      //     equipBatch({
+      //       mainhand:
+      //         character.name === TANKER || character.map === "crypt"
+      //           ? "pmace"
+      //           : "oozingterror",
+      //       orb:
+      //         character.name === TANKER && character.s.burned
+      //           ? "orba"
+      //           : "jacko",
+      //     }),
+      //   );
+      // } else if (character.slots.orb?.name !== "jacko") {
+      //   promises.push(
+      //     equipBatch({
+      //       orb:
+      //         character.name === TANKER && character.s.burned
+      //           ? "orba"
+      //           : "jacko",
+      //     }),
+      //   );
+      // }
 
       for (const buffee of buffees) {
         if (
@@ -116,7 +130,7 @@ async function priestBuff() {
           healingPrioritizedNames().includes(buffee.name)
         ) {
           promises.push(
-            move((buffee.x + character.x) / 2, (buffee.y + character.y) / 2)
+            move((buffee.x + character.x) / 2, (buffee.y + character.y) / 2),
           );
           continue;
         }
@@ -125,12 +139,13 @@ async function priestBuff() {
           distance(buffee, character) <
           character.range + character.xrange * 0.9
         ) {
+          await currentStrategy(buffee);
           promises.push(
             withTimeout(
               heal(buffee).then(() => {
                 reduce_cooldown("attack", Math.min(...parent.pings));
-              })
-            )
+              }),
+            ),
           );
 
           set_message("Heal " + buffee.name);
@@ -149,13 +164,13 @@ async function priestBuff() {
       (ally) =>
         (ally.hp < ally.max_hp - character.level * 10 * 2 &&
           !is_in_range(ally, "heal")) ||
-        ally.hp < ally.max_hp * 0.3
+        ally.hp < ally.max_hp * 0.3,
     ) ||
       allies.every((ally) => ally.hp < ally.max_hp - character.level * 10 * 2))
   ) {
     if (!is_on_cooldown("partyheal") && character.mp > 1000) {
       use_skill("partyheal").then(() =>
-        reduce_cooldown("partyheal", Math.min(...parent.pings))
+        reduce_cooldown("partyheal", Math.min(...parent.pings)),
       );
       set_message("Party Heal");
     }
@@ -166,7 +181,7 @@ async function priestBuff() {
     .map((member) => {
       if (
         Object.values(parent.entities).some(
-          (entity) => entity.target === member
+          (entity) => entity.target === member,
         )
       )
         if (
@@ -175,7 +190,7 @@ async function priestBuff() {
           character.mp > G.skills["absorb"].mp &&
           (get_entity(member).ctype !== "warrior" ||
             Object.values(parent.entities).filter(
-              (entity) => entity.type === "monster" && entity.target === member
+              (entity) => entity.type === "monster" && entity.target === member,
             ).length > 2)
         ) {
           use_skill("absorb", get_entity(member));

--- a/basic_priest.2.js
+++ b/basic_priest.2.js
@@ -25,15 +25,24 @@ async function fight(target) {
     currentStrategy(target);
 
     // Make Priest prior mobs without poison effect that attacking the party, to reduce their attack spped
+    const targetToTaunt =
+      character.name === TANKER && currentStrategy === usePullStrategt
+        ? Object.values(parent.entities).filter(
+            (mob) =>
+              mob.type === "monster" &&
+              !mob.target &&
+              is_in_range(mob, "attack")
+          )
+        : null;
     const targetToAttack =
       character.slots.orb?.name === "test_orb"
         ? Object.values(parent.entities)
             .filter(
               (mob) =>
+                mob.type === "monster" &&
                 !mob.s.poisoned &&
                 is_in_range(mob, "attack") &&
-                mob.type === "monster" &&
-                partyMems.includes(mob.target),
+                partyMems.includes(mob.target)
             )
             .sort((lhs, rhs) => lhs.attack - rhs.attack)
             .pop() ?? target
@@ -78,7 +87,7 @@ async function priestBuff() {
       if (
         !character.slots.mainhand ||
         ["broom", "froststaff", "pinkies"].includes(
-          character.slots.mainhand?.name,
+          character.slots.mainhand?.name
         ) ||
         !character.slots.mainhand.level
       ) {
@@ -89,13 +98,13 @@ async function priestBuff() {
                 ? "pmace"
                 : "oozingterror",
             orb: "jacko",
-          }),
+          })
         );
       } else if (character.slots.orb?.name !== "jacko") {
         promises.push(
           equipBatch({
             orb: "jacko",
-          }),
+          })
         );
       }
 
@@ -107,7 +116,7 @@ async function priestBuff() {
           healingPrioritizedNames().includes(buffee.name)
         ) {
           promises.push(
-            move((buffee.x + character.x) / 2, (buffee.y + character.y) / 2),
+            move((buffee.x + character.x) / 2, (buffee.y + character.y) / 2)
           );
           continue;
         }
@@ -120,8 +129,8 @@ async function priestBuff() {
             withTimeout(
               heal(buffee).then(() => {
                 reduce_cooldown("attack", Math.min(...parent.pings));
-              }),
-            ),
+              })
+            )
           );
 
           set_message("Heal " + buffee.name);
@@ -140,13 +149,13 @@ async function priestBuff() {
       (ally) =>
         (ally.hp < ally.max_hp - character.level * 10 * 2 &&
           !is_in_range(ally, "heal")) ||
-        ally.hp < ally.max_hp * 0.3,
+        ally.hp < ally.max_hp * 0.3
     ) ||
       allies.every((ally) => ally.hp < ally.max_hp - character.level * 10 * 2))
   ) {
     if (!is_on_cooldown("partyheal") && character.mp > 1000) {
       use_skill("partyheal").then(() =>
-        reduce_cooldown("partyheal", Math.min(...parent.pings)),
+        reduce_cooldown("partyheal", Math.min(...parent.pings))
       );
       set_message("Party Heal");
     }
@@ -157,7 +166,7 @@ async function priestBuff() {
     .map((member) => {
       if (
         Object.values(parent.entities).some(
-          (entity) => entity.target === member,
+          (entity) => entity.target === member
         )
       )
         if (
@@ -166,7 +175,7 @@ async function priestBuff() {
           character.mp > G.skills["absorb"].mp &&
           (get_entity(member).ctype !== "warrior" ||
             Object.values(parent.entities).filter(
-              (entity) => entity.type === "monster" && entity.target === member,
+              (entity) => entity.type === "monster" && entity.target === member
             ).length > 2)
         ) {
           use_skill("absorb", get_entity(member));

--- a/basic_priest.2.js
+++ b/basic_priest.2.js
@@ -22,12 +22,15 @@ const loopInterval = ((1 / character.frequency) * 1000) / 4;
 async function fight(target) {
   // Make Priest prior mobs without poison effect that attacking the party, to reduce their attack spped
   const partyDmgRecieved = avgPartyDmgTaken(partyMems);
+  const characterBufferedRange = character.range + character.xrange;
+
   const targetToTaunt =
     isAssignedAsTanker() && currentStrategy === usePullStrategies
       ? Object.values(parent.entities)
           .filter(
             (mob) =>
               mob.type === "monster" &&
+              !mob.dead &&
               !mob.target &&
               is_in_range(mob, "attack") &&
               partyDmgRecieved + calculateDamage(mob, character) <
@@ -46,8 +49,13 @@ async function fight(target) {
             (mob) =>
               mob.type === "monster" &&
               !mob.s.poisoned &&
-              is_in_range(mob, "attack") &&
-              partyMems.includes(mob.target),
+              !mob.dead &&
+              mob.hp &&
+              distance(character, mob) < characterBufferedRange &&
+              (parent.party_list && parent.party_list.length > 0
+                ? parent.party_list
+                : partyMems
+              ).includes(mob.target),
           )
           .sort((lhs, rhs) => lhs.attack - rhs.attack)
           .pop() ?? target
@@ -114,89 +122,108 @@ async function fight(target) {
 
 async function priestBuff() {
   const promises = [];
+  const minPing = () => Math.min(...parent.pings);
 
+  // --- Single Target Heal (Attack Cooldown) ---
   if (ms_to_next_skill("attack") === 0) {
     const buffees = getPlayersToHeal();
 
-    if (buffees.length) {
-      for (const buffee of buffees) {
-        if (
-          !smart.moving &&
-          distance(buffee, character) >=
-            character.range + character.xrange * 0.9 &&
-          prioritizedNames().includes(buffee.name)
-        ) {
-          promises.push(
-            move((buffee.x + character.x) / 2, (buffee.y + character.y) / 2),
-          );
-          continue;
-        }
+    for (const buffee of buffees) {
+      const characterBufferedRange = character.range + character.xrange * 0.9;
+      const distanceToTarget = distance(buffee, character);
 
-        if (
-          distance(buffee, character) <
-          character.range + character.xrange * 0.9
-        ) {
-          try {
-            promises.push(
-              currentStrategy(buffee),
-              withTimeout(
-                heal(buffee).then(() => {
-                  reduce_cooldown("attack", Math.min(...parent.pings));
-                }),
-              ),
-            );
-          } catch (e) {}
+      // If too far, and a party member (prioritized), move closer.
+      if (
+        !smart.moving &&
+        distanceToTarget >= characterBufferedRange &&
+        prioritizedNames().includes(buffee.name)
+      ) {
+        // To the midpoint between the priest and the target
+        promises.push(
+          move((buffee.x + character.x) / 2, (buffee.y + character.y) / 2),
+        );
+        set_message("Moving to heal " + buffee.name);
+        continue; // Stop and wait for movement
+      }
+
+      // If in range, heal and stop the loop.
+      if (distanceToTarget < characterBufferedRange) {
+        try {
+          promises.push(currentStrategy(buffee));
+          promises.push(
+            withTimeout(
+              heal(buffee).then(() => {
+                reduce_cooldown("attack", minPing());
+              }),
+            ),
+          );
           set_message("Heal " + buffee.name);
-          break;
+        } catch (e) {
+          // console.error("Heal failed:", e);
         }
+        break; // Heal one target and wait for the next attack cooldown
       }
     }
   }
 
+  // --- Party Heal Logic ---
   const allies = parent.party_list
     .map((name) => get_entity(name))
     .filter((visible) => visible);
-  if (
-    allies.length &&
-    (allies.some(
-      (ally) =>
-        (ally.hp < ally.max_hp - character.level * 10 * 2 &&
-          !is_in_range(ally, "heal")) ||
-        ally.hp < ally.max_hp * 0.3,
-    ) ||
-      allies.every((ally) => ally.hp < ally.max_hp - character.level * 10 * 2))
-  ) {
-    if (!is_on_cooldown("partyheal") && character.mp > 1000) {
+
+  if (!is_on_cooldown("partyheal") && character.mp > 1000 && allies.length) {
+    // Condition for Party Heal:
+    // any ally is critically low (under 30% HP) OR out of single-heal range while moderately injured.
+    // OR All allies are moderately injured (HP < max_hp - character.level * 20).
+    const moderatelyInjuredThreshold = character.level * 20;
+
+    const shouldPartyHeal =
+      allies.some(
+        (ally) =>
+          ally.hp < ally.max_hp * 0.3 || // Critically low
+          (ally.hp < ally.max_hp - moderatelyInjuredThreshold &&
+            !is_in_range(ally, "heal")), // Moderately low & out of range
+      ) ||
+      allies.every(
+        (ally) => ally.hp < ally.max_hp - moderatelyInjuredThreshold, // All moderately low
+      );
+
+    if (shouldPartyHeal) {
       use_skill("partyheal").then(() =>
-        reduce_cooldown("partyheal", Math.min(...parent.pings)),
+        reduce_cooldown("partyheal", minPing()),
       );
       set_message("Party Heal");
     }
   }
 
-  partyMems
-    .filter((member) => member !== character.name && member !== TANKER)
-    .map((member) => {
-      if (
-        Object.values(parent.entities).some(
-          (entity) => entity.target === member,
-        )
-      )
-        if (
-          is_in_range(get_entity(member), "absorb") &&
-          !is_on_cooldown("absorb") &&
-          character.mp > G.skills["absorb"].mp &&
-          Object.values(parent.entities).filter(
-            (entity) => entity.type === "monster" && entity.target === member,
-          ).length >= (isAssignedAsTanker() ? 1 : 2)
-        ) {
-          use_skill("absorb", get_entity(member));
+  // --- Absorb Skill Logic ---
+  const vulnerableMembers = partyMems.filter(
+    (member) => member !== character.name && member !== TANKER,
+  );
 
-          set_message("Absorb " + member);
-        }
-    });
+  for (const memberName of vulnerableMembers) {
+    const member = get_entity(memberName);
+    if (!member) continue;
 
-  return withTimeout(Promise.all(promises), 1000);
+    const monstersTargetingMember = Object.values(parent.entities).filter(
+      (entity) => entity.type === "monster" && entity.target === memberName,
+    );
+
+    const requiredMonsterCount = isAssignedAsTanker() ? 1 : 2;
+
+    if (
+      is_in_range(member, "absorb") &&
+      !is_on_cooldown("absorb") &&
+      character.mp >= G.skills["absorb"].mp &&
+      monstersTargetingMember.length >= requiredMonsterCount
+    ) {
+      use_skill("absorb", member);
+      set_message("Absorb " + memberName);
+      break; // Absorb one target and move on
+    }
+  }
+
+  return withTimeout(Promise.all(promises), 750);
 }
 
 async function mainLoop() {

--- a/basic_priest.2.js
+++ b/basic_priest.2.js
@@ -43,7 +43,7 @@ async function fight(target) {
       : null;
 
   const targetToAttack =
-    character.slots.orb?.name === "test_orb"
+    character.slots.orb?.name === "test_orb" && !target.cooperative
       ? Object.values(parent.entities)
           .filter(
             (mob) =>
@@ -57,7 +57,7 @@ async function fight(target) {
                 : partyMems
               ).includes(mob.target),
           )
-          .sort((lhs, rhs) => lhs.attack - rhs.attack)
+          .sort((lhs, rhs) => rhs.attack - lhs.attack)
           .pop() ?? target
       : target;
   target = targetToTaunt ?? targetToAttack;

--- a/basic_priest.2.js
+++ b/basic_priest.2.js
@@ -247,7 +247,6 @@ async function mainLoop() {
         !get("cryptInstance") &&
         (partyMems[0] == character.name ||
           !get_entity(partyMems[0]) ||
-          character.map === "crypt" ||
           distance(character, { x: mapX, y: mapY, map }) > 500)
       ) {
         changeToNormalStrategies();

--- a/basic_priest.2.js
+++ b/basic_priest.2.js
@@ -102,9 +102,7 @@ async function fight(target) {
           reduce_cooldown("attack", Math.min(...parent.pings));
         })
         .catch((e) => {
-          if (e.failed && e.response !== "cooldown") {
-            reduce_cooldown("attack", -e.ms);
-          }
+          attackErrorHandler(e);
         }),
     );
   }
@@ -121,42 +119,12 @@ async function priestBuff() {
     const buffees = getPlayersToHeal();
 
     if (buffees.length) {
-      // if (
-      //   !character.slots.mainhand ||
-      //   ["broom", "froststaff", "pinkies"].includes(
-      //     character.slots.mainhand?.name,
-      //   ) ||
-      //   !character.slots.mainhand.level
-      // ) {
-      //   promises.push(
-      //     equipBatch({
-      //       mainhand:
-      //         isAssignedAsTanker() || character.map === "crypt"
-      //           ? "pmace"
-      //           : "oozingterror",
-      //       orb:
-      //         isAssignedAsTanker() && character.s.burned
-      //           ? "orba"
-      //           : "jacko",
-      //     }),
-      //   );
-      // } else if (character.slots.orb?.name !== "jacko") {
-      //   promises.push(
-      //     equipBatch({
-      //       orb:
-      //         isAssignedAsTanker() && character.s.burned
-      //           ? "orba"
-      //           : "jacko",
-      //     }),
-      //   );
-      // }
-
       for (const buffee of buffees) {
         if (
           !smart.moving &&
           distance(buffee, character) >=
             character.range + character.xrange * 0.9 &&
-          healingPrioritizedNames().includes(buffee.name)
+          prioritizedNames().includes(buffee.name)
         ) {
           promises.push(
             move((buffee.x + character.x) / 2, (buffee.y + character.y) / 2),
@@ -251,9 +219,6 @@ async function mainLoop() {
 
     let target = getTarget();
 
-    //// BOSSES
-    // if (goToBoss()) return;
-
     //// THE CRYPT & EVENTS
     if (get("cryptInstance")) target = await useCryptStrategy(target);
     else target = await changeToDailyEventTargets();
@@ -291,58 +256,3 @@ async function mainLoop() {
 }
 
 if (!parent.caracAL) mainLoop();
-
-// setInterval(async function () {
-//   assignRoles();
-
-//   if (character.rip) {
-//     respawn();
-//     return;
-//   }
-
-//   priestBuff();
-
-//   if ((smart.moving || isAdvanceSmartMoving) && !smartmoveDebug) return;
-
-//   let target = getTarget();
-
-//   //// BOSSES
-//   if (goToBoss()) return;
-
-//   //// THE CRYPT & EVENTS
-//   if (get("cryptInstance")) target = await useCryptStrategy(target);
-//   else target = await changeToDailyEventTargets();
-
-//   //// Logic to targets and farm places
-//   if (
-//     !smart.moving &&
-//     !isAdvanceSmartMoving &&
-//     get("cryptInstance") &&
-//     character.map !== "crypt" &&
-//     !target
-//   ) {
-//     changeToNormalStrategies();
-//     await advanceSmartMove(CRYPT_STARTING_LOCATION);
-//   } else if (
-//     !smart.moving &&
-//     !target &&
-//     !get("cryptInstance") &&
-//     (partyMems[0] == character.name ||
-//       !get_entity(partyMems[0]) ||
-//       character.map === "crypt" ||
-//       distance(character, { x: mapX, y: mapY, map }) > 500)
-//   ) {
-//     changeToNormalStrategies();
-//     const scareInterval = setInterval(() => {
-//       scareAwayMobs();
-//     }, 5000);
-//     await advanceSmartMove({
-//       map,
-//       x: mapX,
-//       y: mapY,
-//     });
-//     clearInterval(scareInterval);
-//   }
-
-//   await fight(target);
-// }, loopInterval);

--- a/basic_priest.2.js
+++ b/basic_priest.2.js
@@ -85,32 +85,39 @@ async function fight(target) {
     );
 
   if (
-    target &&
-    can_attack(target) &&
-    shouldAttack() &&
-    !character.s.penalty_cd
+    !character.s.penalty_cd &&
+    ms_to_next_skill("attack") === 0 &&
+    distance(target, character) <
+      character.range +
+        character.xrange +
+        extraDistanceWithinHitbox(target) +
+        extraDistanceWithinHitbox(character) &&
+    shouldAttack()
   ) {
     set_message("Attacking");
     promisesToAwait.push(
       currentStrategy(target),
-      withTimeout(attack(target), 2500),
+      withTimeout(attack(target), 2500)
+        .then(() => {
+          reduce_cooldown("attack", Math.min(...parent.pings));
+        })
+        .catch((e) => {
+          if (e.failed && e.response !== "cooldown") {
+            reduce_cooldown("attack", -e.ms);
+          }
+        }),
     );
-
-    try {
-      await withTimeout(attack(targetToTaunt ?? targetToAttack), 2500);
-      reduce_cooldown("attack", Math.min(...parent.pings));
-    } catch (e) {
-      if (e.failed && e.response !== "cooldown") {
-        reduce_cooldown("attack", -e.ms);
-      }
-    }
   }
+
+  try {
+    await withTimeout(Promise.all(promisesToAwait), 2500);
+  } catch (e) {}
 }
 
 async function priestBuff() {
   const promises = [];
 
-  if (!is_on_cooldown("attack")) {
+  if (ms_to_next_skill("attack") === 0) {
     const buffees = getPlayersToHeal();
 
     if (buffees.length) {

--- a/basic_priest.2.js
+++ b/basic_priest.2.js
@@ -20,44 +20,81 @@ var rangeRate = 0.5;
 const loopInterval = ((1 / character.frequency) * 1000) / 4;
 
 async function fight(target) {
-  if (can_attack(target) && shouldAttack() && !character.s.penalty_cd) {
+  // Make Priest prior mobs without poison effect that attacking the party, to reduce their attack spped
+  const partyDmgRecieved = avgPartyDmgTaken(partyMems);
+  const targetToTaunt =
+    isAssignedAsTanker() && currentStrategy === usePullStrategies
+      ? Object.values(parent.entities)
+          .filter(
+            (mob) =>
+              mob.type === "monster" &&
+              !mob.target &&
+              is_in_range(mob, "attack") &&
+              partyDmgRecieved + calculateDamage(mob, character) <
+                character.heal * 0.9 * character.frequency,
+          )
+          .sort(
+            (lhs, rhs) => distance(lhs, character) - distance(rhs, character),
+          )
+          .shift()
+      : null;
+
+  const targetToAttack =
+    character.slots.orb?.name === "test_orb"
+      ? Object.values(parent.entities)
+          .filter(
+            (mob) =>
+              mob.type === "monster" &&
+              !mob.s.poisoned &&
+              is_in_range(mob, "attack") &&
+              partyMems.includes(mob.target),
+          )
+          .sort((lhs, rhs) => lhs.attack - rhs.attack)
+          .pop() ?? target
+      : target;
+  target = targetToTaunt ?? targetToAttack;
+  change_target(target);
+
+  const promisesToAwait = [];
+
+  if (
+    target &&
+    !target.s.curse &&
+    character.mp > 1100 &&
+    !is_on_cooldown("curse") &&
+    is_in_range(target, "curse") &&
+    target.max_hp > 3000
+  )
+    promisesToAwait.push(
+      withTimeout(use_skill("curse", target), 2500).then(() =>
+        reduce_cooldown("curse", Math.min(...parent.pings)),
+      ),
+    );
+
+  if (
+    target &&
+    shouldAttack() &&
+    !is_on_cooldown("darkblessing") &&
+    character.mp > G.skills["darkblessing"].mp &&
+    !character.s?.darkblessing
+  )
+    promisesToAwait.push(
+      withTimeout(use_skill("darkblessing"), 2500).then(() =>
+        reduce_cooldown("darkblessing", Math.min(...parent.pings)),
+      ),
+    );
+
+  if (
+    target &&
+    can_attack(target) &&
+    shouldAttack() &&
+    !character.s.penalty_cd
+  ) {
     set_message("Attacking");
-    currentStrategy(target);
-
-    // Make Priest prior mobs without poison effect that attacking the party, to reduce their attack spped
-    const partyDmgRecieved = avgPartyDmgTaken(partyMems);
-
-    const targetToTaunt =
-      isAssignedAsTanker() && currentStrategy === usePullStrategies
-        ? Object.values(parent.entities)
-            .filter(
-              (mob) =>
-                mob.type === "monster" &&
-                !mob.target &&
-                is_in_range(mob, "attack") &&
-                partyDmgRecieved + calculateDamage(mob, character) <
-                  character.heal * 0.9 * character.frequency,
-            )
-            .sort(
-              (lhs, rhs) => distance(lhs, character) - distance(rhs, character),
-            )
-            .shift()
-        : null;
-
-    const targetToAttack =
-      character.slots.orb?.name === "test_orb"
-        ? Object.values(parent.entities)
-            .filter(
-              (mob) =>
-                mob.type === "monster" &&
-                !mob.s.poisoned &&
-                is_in_range(mob, "attack") &&
-                partyMems.includes(mob.target),
-            )
-            .sort((lhs, rhs) => lhs.attack - rhs.attack)
-            .pop() ?? target
-        : target;
-    change_target(targetToTaunt ?? targetToAttack);
+    promisesToAwait.push(
+      currentStrategy(target),
+      withTimeout(attack(target), 2500),
+    );
 
     try {
       await withTimeout(attack(targetToTaunt ?? targetToAttack), 2500);
@@ -67,24 +104,7 @@ async function fight(target) {
         reduce_cooldown("attack", -e.ms);
       }
     }
-
-    if (
-      target &&
-      !is_on_cooldown("darkblessing") &&
-      character.mp > G.skills["darkblessing"].mp &&
-      !character.s?.darkblessing
-    )
-      use_skill("darkblessing");
   }
-
-  if (
-    target &&
-    character.mp > 1100 &&
-    !is_on_cooldown("curse") &&
-    is_in_range(target, "curse") &&
-    target.max_hp > 3000
-  )
-    use_skill("curse", target);
 }
 
 async function priestBuff() {
@@ -142,16 +162,15 @@ async function priestBuff() {
           character.range + character.xrange * 0.9
         ) {
           try {
-            promises.push(currentStrategy(buffee));
+            promises.push(
+              currentStrategy(buffee),
+              withTimeout(
+                heal(buffee).then(() => {
+                  reduce_cooldown("attack", Math.min(...parent.pings));
+                }),
+              ),
+            );
           } catch (e) {}
-          promises.push(
-            withTimeout(
-              heal(buffee).then(() => {
-                reduce_cooldown("attack", Math.min(...parent.pings));
-              }),
-            ),
-          );
-
           set_message("Heal " + buffee.name);
           break;
         }
@@ -256,7 +275,7 @@ async function mainLoop() {
           y: mapY,
         });
       }
-    } else fight(target);
+    } else await fight(target);
   } catch (e) {
     console.error(e);
   }

--- a/basic_priest.2.js
+++ b/basic_priest.2.js
@@ -196,7 +196,7 @@ async function priestBuff() {
         }
     });
 
-  return Promise.all(promises);
+  return withTimeout(Promise.all(promises), 1000);
 }
 
 async function mainLoop() {

--- a/basic_ranger.32.js
+++ b/basic_ranger.32.js
@@ -77,8 +77,6 @@ async function fight(target) {
     });
 
   const weakMobs = potentialTargets.filter(isWeak);
-  console.log(potentialTargets.map((entity) => entity.id));
-  console.log(weakMobs.map((entity) => entity.id));
 
   if (currentStrategy === usePullStrategies && potentialTargets.length)
     target = potentialTargets[0];

--- a/basic_ranger.32.js
+++ b/basic_ranger.32.js
@@ -1,0 +1,242 @@
+// Load basic functions from other code snippet
+if (parent.caracAL) {
+  parent.caracAL
+    .load_scripts([
+      "adventure-land-scripts-backup/basic_function.7.js",
+      "adventure-land-scripts-backup/other_class_msg_listener.8.js",
+    ])
+    .then(() => {
+      mainLoop();
+      fuaLoop();
+    });
+} else {
+  load_code(7);
+  load_code(8);
+}
+
+// Kiting
+var originRangeRate = 0.85;
+rangeRate = originRangeRate;
+
+var rangerTarget = ["phoenix", "crab", "squig"];
+var rangerMap = "main";
+var rangerMapX = -1163;
+var rangerMapY = 74;
+
+function getRangerTarget() {
+  if (rangerTarget && rangerTarget.length) {
+    for (const monsterName of rangerTarget) {
+      const monsterInstance = get_nearest_monster({ type: monsterName });
+      if (monsterInstance) return monsterInstance;
+    }
+  }
+  return undefined;
+}
+
+async function fight(target) {
+  // Early exit if attack is still on cooldown
+  if (ms_to_next_skill("attack") > 0) return;
+
+  const attackReady = ms_to_next_skill("attack") === 0;
+  const canAct = attackReady && !character.fear;
+  const nearRange = character.range + character.xrange;
+  const explosionRadius = character.explosion
+    ? character.explosion / 3.6
+    : BLAST_RADIUS;
+  const inRange = (entity) => distance(entity, character) < nearRange;
+  const isWeak = (monster) =>
+    monster.hp < calculateDamage(character, monster) * 0.9 || monster.target;
+  const isCooperative = (monster) => monster.cooperative;
+  const isMob = (entity) => entity.type === "monster";
+  const notCupid = character.slots.mainhand?.name !== "cupid";
+  const entitiesInVision = Object.values(parent.entities);
+  const reduceCd = (skill) => reduce_cooldown(skill, Math.min(...parent.pings));
+  const promisesToAwait = [];
+
+  // Potential and weak mobs
+  const potentialTargets = Object.values(parent.entities)
+    .filter(
+      (m) =>
+        m.type === "monster" &&
+        inRange(m) &&
+        !m.s?.fullguardx &&
+        (m.attack * (m.frequency > 1 ? m.frequency : 1) < 500 ||
+          (m.cooperative && m.target && !partyMems.includes(m.target)) ||
+          m["1hp"] ||
+          m.target),
+    )
+    .sort((lhs, rhs) => {
+      if (lhs.cooperative || (lhs.target && !rhs.target)) return -1;
+      if (rhs.cooperative || (rhs.target && !lhs.target)) return 1;
+      return (
+        numberOfMonsterAroundTarget(rhs, explosionRadius) -
+          numberOfMonsterAroundTarget(lhs, explosionRadius) ||
+        lhs.hp - rhs.hp ||
+        distance(character, lhs) - distance(character, rhs)
+      );
+    });
+
+  const weakMobs = potentialTargets.filter(isWeak);
+  console.log(potentialTargets.map((entity) => entity.id));
+  console.log(weakMobs.map((entity) => entity.id));
+
+  if (currentStrategy === usePullStrategies && potentialTargets.length)
+    target = potentialTargets[0];
+
+  // Reacquire target if feared
+  if (character.fear) {
+    const aggroing = potentialTargets.find(
+      (mob) => mob.target === character.name,
+    );
+    if (aggroing) target = aggroing;
+  }
+
+  // Carry out the strategy
+  promisesToAwait.push(currentStrategy(target));
+
+  // Apply huntersmark if suitable
+  if (
+    target &&
+    !target.s?.marked &&
+    character.mp > 300 &&
+    !is_on_cooldown("huntersmark") &&
+    target.hp > 3000
+  ) {
+    promisesToAwait.push(
+      use_skill("huntersmark", target).then(() => reduceCd("huntersmark")),
+    );
+  }
+
+  // Find supershot target
+  if (character.mp > 400 && !is_on_cooldown("supershot")) {
+    const coopTarget = target?.cooperative
+      ? target
+      : entitiesInVision.find(
+          (entity) => isMob(entity) && isCooperative(entity),
+        );
+
+    const easyMob =
+      entitiesInVision
+        .filter(
+          (entity) =>
+            isMob(entity) &&
+            entity.attack * entity.frequency < 500 &&
+            is_in_range(entity, "supershot"),
+        )
+        .sort((lhs, rhs) => distance(character, lhs) - distance(character, rhs))
+        .shift() ??
+      coopTarget ??
+      target;
+
+    if (easyMob)
+      promisesToAwait.push(
+        use_skill("supershot", easyMob).then(() => reduceCd("supershot")),
+      );
+  }
+
+  // === Handle multishot logic ===
+
+  const tryMultiShot = async (skill, mobs) => {
+    if (!canAct || mobs.length === 0) return false;
+    set_message(`${skill} Shooting`);
+    // log(`Using ${skill} on ${mobs.map((m) => m.id).join(", ")}`);
+    return use_skill(skill, mobs)
+      .then(() => reduceCd("attack"))
+      .catch((e) => attackErrorHandler(e));
+  };
+
+  // Prioritize 5shot > 3shot > single
+  if (
+    character.level >= G.skills["5shot"].level &&
+    notCupid &&
+    character.hp > character.max_hp * 0.55 &&
+    character.mp > G.skills["5shot"].mp + G.skills["huntersmark"].mp &&
+    weakMobs.length >= 4
+  ) {
+    promisesToAwait.push(tryMultiShot("5shot", weakMobs.slice(0, 5)));
+  } else if (
+    character.level >= G.skills["3shot"].level &&
+    notCupid &&
+    character.hp > character.max_hp * 0.55 &&
+    character.mp > G.skills["3shot"].mp + G.skills["huntersmark"].mp &&
+    potentialTargets.length >= 2
+  ) {
+    promisesToAwait.push(tryMultiShot("3shot", potentialTargets.slice(0, 3)));
+  } else if (target && distance(target, character) < nearRange && notCupid) {
+    set_message("Shooting");
+    promisesToAwait.push(
+      attack(target)
+        .then(() => reduceCd("attack"))
+        .catch((e) => attackErrorHandler(e)),
+    );
+  }
+
+  try {
+    await withTimeout(Promise.all(promisesToAwait), 1500);
+  } catch (e) {
+    console.log(e);
+  }
+}
+
+async function mainLoop() {
+  try {
+    desiredElixir = "pumpkinspice";
+    assignRoles();
+
+    // buff();
+
+    if (character.rip) {
+      respawn();
+      throw new Error("Character's down", {
+        cause: "death",
+      });
+    }
+
+    await cupidHeal();
+
+    if ((smart.moving || isAdvanceSmartMoving) && !smartmoveDebug)
+      throw new Error("Smart moving", {
+        cause: "smart_move",
+      });
+
+    let target = getTarget();
+
+    //// THE CRYPT & EVENTS
+    if (get("cryptInstance")) target = await useCryptStrategy(target);
+    else target = await changeToDailyEventTargets();
+
+    //// Logic to targets and farm places
+    if (!target) {
+      if (
+        !smart.moving &&
+        !isAdvanceSmartMoving &&
+        get("cryptInstance") &&
+        character.map !== "crypt"
+      ) {
+        changeToNormalStrategies();
+        advanceSmartMove(CRYPT_STARTING_LOCATION);
+      } else if (
+        !smart.moving &&
+        !isAdvanceSmartMoving &&
+        !get("cryptInstance") &&
+        (partyMems[0] == character.name ||
+          !get_entity(partyMems[0]) ||
+          distance(character, { x: mapX, y: mapY, map }) > 500)
+      ) {
+        log("Moving to farming location");
+        changeToNormalStrategies();
+        advanceSmartMove({
+          map,
+          x: mapX,
+          y: mapY,
+        });
+      }
+    } else await fight(target);
+  } catch (e) {
+    console.error(e);
+  }
+
+  setTimeout(mainLoop, getLoopInterval());
+}
+
+if (!parent.caracAL) mainLoop();

--- a/basic_ranger.32.js
+++ b/basic_ranger.32.js
@@ -1,5 +1,4 @@
-// Load basic functions from other code snippet
-
+// Load basic functions from other code snippet (unchanged)
 if (parent.caracAL) {
   parent.caracAL
     .load_scripts([
@@ -14,20 +13,25 @@ if (parent.caracAL) {
   load_code(8);
 }
 
-// Kiting
+// Kiting (unchanged)
 var originRangeRate = 0.85;
 rangeRate = originRangeRate;
 
+// --- Helper Functions ---
 const isWeak = (monster) =>
   monster.hp < calculateDamage(character, monster) * 0.9 || monster.target;
 const isCooperative = (monster) => monster.cooperative;
 const isMob = (entity) => entity.type === "monster";
-const reduceCd = (skill) => reduce_cooldown(skill, Math.min(...parent.pings));
+
+// 1. Reusable Cooldown Reduction
+const reduceCd = (skillName) =>
+  reduce_cooldown(skillName, Math.min(...parent.pings));
+
 const tryMultiShot = async (skill, entityList) => {
   if (entityList.length === 0) return false;
   set_message(`${skill} Shooting`);
   return use_skill(skill, entityList)
-    .then(() => reduceCd("attack"))
+    .then(() => reduceCd(skill)) // Use reduceCd for the skill (was incorrectly hardcoded to "attack")
     .catch((e) => attackErrorHandler(e));
 };
 
@@ -42,9 +46,8 @@ async function fight(target) {
     : BLAST_RADIUS;
   const notCupid = character.slots.mainhand?.name !== "cupid";
   const entitiesInVision = Object.values(parent.entities);
-  const promisesToAwait = [];
+  const promisesToAwait = []; // --- Target Selection & Optimization ---
 
-  // Potential and weak mobs
   const potentialTargets = entitiesInVision
     .filter(
       (entity) =>
@@ -54,14 +57,12 @@ async function fight(target) {
         inRange(entity) &&
         !entity.s?.fullguardx &&
         (entity.attack * (entity.frequency > 1 ? entity.frequency : 1) < 500 ||
-          (entity.cooperative &&
-            entity.target &&
-            !partyMems.includes(entity.target)) ||
+          (entity.cooperative && !partyMems.includes(entity.target)) ||
           entity["1hp"] ||
           entity.target),
     )
     .map((entity) => {
-      // **Expensive calculation moved here, runs only N times (number of targets), not N log N times.**
+      // Optimization: Pre-calculate cluster count and distance once
       entity.cluster_count = numberOfMonsterAroundTarget(
         entity,
         explosionRadius,
@@ -70,49 +71,85 @@ async function fight(target) {
       return entity;
     })
     .sort((lhs, rhs) => {
+      // Cooperative and target prioritization (Highest Priority)
       if (lhs.cooperative || (lhs.target && !rhs.target)) return -1;
       if (rhs.cooperative || (rhs.target && !lhs.target)) return 1;
 
       return (
-        rhs.cluster_count - lhs.cluster_count || // Sort by cluster count (highest first)
-        rhs.hp - lhs.hp || // Then by HP (lowest first)
-        rhs.distance - lhs.distance // Then by distance (closest first)
+        // 1. Maximize Cluster Count (Highest First: rhs - lhs)
+        rhs.cluster_count - lhs.cluster_count || // 2. Minimize HP (Lowest First: lhs - rhs) <-- Corrected from your initial code
+        lhs.hp - rhs.hp || // 3. Minimize Distance (Lowest First: lhs - rhs) <-- Corrected from your initial code
+        lhs.distance - rhs.distance
       );
     });
 
-  const weakMobs = potentialTargets.filter(isWeak);
+  const weakMobs = potentialTargets.filter(isWeak); // --- Target Acquisition ---
 
   if (currentStrategy === usePullStrategies && potentialTargets.length) {
     target = potentialTargets[0];
     change_target(target);
-  }
+  } // Reacquire target if feared
 
-  // Reacquire target if feared
   if (character.fear) {
     const aggroing = potentialTargets.find(
       (mob) => mob.target === character.name,
     );
+    scareAwayMobs();
     if (aggroing) target = aggroing;
   }
 
-  // Carry out the strategy
-  promisesToAwait.push(currentStrategy(target));
-
-  // Apply huntersmark if suitable
-  if (
+  // --- Huntersmark ---
+  const canHuntersMark =
     target &&
     !target.s?.marked &&
     character.mp > 300 &&
     !is_on_cooldown("huntersmark") &&
-    target.hp > 3000
-  ) {
+    target.hp > 3000;
+  if (canHuntersMark) {
     promisesToAwait.push(
       use_skill("huntersmark", target).then(() => reduceCd("huntersmark")),
     );
   }
 
-  // Find supershot target
-  if (character.mp > 400 && !is_on_cooldown("supershot")) {
+  // --- Attack Priority: 5shot > 3shot > single ---
+  const hpOk = character.hp > character.max_hp * 0.55;
+  const is5ShotReady =
+    character.level >= G.skills["5shot"].level &&
+    canMultiShot &&
+    hpOk &&
+    character.mp > G.skills["5shot"].mp + G.skills["huntersmark"].mp &&
+    weakMobs.length >= 4;
+  const is3ShotReady =
+    character.level >= G.skills["3shot"].level &&
+    canMultiShot &&
+    hpOk &&
+    character.mp > G.skills["3shot"].mp + G.skills["huntersmark"].mp &&
+    potentialTargets.length >= 2;
+
+  if (is5ShotReady) {
+    const mobsTo5Shot = weakMobs.slice(0, 5);
+    promisesToAwait.push(currentStrategy(mobsTo5Shot));
+    if (notCupid) promisesToAwait.push(tryMultiShot("5shot", mobsTo5Shot));
+  } else if (is3ShotReady) {
+    const mobsTo3Shot = potentialTargets.slice(0, 3);
+    promisesToAwait.push(currentStrategy(mobsTo3Shot));
+    if (notCupid)
+      promisesToAwait.push(tryMultiShot("3shot", potentialTargets.slice(0, 3)));
+  } else if (target && distance(target, character) < nearRange) {
+    set_message("Shooting");
+    promisesToAwait.push(currentStrategy(target));
+    if (notCupid)
+      promisesToAwait.push(
+        attack(target)
+          .then(() => reduceCd("attack"))
+          .catch((e) => attackErrorHandler(e)),
+      );
+  }
+
+  // --- Supershot ---
+  const canSuperShot = character.mp > 400 && !is_on_cooldown("supershot");
+
+  if (canSuperShot) {
     const coopTarget = target?.cooperative
       ? target
       : entitiesInVision.find(
@@ -138,118 +175,83 @@ async function fight(target) {
       );
   }
 
-  // Prioritize 5shot > 3shot > single
-  if (
-    character.level >= G.skills["5shot"].level &&
-    canMultiShot &&
-    notCupid &&
-    character.hp > character.max_hp * 0.55 &&
-    character.mp > G.skills["5shot"].mp + G.skills["huntersmark"].mp &&
-    weakMobs.length >= 4
-  ) {
-    promisesToAwait.push(tryMultiShot("5shot", weakMobs.slice(0, 5)));
-  } else if (
-    character.level >= G.skills["3shot"].level &&
-    canMultiShot &&
-    notCupid &&
-    character.hp > character.max_hp * 0.55 &&
-    character.mp > G.skills["3shot"].mp + G.skills["huntersmark"].mp &&
-    potentialTargets.length >= 2
-  ) {
-    promisesToAwait.push(tryMultiShot("3shot", potentialTargets.slice(0, 3)));
-  } else if (target && distance(target, character) < nearRange && notCupid) {
-    set_message("Shooting");
-    promisesToAwait.push(
-      attack(target)
-        .then(() => reduceCd("attack"))
-        .catch((e) => attackErrorHandler(e)),
-    );
-  }
-
+  // --- Await and Error Handling ---
   try {
-    await withTimeout(Promise.all(promisesToAwait), 1500);
+    await withTimeout(Promise.allSettled(promisesToAwait), 1500);
   } catch (e) {
     console.log(e);
   }
 }
 
+// --- Cupid Heal Logic (Refactored) ---
 async function cupidHeal(playersToHeal) {
-  if (
-    (locate_item("cupid") === -1 &&
-      character.slots.mainhand?.name !== "cupid") ||
-    ms_to_next_skill("attack") > 0
-  )
-    return;
+  const isAttackOnCD = ms_to_next_skill("attack") > 0;
+  const hasCupid =
+    locate_item("cupid") !== -1 || character.slots.mainhand?.name === "cupid";
+  if (isAttackOnCD || !hasCupid) return;
 
   const characterRange = character.range + character.xrange;
-  // const prioritized = prioritizedNames();
-
-  const lowHealthPlayers = playersToHeal.filter(
-    (player) => player.name !== character.name,
-  );
-  const lowHealthPlayersInRange = lowHealthPlayers.filter(
-    (player) => distance(player, character) < characterRange,
+  const lowHealthPlayersInRange = playersToHeal.filter(
+    (player) =>
+      player.name !== character.name &&
+      distance(player, character) < characterRange,
   );
 
   const promisesToAwait = [];
 
   if (lowHealthPlayersInRange.length > 0) {
-    console.log(
-      lowHealthPlayersInRange
-        .map((player) => `${player.name} (${player.hp}/${player.max_hp})`)
-        .join(", "),
-    );
-    promisesToAwait.push(
-      equipBatch({
-        mainhand: "cupid",
-      }),
-    );
+    // Equipping Cupid first
+    if (character.slots.mainhand?.name !== "cupid")
+      promisesToAwait.push(equip(findMaxLevelItem("cupid")));
 
-    if (
+    // Determine the best shot for healing
+    const mpCost = G.skills["huntersmark"].mp;
+    const is5ShotReady =
       character.level >= G.skills["5shot"].level &&
       lowHealthPlayersInRange.length >= 4 &&
-      character.mp > G.skills["5shot"].mp + G.skills["huntersmark"].mp &&
-      !character.fear
-    ) {
-      set_message("5shot Cupid");
-      log(
-        `Healing ${lowHealthPlayersInRange
-          .slice(0, 5)
-          .map((player) => player.name)
-          .join(", ")}`,
-      );
-      promisesToAwait.push(
-        tryMultiShot("5shot", lowHealthPlayersInRange.slice(0, 5)),
-      );
-    } else if (
+      character.mp > G.skills["5shot"].mp + mpCost &&
+      !character.fear;
+    const is3ShotReady =
       character.level >= G.skills["3shot"].level &&
       lowHealthPlayersInRange.length >= 2 &&
-      character.mp > G.skills["3shot"].mp + G.skills["huntersmark"].mp &&
-      !character.fear
-    ) {
-      set_message("3shot Cupid");
-      log(
-        `Healing ${lowHealthPlayersInRange
-          .slice(0, 3)
-          .map((player) => player.name)
-          .join(", ")}`,
-      );
-      promisesToAwait.push(
-        tryMultiShot("3shot", lowHealthPlayersInRange.slice(0, 3)),
-      );
-    } else if (lowHealthPlayersInRange.length) {
+      character.mp > G.skills["3shot"].mp + mpCost &&
+      !character.fear;
+
+    let healingTarget = null;
+    let skillName = "attack";
+    let sliceAmount = 1;
+
+    if (is5ShotReady) {
+      skillName = "5shot";
+      sliceAmount = 5;
+    } else if (is3ShotReady) {
+      skillName = "3shot";
+      sliceAmount = 3;
+    } else {
+      // Single shot fallback
+      healingTarget = lowHealthPlayersInRange[0];
+    }
+
+    if (skillName !== "attack") {
+      // Multi-shot healing
+      set_message(`${skillName} Cupid`);
+      const targets = lowHealthPlayersInRange.slice(0, sliceAmount);
+      log(`Healing ${targets.map((player) => player.name).join(", ")}`);
+      promisesToAwait.push(tryMultiShot(skillName, targets));
+    } else if (healingTarget) {
+      // Single shot healing
       set_message("Single Cupid");
-      log(`Healing ${lowHealthPlayersInRange[0].name}`);
+      log(`Healing ${healingTarget.name}`);
       promisesToAwait.push(
-        use_skill("attack", lowHealthPlayersInRange[0]).then(() =>
-          reduce_cooldown("attack", Math.min(...parent.pings)),
+        use_skill("attack", healingTarget).then(
+          () => reduceCd("attack"), // Use reduceCd
         ),
       );
     }
   }
 
   try {
-    await withTimeout(Promise.all(promisesToAwait), 1000);
+    await withTimeout(Promise.allSettled(promisesToAwait), 1000);
   } catch (e) {
     attackErrorHandler(e);
     console.error("Error while Cupiding!", e);
@@ -263,6 +265,7 @@ async function mainLoop() {
 
     // buff();
 
+    // 1. Death Check
     if (character.rip) {
       respawn();
       throw new Error("Character's down", {
@@ -270,38 +273,45 @@ async function mainLoop() {
       });
     }
 
+    // 2. Cupid Healing
     const playersToHeal = getPlayersToHeal();
     await cupidHeal(playersToHeal);
 
-    if ((smart.moving || isAdvanceSmartMoving) && !smartmoveDebug)
+    // 3. Movement Control Check
+    const isMovingControlled =
+      (smart.moving || isAdvanceSmartMoving) && !smartmoveDebug;
+    if (isMovingControlled) {
       throw new Error("Smart moving", {
         cause: "smart_move",
       });
+    }
 
+    // 4. Target Acquisition
     let target = getTarget();
 
-    //// THE CRYPT & EVENTS
-    if (get("cryptInstance")) target = await useCryptStrategy(target);
-    else target = await changeToDailyEventTargets();
+    // Crypt & Event logic
+    if (get("cryptInstance")) {
+      target = await useCryptStrategy(target);
+    } else {
+      target = await changeToDailyEventTargets();
+    }
 
-    //// Logic to targets and farm places
+    // 5. Movement Logic
     if (!target) {
-      if (
-        !smart.moving &&
-        !isAdvanceSmartMoving &&
-        get("cryptInstance") &&
-        character.map !== "crypt"
-      ) {
+      const needsToEnterCrypt =
+        get("cryptInstance") && character.map !== "crypt";
+      const isPartyLeaderOrAlone =
+        partyMems[0] === character.name || !get_entity(partyMems[0]);
+      const isFarFromPartyLeader =
+        distance(character, { x: mapX, y: mapY, map }) > 500;
+
+      const needsToMoveToFarmLocation =
+        !get("cryptInstance") && (isPartyLeaderOrAlone || isFarFromPartyLeader);
+
+      if (needsToEnterCrypt) {
         changeToNormalStrategies();
         advanceSmartMove(CRYPT_STARTING_LOCATION);
-      } else if (
-        !smart.moving &&
-        !isAdvanceSmartMoving &&
-        !get("cryptInstance") &&
-        (partyMems[0] == character.name ||
-          !get_entity(partyMems[0]) ||
-          distance(character, { x: mapX, y: mapY, map }) > 500)
-      ) {
+      } else if (needsToMoveToFarmLocation) {
         log("Moving to farming location");
         changeToNormalStrategies();
         advanceSmartMove({
@@ -310,9 +320,15 @@ async function mainLoop() {
           y: mapY,
         });
       }
-    } else await fight(target);
+    } else {
+      // Target found, engage in combat
+      await fight(target);
+    }
   } catch (e) {
-    console.error(e);
+    // Only log unhandled errors
+    if (e.cause !== "smart_move" && e.cause !== "death") {
+      console.error(e);
+    }
   }
 
   setTimeout(mainLoop, getLoopInterval());

--- a/basic_ranger.32.js
+++ b/basic_ranger.32.js
@@ -1,4 +1,5 @@
 // Load basic functions from other code snippet
+
 if (parent.caracAL) {
   parent.caracAL
     .load_scripts([
@@ -7,7 +8,6 @@ if (parent.caracAL) {
     ])
     .then(() => {
       mainLoop();
-      fuaLoop();
     });
 } else {
   load_code(7);
@@ -18,68 +18,74 @@ if (parent.caracAL) {
 var originRangeRate = 0.85;
 rangeRate = originRangeRate;
 
-var rangerTarget = ["phoenix", "crab", "squig"];
-var rangerMap = "main";
-var rangerMapX = -1163;
-var rangerMapY = 74;
-
-function getRangerTarget() {
-  if (rangerTarget && rangerTarget.length) {
-    for (const monsterName of rangerTarget) {
-      const monsterInstance = get_nearest_monster({ type: monsterName });
-      if (monsterInstance) return monsterInstance;
-    }
-  }
-  return undefined;
-}
+const isWeak = (monster) =>
+  monster.hp < calculateDamage(character, monster) * 0.9 || monster.target;
+const isCooperative = (monster) => monster.cooperative;
+const isMob = (entity) => entity.type === "monster";
+const reduceCd = (skill) => reduce_cooldown(skill, Math.min(...parent.pings));
+const tryMultiShot = async (skill, entityList) => {
+  if (entityList.length === 0) return false;
+  set_message(`${skill} Shooting`);
+  return use_skill(skill, entityList)
+    .then(() => reduceCd("attack"))
+    .catch((e) => attackErrorHandler(e));
+};
 
 async function fight(target) {
-  // Early exit if attack is still on cooldown
   if (ms_to_next_skill("attack") > 0) return;
 
-  const attackReady = ms_to_next_skill("attack") === 0;
-  const canAct = attackReady && !character.fear;
+  const canMultiShot = !character.fear;
+  const inRange = (entity) => distance(entity, character) < nearRange;
   const nearRange = character.range + character.xrange;
   const explosionRadius = character.explosion
     ? character.explosion / 3.6
     : BLAST_RADIUS;
-  const inRange = (entity) => distance(entity, character) < nearRange;
-  const isWeak = (monster) =>
-    monster.hp < calculateDamage(character, monster) * 0.9 || monster.target;
-  const isCooperative = (monster) => monster.cooperative;
-  const isMob = (entity) => entity.type === "monster";
   const notCupid = character.slots.mainhand?.name !== "cupid";
   const entitiesInVision = Object.values(parent.entities);
-  const reduceCd = (skill) => reduce_cooldown(skill, Math.min(...parent.pings));
   const promisesToAwait = [];
 
   // Potential and weak mobs
-  const potentialTargets = Object.values(parent.entities)
+  const potentialTargets = entitiesInVision
     .filter(
-      (m) =>
-        m.type === "monster" &&
-        inRange(m) &&
-        !m.s?.fullguardx &&
-        (m.attack * (m.frequency > 1 ? m.frequency : 1) < 500 ||
-          (m.cooperative && m.target && !partyMems.includes(m.target)) ||
-          m["1hp"] ||
-          m.target),
+      (entity) =>
+        entity.type === "monster" &&
+        !entity.dead &&
+        !entity.rip &&
+        inRange(entity) &&
+        !entity.s?.fullguardx &&
+        (entity.attack * (entity.frequency > 1 ? entity.frequency : 1) < 500 ||
+          (entity.cooperative &&
+            entity.target &&
+            !partyMems.includes(entity.target)) ||
+          entity["1hp"] ||
+          entity.target),
     )
+    .map((entity) => {
+      // **Expensive calculation moved here, runs only N times (number of targets), not N log N times.**
+      entity.cluster_count = numberOfMonsterAroundTarget(
+        entity,
+        explosionRadius,
+      );
+      entity.distance = distance(character, entity);
+      return entity;
+    })
     .sort((lhs, rhs) => {
       if (lhs.cooperative || (lhs.target && !rhs.target)) return -1;
       if (rhs.cooperative || (rhs.target && !lhs.target)) return 1;
+
       return (
-        numberOfMonsterAroundTarget(rhs, explosionRadius) -
-          numberOfMonsterAroundTarget(lhs, explosionRadius) ||
-        lhs.hp - rhs.hp ||
-        distance(character, lhs) - distance(character, rhs)
+        rhs.cluster_count - lhs.cluster_count || // Sort by cluster count (highest first)
+        rhs.hp - lhs.hp || // Then by HP (lowest first)
+        rhs.distance - lhs.distance // Then by distance (closest first)
       );
     });
 
   const weakMobs = potentialTargets.filter(isWeak);
 
-  if (currentStrategy === usePullStrategies && potentialTargets.length)
+  if (currentStrategy === usePullStrategies && potentialTargets.length) {
     target = potentialTargets[0];
+    change_target(target);
+  }
 
   // Reacquire target if feared
   if (character.fear) {
@@ -132,20 +138,10 @@ async function fight(target) {
       );
   }
 
-  // === Handle multishot logic ===
-
-  const tryMultiShot = async (skill, mobs) => {
-    if (!canAct || mobs.length === 0) return false;
-    set_message(`${skill} Shooting`);
-    // log(`Using ${skill} on ${mobs.map((m) => m.id).join(", ")}`);
-    return use_skill(skill, mobs)
-      .then(() => reduceCd("attack"))
-      .catch((e) => attackErrorHandler(e));
-  };
-
   // Prioritize 5shot > 3shot > single
   if (
     character.level >= G.skills["5shot"].level &&
+    canMultiShot &&
     notCupid &&
     character.hp > character.max_hp * 0.55 &&
     character.mp > G.skills["5shot"].mp + G.skills["huntersmark"].mp &&
@@ -154,6 +150,7 @@ async function fight(target) {
     promisesToAwait.push(tryMultiShot("5shot", weakMobs.slice(0, 5)));
   } else if (
     character.level >= G.skills["3shot"].level &&
+    canMultiShot &&
     notCupid &&
     character.hp > character.max_hp * 0.55 &&
     character.mp > G.skills["3shot"].mp + G.skills["huntersmark"].mp &&
@@ -176,6 +173,89 @@ async function fight(target) {
   }
 }
 
+async function cupidHeal(playersToHeal) {
+  if (
+    (locate_item("cupid") === -1 &&
+      character.slots.mainhand?.name !== "cupid") ||
+    ms_to_next_skill("attack") > 0
+  )
+    return;
+
+  const characterRange = character.range + character.xrange;
+  // const prioritized = prioritizedNames();
+
+  const lowHealthPlayers = playersToHeal.filter(
+    (player) => player.name !== character.name,
+  );
+  const lowHealthPlayersInRange = lowHealthPlayers.filter(
+    (player) => distance(player, character) < characterRange,
+  );
+
+  const promisesToAwait = [];
+
+  if (lowHealthPlayersInRange.length > 0) {
+    console.log(
+      lowHealthPlayersInRange
+        .map((player) => `${player.name} (${player.hp}/${player.max_hp})`)
+        .join(", "),
+    );
+    promisesToAwait.push(
+      equipBatch({
+        mainhand: "cupid",
+      }),
+    );
+
+    if (
+      character.level >= G.skills["5shot"].level &&
+      lowHealthPlayersInRange.length >= 4 &&
+      character.mp > G.skills["5shot"].mp + G.skills["huntersmark"].mp &&
+      !character.fear
+    ) {
+      set_message("5shot Cupid");
+      log(
+        `Healing ${lowHealthPlayersInRange
+          .slice(0, 5)
+          .map((player) => player.name)
+          .join(", ")}`,
+      );
+      promisesToAwait.push(
+        tryMultiShot("5shot", lowHealthPlayersInRange.slice(0, 5)),
+      );
+    } else if (
+      character.level >= G.skills["3shot"].level &&
+      lowHealthPlayersInRange.length >= 2 &&
+      character.mp > G.skills["3shot"].mp + G.skills["huntersmark"].mp &&
+      !character.fear
+    ) {
+      set_message("3shot Cupid");
+      log(
+        `Healing ${lowHealthPlayersInRange
+          .slice(0, 3)
+          .map((player) => player.name)
+          .join(", ")}`,
+      );
+      promisesToAwait.push(
+        tryMultiShot("3shot", lowHealthPlayersInRange.slice(0, 3)),
+      );
+    } else if (lowHealthPlayersInRange.length) {
+      set_message("Single Cupid");
+      log(`Healing ${lowHealthPlayersInRange[0].name}`);
+      promisesToAwait.push(
+        use_skill("attack", lowHealthPlayersInRange[0]).then(() =>
+          reduce_cooldown("attack", Math.min(...parent.pings)),
+        ),
+      );
+    }
+  }
+
+  try {
+    await withTimeout(Promise.all(promisesToAwait), 1000);
+  } catch (e) {
+    attackErrorHandler(e);
+    console.error("Error while Cupiding!", e);
+  }
+}
+
 async function mainLoop() {
   try {
     desiredElixir = "pumpkinspice";
@@ -190,7 +270,8 @@ async function mainLoop() {
       });
     }
 
-    await cupidHeal();
+    const playersToHeal = getPlayersToHeal();
+    await cupidHeal(playersToHeal);
 
     if ((smart.moving || isAdvanceSmartMoving) && !smartmoveDebug)
       throw new Error("Smart moving", {

--- a/basic_rogue.31.js
+++ b/basic_rogue.31.js
@@ -1,0 +1,261 @@
+// Load basic functions from other code snippet
+
+if (parent.caracAL) {
+  parent.caracAL
+    .load_scripts([
+      "adventure-land-scripts-backup/basic_function.7.js",
+      "adventure-land-scripts-backup/other_class_msg_listener.8.js",
+    ])
+    .then(() => {
+      mainLoop();
+    });
+} else {
+  load_code(7);
+  load_code(8);
+}
+
+// Kiting
+var originRangeRate = 0.95;
+rangeRate = originRangeRate;
+
+async function fight(target) {
+  if (currentStrategy === usePullStrategies) {
+    const allAggroedByParty = Object.values(parent.entities)
+      .filter(
+        (entity) =>
+          entity.type === "monster" &&
+          ([...partyMems, ...parent.party_list].includes(entity.target) ||
+            (entity.coorperative && entity.target)),
+      )
+      .sort((lhs, rhs) => {
+        const lhsHpPercentage = lhs.hp / lhs.max_hp;
+        const rhsHpPercentage = rhs.hp / rhs.max_hp;
+
+        if (lhs.coorperative && rhs.coorperative) {
+          if (lhs["1hp"]) return -1;
+          else return 1;
+        }
+        if (lhs.coorperative) return -1;
+        if (rhs.coorperative) return 1;
+
+        return rhsHpPercentage - lhsHpPercentage;
+      });
+
+    target = allAggroedByParty.shift() ?? target;
+  }
+
+  if (!target) return;
+
+  const promisesToAwait = [];
+
+  if (!is_on_cooldown("energize")) {
+    const buffee = getLowestMana();
+    if (
+      buffee &&
+      buffee.max_mp - buffee.mp > 500 &&
+      buffee.mp < buffee.max_mp * 0.65 &&
+      character.mp > character.max_mp * 0.75 &&
+      is_in_range(buffee, "energize")
+    ) {
+      log("Energize " + buffee.name);
+      promisesToAwait.push(
+        withTimeout(
+          use_skill("energize", buffee).then(() =>
+            reduce_cooldown("energize", character.ping * 0.95),
+          ),
+          2500,
+        ),
+      );
+    } else if (ms_to_next_skill("attack") <= 0 && !character.s.penalty_cd) {
+      log("Energize " + character.name);
+      promisesToAwait.push(
+        withTimeout(
+          use_skill("energize", character).then(() =>
+            reduce_cooldown("energize", character.ping * 0.95),
+          ),
+          2500,
+        ),
+      );
+    }
+  }
+
+  if (
+    ms_to_next_skill("attack") === 0 &&
+    !character.s.penalty_cd &&
+    distance(target, character) < character.range + character.xrange &&
+    shouldAttack()
+  ) {
+    promisesToAwait.push(
+      currentStrategy(target),
+      withTimeout(attack(target), 2500)
+        .then(() => {
+          reduce_cooldown("attack", Math.min(...parent.pings));
+        })
+        .catch((e) => {
+          if (e.failed && e.response !== "cooldown") {
+            reduce_cooldown("attack", -e.ms);
+          }
+        }),
+    );
+
+    set_message("Attacking");
+  }
+
+  try {
+    await Promise.all(promisesToAwait);
+  } catch (e) {}
+
+  if (
+    target["damage_type"] === "magical" &&
+    !is_on_cooldown("reflection") &&
+    partyMems.includes(target.target) &&
+    character.mp > 1000
+  ) {
+    use_skill("reflection", get_entity(target.target));
+  }
+
+  // if (character.mp > 2000 && !is_on_cooldown("alchemy") && !isInvFull()) {
+  //   const sellableSlot = character.items.findIndex((item) =>
+  //     SALE_ABLE.includes(item?.name)
+  //   );
+
+  //   if (sellableSlot !== -1) {
+  //     if (sellableSlot === 0 && SALE_ABLE.includes(character.items[0]?.name)) {
+  //       use_skill("alchemy");
+  //     } else {
+  //       swap(0, sellableSlot).then(() => {
+  //         if (SALE_ABLE.includes(character.items[0]?.name)) use_skill("alchemy");
+  //       });
+  //     }
+  //   }
+  // }
+}
+
+async function mainLoop() {
+  try {
+    desiredElixir = "pumpkinspice";
+    assignRoles();
+
+    // buff();
+
+    if (character.rip) {
+      respawn();
+      throw new Error("Character's down", {
+        cause: "death",
+      });
+    }
+
+    if ((smart.moving || isAdvanceSmartMoving) && !smartmoveDebug)
+      throw new Error("Smart moving", {
+        cause: "smart_move",
+      });
+
+    let target = getTarget();
+
+    // if (goToBoss()) return;
+
+    //// THE CRYPT & EVENTS
+    if (get("cryptInstance")) target = await useCryptStrategy(target);
+    else target = await changeToDailyEventTargets();
+
+    //// Logic to targets and farm places
+    if (!target) {
+      if (
+        !smart.moving &&
+        !isAdvanceSmartMoving &&
+        get("cryptInstance") &&
+        character.map !== "crypt"
+      ) {
+        changeToNormalStrategies();
+        advanceSmartMove(CRYPT_STARTING_LOCATION);
+      } else if (
+        !smart.moving &&
+        !isAdvanceSmartMoving &&
+        !get("cryptInstance") &&
+        (partyMems[0] == character.name ||
+          !get_entity(partyMems[0]) ||
+          distance(character, { x: mapX, y: mapY, map }) > 500)
+      ) {
+        log("Moving to farming location");
+        changeToNormalStrategies();
+        advanceSmartMove({
+          map,
+          x: mapX,
+          y: mapY,
+        });
+      }
+    } else await fight(target);
+  } catch (e) {
+    console.error(e);
+  }
+
+  setTimeout(mainLoop, getLoopInterval());
+}
+
+if (!parent.caracAL) mainLoop();
+
+// setInterval(async function () {
+//   desiredElixir = "pumpkinspice";
+//   assignRoles();
+
+//   buff();
+
+//   if (character.rip) {
+//     respawn();
+//     return;
+//   }
+
+//   if (character.level > 50) {
+//     set("mageLocation", {
+//       mp: character.mp,
+//       map: character.map,
+//       x: character.x,
+//       y: character.y,
+//     });
+//   }
+
+//   if ((smart.moving || isAdvanceSmartMoving) && !smartmoveDebug) return;
+
+//   let target = getTarget();
+
+//   if (goToBoss()) return;
+
+//   //// THE CRYPT & EVENTS
+//   if (get("cryptInstance")) target = await useCryptStrategy(target);
+//   else target = await changeToDailyEventTargets();
+
+//   //// Logic to targets and farm places
+//   if (
+//     !smart.moving &&
+//     !isAdvanceSmartMoving &&
+//     get("cryptInstance") &&
+//     character.map !== "crypt" &&
+//     !target
+//   ) {
+//     changeToNormalStrategies();
+//     await advanceSmartMove(CRYPT_STARTING_LOCATION);
+//   } else if (
+//     !smart.moving &&
+//     !isAdvanceSmartMoving &&
+//     !target &&
+//     !get("cryptInstance") &&
+//     (partyMems[0] == character.name ||
+//       !get_entity(partyMems[0]) ||
+//       character.map === "crypt" ||
+//       distance(character, { x: mapX, y: mapY, map }) > 500)
+//   ) {
+//     log("Moving to farming location");
+//     changeToNormalStrategies();
+//     const scareInterval = setInterval(() => {
+//       scareAwayMobs();
+//     }, 5000);
+//     await advanceSmartMove({
+//       map,
+//       x: mapX,
+//       y: mapY,
+//     });
+//     clearInterval(scareInterval);
+//   }
+
+//   await fight(target);
+// }, loopInterval);

--- a/basic_rogue.31.js
+++ b/basic_rogue.31.js
@@ -8,6 +8,7 @@ if (parent.caracAL) {
     ])
     .then(() => {
       mainLoop();
+      fuaLoop();
     });
 } else {
   load_code(7);
@@ -25,18 +26,18 @@ async function fight(target) {
         (entity) =>
           entity.type === "monster" &&
           ([...partyMems, ...parent.party_list].includes(entity.target) ||
-            (entity.coorperative && entity.target)),
+            (entity.cooperative && entity.target)),
       )
       .sort((lhs, rhs) => {
         const lhsHpPercentage = lhs.hp / lhs.max_hp;
         const rhsHpPercentage = rhs.hp / rhs.max_hp;
 
-        if (lhs.coorperative && rhs.coorperative) {
+        if (lhs.cooperative && rhs.cooperative) {
           if (lhs["1hp"]) return -1;
           else return 1;
         }
-        if (lhs.coorperative) return -1;
-        if (rhs.coorperative) return 1;
+        if (lhs.cooperative) return -1;
+        if (rhs.cooperative) return 1;
 
         return rhsHpPercentage - lhsHpPercentage;
       });
@@ -48,53 +49,23 @@ async function fight(target) {
 
   const promisesToAwait = [];
 
-  if (!is_on_cooldown("energize")) {
-    const buffee = getLowestMana();
-    if (
-      buffee &&
-      buffee.max_mp - buffee.mp > 500 &&
-      buffee.mp < buffee.max_mp * 0.65 &&
-      character.mp > character.max_mp * 0.75 &&
-      is_in_range(buffee, "energize")
-    ) {
-      log("Energize " + buffee.name);
-      promisesToAwait.push(
-        withTimeout(
-          use_skill("energize", buffee).then(() =>
-            reduce_cooldown("energize", character.ping * 0.95),
-          ),
-          2500,
-        ),
-      );
-    } else if (ms_to_next_skill("attack") <= 0 && !character.s.penalty_cd) {
-      log("Energize " + character.name);
-      promisesToAwait.push(
-        withTimeout(
-          use_skill("energize", character).then(() =>
-            reduce_cooldown("energize", character.ping * 0.95),
-          ),
-          2500,
-        ),
-      );
-    }
-  }
-
   if (
     ms_to_next_skill("attack") === 0 &&
     !character.s.penalty_cd &&
     distance(target, character) < character.range + character.xrange &&
     shouldAttack()
   ) {
+    if (!ms_to_next_skill("invis")) {
+      use_skill("invis").then(() =>
+        reduce_cooldown("invis", Math.min(...parent.pings)),
+      );
+    }
     promisesToAwait.push(
       currentStrategy(target),
       withTimeout(attack(target), 2500)
-        .then(() => {
-          reduce_cooldown("attack", Math.min(...parent.pings));
-        })
+        .then(() => reduce_cooldown("attack", Math.min(...parent.pings)))
         .catch((e) => {
-          if (e.failed && e.response !== "cooldown") {
-            reduce_cooldown("attack", -e.ms);
-          }
+          attackErrorHandler(e);
         }),
     );
 
@@ -104,32 +75,68 @@ async function fight(target) {
   try {
     await Promise.all(promisesToAwait);
   } catch (e) {}
+}
 
-  if (
-    target["damage_type"] === "magical" &&
-    !is_on_cooldown("reflection") &&
-    partyMems.includes(target.target) &&
-    character.mp > 1000
-  ) {
-    use_skill("reflection", get_entity(target.target));
+async function fuaLoop() {
+  try {
+    const currentTarget = get_targeted_monster();
+    const promisesToAwait = [];
+
+    const prioritized = prioritizedNames();
+    const playersNearbyWithoutRogueSpeed = [
+      ...Object.values(parent.entities),
+      character,
+    ]
+      .filter(
+        (entity) =>
+          entity.type === "character" &&
+          !entity.s.rspeed &&
+          is_in_range(entity, "rspeed"),
+      )
+      .sort((lhs, rhs) => {
+        const lhsPriority = prioritized.includes(lhs.id || lhs.name) ? 1 : 0;
+        const rhsPriority = prioritized.includes(rhs.id || rhs.name) ? 1 : 0;
+        return rhsPriority - lhsPriority; // higher priority first
+      });
+
+    if (
+      playersNearbyWithoutRogueSpeed.length &&
+      ms_to_next_skill("rspeed") === 0 &&
+      character.mp > G.skills["rspeed"].mp
+    ) {
+      use_skill("rspeed", playersNearbyWithoutRogueSpeed.shift());
+    }
+
+    if (
+      distance(character, currentTarget) < character.range + character.xrange &&
+      ms_to_next_skill("quickstab") === 0 &&
+      character.mp > parent.G.skills["rspeed"].mp * 2
+    ) {
+      const currentMainhand = item_info(character.slots.mainhand);
+      const skillToBeUsed =
+        currentMainhand?.wtype === "dagger"
+          ? "quickstab"
+          : currentMainhand?.wtype === "fist"
+          ? "quickpunch"
+          : undefined;
+      if (skillToBeUsed) {
+        promisesToAwait.push(
+          use_skill(skillToBeUsed, currentTarget).then(() =>
+            reduce_cooldown(skillToBeUsed, Math.min(...parent.pings)),
+          ),
+        );
+      }
+    }
+
+    await withTimeout(Promise.all(promisesToAwait), 500);
+  } catch (e) {
+    console.log("Error while FuA: " + e);
   }
 
-  // if (character.mp > 2000 && !is_on_cooldown("alchemy") && !isInvFull()) {
-  //   const sellableSlot = character.items.findIndex((item) =>
-  //     SALE_ABLE.includes(item?.name)
-  //   );
-
-  //   if (sellableSlot !== -1) {
-  //     if (sellableSlot === 0 && SALE_ABLE.includes(character.items[0]?.name)) {
-  //       use_skill("alchemy");
-  //     } else {
-  //       swap(0, sellableSlot).then(() => {
-  //         if (SALE_ABLE.includes(character.items[0]?.name)) use_skill("alchemy");
-  //       });
-  //     }
-  //   }
-  // }
+  setTimeout(fuaLoop, Math.max(ms_to_next_skill("quickpunch"), 100));
 }
+
+if (!parent.caracAL) fuaLoop();
 
 async function mainLoop() {
   try {
@@ -151,8 +158,6 @@ async function mainLoop() {
       });
 
     let target = getTarget();
-
-    // if (goToBoss()) return;
 
     //// THE CRYPT & EVENTS
     if (get("cryptInstance")) target = await useCryptStrategy(target);
@@ -193,69 +198,3 @@ async function mainLoop() {
 }
 
 if (!parent.caracAL) mainLoop();
-
-// setInterval(async function () {
-//   desiredElixir = "pumpkinspice";
-//   assignRoles();
-
-//   buff();
-
-//   if (character.rip) {
-//     respawn();
-//     return;
-//   }
-
-//   if (character.level > 50) {
-//     set("mageLocation", {
-//       mp: character.mp,
-//       map: character.map,
-//       x: character.x,
-//       y: character.y,
-//     });
-//   }
-
-//   if ((smart.moving || isAdvanceSmartMoving) && !smartmoveDebug) return;
-
-//   let target = getTarget();
-
-//   if (goToBoss()) return;
-
-//   //// THE CRYPT & EVENTS
-//   if (get("cryptInstance")) target = await useCryptStrategy(target);
-//   else target = await changeToDailyEventTargets();
-
-//   //// Logic to targets and farm places
-//   if (
-//     !smart.moving &&
-//     !isAdvanceSmartMoving &&
-//     get("cryptInstance") &&
-//     character.map !== "crypt" &&
-//     !target
-//   ) {
-//     changeToNormalStrategies();
-//     await advanceSmartMove(CRYPT_STARTING_LOCATION);
-//   } else if (
-//     !smart.moving &&
-//     !isAdvanceSmartMoving &&
-//     !target &&
-//     !get("cryptInstance") &&
-//     (partyMems[0] == character.name ||
-//       !get_entity(partyMems[0]) ||
-//       character.map === "crypt" ||
-//       distance(character, { x: mapX, y: mapY, map }) > 500)
-//   ) {
-//     log("Moving to farming location");
-//     changeToNormalStrategies();
-//     const scareInterval = setInterval(() => {
-//       scareAwayMobs();
-//     }, 5000);
-//     await advanceSmartMove({
-//       map,
-//       x: mapX,
-//       y: mapY,
-//     });
-//     clearInterval(scareInterval);
-//   }
-
-//   await fight(target);
-// }, loopInterval);

--- a/basic_rogue.31.js
+++ b/basic_rogue.31.js
@@ -79,7 +79,7 @@ async function fight(target) {
 
 async function fuaLoop() {
   try {
-    const currentTarget = get_targeted_monster();
+    const currentTarget = get_target();
     const promisesToAwait = [];
 
     const prioritized = prioritizedNames();
@@ -128,9 +128,9 @@ async function fuaLoop() {
       }
     }
 
-    await withTimeout(Promise.all(promisesToAwait), 500);
+    await withTimeout(Promise.allSettled(promisesToAwait), 500);
   } catch (e) {
-    console.log("Error while FuA: " + e);
+    console.log("Error while FuA: ", e);
   }
 
   setTimeout(fuaLoop, Math.max(ms_to_next_skill("quickpunch"), 100));

--- a/basic_warrior.9.js
+++ b/basic_warrior.9.js
@@ -174,7 +174,7 @@ async function fight(target) {
   const partyDmgRecieved = avgPartyDmgTaken(partyMems);
   const partyHealer = get_player(HEALER);
   if (
-    character.name === TANKER &&
+    isAssignedAsTanker() &&
     character.mp > G.skills["taunt"].mp &&
     !is_on_cooldown("taunt") &&
     partyHealer &&
@@ -239,6 +239,7 @@ async function fight(target) {
 
 async function mainLoop() {
   try {
+    desiredElixir = isAssignedAsTanker() ? "elixirluck" : "pumpkinspice";
     assignRoles();
 
     if (

--- a/basic_warrior.9.js
+++ b/basic_warrior.9.js
@@ -23,7 +23,7 @@ async function fight(target) {
   const haveIgnoreMobAroundTarget = (targetMob) => {
     return mobsListAroundTarget(
       targetMob,
-      character.explosion / 3.6 || BLAST_RADIUS
+      character.explosion / 3.6 || BLAST_RADIUS,
     ).some((mob) => MELEE_IGNORE_LIST.includes(mob.mtype));
   };
 
@@ -47,11 +47,11 @@ async function fight(target) {
         .sort((lhs, rhs) => {
           const lhsNumberOfSurrounding = numberOfMonsterAroundTarget(
             lhs,
-            character.explosion / 3.6 || BLAST_RADIUS
+            character.explosion / 3.6 || BLAST_RADIUS,
           );
           const rhsNumberOfSurrounding = numberOfMonsterAroundTarget(
             rhs,
-            character.explosion / 3.6 || BLAST_RADIUS
+            character.explosion / 3.6 || BLAST_RADIUS,
           );
           if (lhsNumberOfSurrounding === rhsNumberOfSurrounding)
             return rhs.hp - lhs.hp;
@@ -125,7 +125,7 @@ async function fight(target) {
               slot: "offhand",
               num: findMaxLevelItem(warriorItems.offhand),
             },
-          ])
+          ]),
         )
         .finally(() => {
           isEquipingItems = false;
@@ -184,16 +184,16 @@ async function fight(target) {
       (mob) =>
         mob.type === "monster" &&
         partyMems.some(
-          (ally) => ally !== character.name && mob.target === ally
+          (ally) => ally !== character.name && mob.target === ally,
         ) &&
         mob.attack > 120 &&
         calculateDamage(mob, character) < 1800 &&
-        !mob.cooperative
+        !mob.cooperative,
     );
 
     if (mobsTargetingAlly && is_in_range(mobsTargetingAlly, "taunt")) {
       use_skill("taunt", mobsTargetingAlly).then(() =>
-        reduce_cooldown("taunt", character.ping * 0.95)
+        reduce_cooldown("taunt", character.ping * 0.95),
       );
     } else if (
       !target.target ||
@@ -203,7 +203,7 @@ async function fight(target) {
         is_in_range(target, "taunt"))
     ) {
       use_skill("taunt", target).then(() =>
-        reduce_cooldown("taunt", character.ping * 0.95)
+        reduce_cooldown("taunt", character.ping * 0.95),
       );
     }
   }
@@ -215,7 +215,7 @@ async function fight(target) {
       get_entity(HEALER)?.rip ||
       character.hp < character.max_hp * 0.3) &&
       Object.values(parent.entities).filter(
-        (mob) => mob.target === character.name
+        (mob) => mob.target === character.name,
       ).length > 2 &&
       !is_on_cooldown("scare") &&
       character.mp > 100 &&
@@ -263,7 +263,7 @@ async function mainLoop() {
         character.range + character.xrange
     )
       await warriorCleave(
-        currentStrategy === usePullStrategies ? "pull" : "normal"
+        currentStrategy === usePullStrategies ? "pull" : "normal",
       );
 
     if ((smart.moving || isAdvanceSmartMoving) && !smartmoveDebug)
@@ -285,18 +285,30 @@ async function mainLoop() {
 
     // Targeting & movement logic
     if (!target) {
-      if (!smart.moving && !isAdvanceSmartMoving) {
-        if (get("cryptInstance") && character.map !== "crypt") {
-          changeToNormalStrategies();
-          advanceSmartMove(CRYPT_STARTING_LOCATION);
-        } else if (!get("cryptInstance")) {
-          changeToNormalStrategies();
-          advanceSmartMove({ map, x: mapX, y: mapY });
-        }
+      if (
+        !smart.moving &&
+        !isAdvanceSmartMoving &&
+        get("cryptInstance") &&
+        character.map !== "crypt"
+      ) {
+        changeToNormalStrategies();
+        advanceSmartMove(CRYPT_STARTING_LOCATION);
+      } else if (
+        !smart.moving &&
+        !get("cryptInstance") &&
+        (partyMems[0] === character.name ||
+          !get_entity(partyMems[0]) ||
+          character.map === "crypt" ||
+          distance(character, { x: mapX, y: mapY, map }) > 500)
+      ) {
+        changeToNormalStrategies();
+        advanceSmartMove({
+          map,
+          x: mapX,
+          y: mapY,
+        });
       }
-    } else {
-      fight(target);
-    }
+    } else fight(target);
   } catch (e) {
     console.error(e);
   }

--- a/basic_warrior.9.js
+++ b/basic_warrior.9.js
@@ -23,7 +23,7 @@ async function fight(target) {
   const haveIgnoreMobAroundTarget = (targetMob) => {
     return mobsListAroundTarget(
       targetMob,
-      character.explosion / 3.6 || BLAST_RADIUS,
+      character.explosion / 3.6 || BLAST_RADIUS
     ).some((mob) => MELEE_IGNORE_LIST.includes(mob.mtype));
   };
 
@@ -47,11 +47,11 @@ async function fight(target) {
         .sort((lhs, rhs) => {
           const lhsNumberOfSurrounding = numberOfMonsterAroundTarget(
             lhs,
-            character.explosion / 3.6 || BLAST_RADIUS,
+            character.explosion / 3.6 || BLAST_RADIUS
           );
           const rhsNumberOfSurrounding = numberOfMonsterAroundTarget(
             rhs,
-            character.explosion / 3.6 || BLAST_RADIUS,
+            character.explosion / 3.6 || BLAST_RADIUS
           );
           if (lhsNumberOfSurrounding === rhsNumberOfSurrounding)
             return rhs.hp - lhs.hp;
@@ -125,7 +125,7 @@ async function fight(target) {
               slot: "offhand",
               num: findMaxLevelItem(warriorItems.offhand),
             },
-          ]),
+          ])
         )
         .finally(() => {
           isEquipingItems = false;
@@ -174,6 +174,7 @@ async function fight(target) {
   const partyDmgRecieved = avgPartyDmgTaken(partyMems);
   const partyHealer = get_player(HEALER);
   if (
+    character.name === TANKER &&
     character.mp > G.skills["taunt"].mp &&
     !is_on_cooldown("taunt") &&
     partyHealer &&
@@ -183,16 +184,16 @@ async function fight(target) {
       (mob) =>
         mob.type === "monster" &&
         partyMems.some(
-          (ally) => ally !== character.name && mob.target === ally,
+          (ally) => ally !== character.name && mob.target === ally
         ) &&
         mob.attack > 120 &&
         calculateDamage(mob, character) < 1800 &&
-        !mob.cooperative,
+        !mob.cooperative
     );
 
     if (mobsTargetingAlly && is_in_range(mobsTargetingAlly, "taunt")) {
       use_skill("taunt", mobsTargetingAlly).then(() =>
-        reduce_cooldown("taunt", character.ping * 0.95),
+        reduce_cooldown("taunt", character.ping * 0.95)
       );
     } else if (
       !target.target ||
@@ -202,7 +203,7 @@ async function fight(target) {
         is_in_range(target, "taunt"))
     ) {
       use_skill("taunt", target).then(() =>
-        reduce_cooldown("taunt", character.ping * 0.95),
+        reduce_cooldown("taunt", character.ping * 0.95)
       );
     }
   }
@@ -214,7 +215,7 @@ async function fight(target) {
       get_entity(HEALER)?.rip ||
       character.hp < character.max_hp * 0.3) &&
       Object.values(parent.entities).filter(
-        (mob) => mob.target === character.name,
+        (mob) => mob.target === character.name
       ).length > 2 &&
       !is_on_cooldown("scare") &&
       character.mp > 100 &&
@@ -262,7 +263,7 @@ async function mainLoop() {
         character.range + character.xrange
     )
       await warriorCleave(
-        currentStrategy === usePullStrategies ? "pull" : "normal",
+        currentStrategy === usePullStrategies ? "pull" : "normal"
       );
 
     if ((smart.moving || isAdvanceSmartMoving) && !smartmoveDebug)

--- a/basic_warrior.9.js
+++ b/basic_warrior.9.js
@@ -104,11 +104,7 @@ async function fight(target) {
         .then(() => {
           reduce_cooldown("attack", Math.min(...parent.pings));
         })
-        .catch((e) => {
-          if (e.failed && e.response !== "cooldown") {
-            reduce_cooldown("attack", -e.ms);
-          }
-        }),
+        .catch((e) => attackErrorHandler(e)),
     ];
 
     // Offhand swap logic
@@ -233,7 +229,6 @@ async function fight(target) {
 }
 
 // Main game loop
-
 async function cleaveLoop() {
   try {
     if (
@@ -290,9 +285,6 @@ async function mainLoop() {
       });
 
     let target = getTarget();
-
-    // Boss handling
-    // if (goToBoss()) return;
 
     // Crypt & Event logic
     if (get("cryptInstance")) {

--- a/basic_warrior.9.js
+++ b/basic_warrior.9.js
@@ -38,17 +38,17 @@ async function fight(target) {
   };
 
   if (currentStrategy === usePullStrategies) {
-    aggroedMobs = Object.values(parent.entities).filter((mob) => {
+    const aggroedMobs = Object.values(parent.entities).filter((entity) => {
       return (
-        !haveFormidableMonsterAroundTarget(mob) &&
-        distance(mob, character) <
+        entity.type === "monster" &&
+        !MELEE_IGNORE_LIST.includes(entity.mtype) &&
+        entity.target &&
+        !haveFormidableMonsterAroundTarget(entity) &&
+        distance(entity, character) <
           character.range +
             character.xrange * 0.9 +
             extraDistanceWithinHitbox(character) &&
-        mob.target &&
-        mob.type === "monster" &&
-        !MELEE_IGNORE_LIST.includes(mob.mtype) &&
-        !haveIgnoreMobAroundTarget(mob)
+        !haveIgnoreMobAroundTarget(entity)
       );
     });
 
@@ -86,6 +86,8 @@ async function fight(target) {
     changeToNormalStrategies();
   }
 
+  const promisesToAwait = [];
+
   if (
     ms_to_next_skill("attack") === 0 &&
     !character.s.penalty_cd &&
@@ -98,14 +100,12 @@ async function fight(target) {
   ) {
     set_message("Attacking");
     // Main attack logic
-    const promisesToAwait = [
+    promisesToAwait.push(
       currentStrategy(target),
-      withTimeout(attack(target), 2500)
-        .then(() => {
-          reduce_cooldown("attack", Math.min(...parent.pings));
-        })
+      attack(target)
+        .then(() => reduce_cooldown("attack", Math.min(...parent.pings)))
         .catch((e) => attackErrorHandler(e)),
-    ];
+    );
 
     // Offhand swap logic
     if (
@@ -116,7 +116,6 @@ async function fight(target) {
       character.cc < 100 &&
       !character.s.sugarrush
     ) {
-      const warriorItems = calculateWarriorItems();
       const candycane1 = findMaxLevelItem("candycanesword");
       const candycane2 = findMaxLevelItem("candycanesword", 1);
       if (candycane1 !== -1 && candycane2 !== -1) {
@@ -141,16 +140,16 @@ async function fight(target) {
       }
     }
 
-    try {
-      await withTimeout(Promise.all(promisesToAwait), 1000);
-    } catch (e) {}
-
     if (
       character.mp > G.skills["warcry"].mp &&
       !is_on_cooldown("warcry") &&
       !character.s["warcry"]
     ) {
-      use_skill("warcry");
+      promisesToAwait.push(
+        use_skill("warcry").then(() =>
+          reduce_cooldown("warcry", character.ping * 0.95),
+        ),
+      );
     }
   }
 
@@ -161,7 +160,7 @@ async function fight(target) {
     avgDmgTaken(character) > 500 &&
     character.hp < character.max_hp * 0.5
   ) {
-    use_skill("hardshell");
+    promisesToAwait.push(use_skill("hardshell"));
   }
 
   if (
@@ -171,11 +170,10 @@ async function fight(target) {
       .filter((entity) => entity)
       .some((player) => player.hp < player.max_hp * 0.4)
   ) {
-    warriorStomp();
+    promisesToAwait.push(warriorStomp());
   }
 
   // Taunt logic to protect allies
-  const partyDmgRecieved = avgPartyDmgTaken(partyMems);
   const partyHealer = get_player(HEALER);
   if (
     isAssignedAsTanker() &&
@@ -196,8 +194,10 @@ async function fight(target) {
     );
 
     if (mobsTargetingAlly && is_in_range(mobsTargetingAlly, "taunt")) {
-      use_skill("taunt", mobsTargetingAlly).then(() =>
-        reduce_cooldown("taunt", character.ping * 0.95),
+      promisesToAwait.push(
+        use_skill("taunt", mobsTargetingAlly).then(() =>
+          reduce_cooldown("taunt", character.ping * 0.95),
+        ),
       );
     } else if (
       !target.target ||
@@ -206,26 +206,30 @@ async function fight(target) {
         !target.cooperative &&
         is_in_range(target, "taunt"))
     ) {
-      use_skill("taunt", target).then(() =>
-        reduce_cooldown("taunt", character.ping * 0.95),
+      promisesToAwait.push(
+        use_skill("taunt", target).then(() =>
+          reduce_cooldown("taunt", character.ping * 0.95),
+        ),
       );
     }
   }
 
   // Emergency scare if overwhelmed
-  if (
-    character.fear ||
-    ((!get_entity(HEALER) ||
-      get_entity(HEALER)?.rip ||
-      character.hp < character.max_hp * 0.3) &&
-      Object.values(parent.entities).filter(
-        (mob) => mob.target === character.name,
-      ).length > 2 &&
-      !is_on_cooldown("scare") &&
-      character.mp > 100 &&
-      character.cc < 100)
-  ) {
-    await scareAwayMobs();
+  const isDangerouslyLow =
+    !partyHealer || partyHealer.rip || character.hp < character.max_hp * 0.3;
+
+  // 2. Is the character being targeted by too many mobs?
+  const isOverwhelmed =
+    Object.values(parent.entities).filter(
+      (mob) => mob.target === character.name,
+    ).length > 2;
+
+  // 3. Are the ability resources/cooldowns ready?
+  const isReadyToScare =
+    !is_on_cooldown("scare") && character.mp > 100 && character.cc < 100;
+
+  if (character.fear || (isDangerouslyLow && isOverwhelmed && isReadyToScare)) {
+    scareAwayMobs();
   }
 
   if (
@@ -236,6 +240,12 @@ async function fight(target) {
     rangeRate = target.speed / character.speed;
   } else {
     rangeRate = originRangeRate;
+  }
+
+  try {
+    await withTimeout(Promise.all(promisesToAwait), 1000);
+  } catch (e) {
+    console.error("Error while attacking", e);
   }
 }
 
@@ -248,8 +258,10 @@ async function cleaveLoop() {
       distance(character, get_targeted_monster()) >
         character.range + character.xrange * 1.1
     )
-      await warriorCleave(
-        currentStrategy === usePullStrategies ? "pull" : "normal",
+      await withTimeout(
+        warriorCleave(
+          currentStrategy === usePullStrategies ? "pull" : "normal",
+        ),
       );
   } catch (e) {
     console.log("Error while cleaving: ", e);

--- a/basic_warrior.9.js
+++ b/basic_warrior.9.js
@@ -18,6 +18,15 @@ if (parent.caracAL) {
 const originRangeRate = 0.97;
 rangeRate = originRangeRate;
 
+const bosses = {
+  icegolem: { type: "icegolem", threshold: 0.7, hoppable: 0.999 },
+  franky: { type: "franky", threshold: 0.7, hoppable: 0.965 },
+  mrpumpkin: { type: "mrpumpkin", threshold: 0.7, hoppable: 0.95 },
+  mrgreen: { type: "mrgreen", threshold: 0.7, hoppable: 0.95 },
+  crabxx: { type: "crabxx", threshold: 0.95, hoppable: 0.9999 },
+  dragold: { type: "dragold", threshold: 0.99, hoppable: 1 },
+};
+
 // Main fight function
 async function fight(target) {
   const haveIgnoreMobAroundTarget = (targetMob) => {
@@ -60,6 +69,7 @@ async function fight(target) {
         .shift();
 
       target =
+        !target.cooperative &&
         aoeMob &&
         mobsToFarm.findIndex((id) => id === aoeMob.mtype) <=
           mobsToFarm.findIndex((id) => id === target.mtype)

--- a/basic_warrior.9.js
+++ b/basic_warrior.9.js
@@ -1,5 +1,12 @@
-// Load basic functions
+// Function to reduce cooldown based on the lowest current ping in the party
+const reduceCd = (skillName, isPingBased = true) => {
+  const cooldownTime = isPingBased
+    ? Math.min(...parent.pings)
+    : character.ping * 0.95;
+  reduce_cooldown(skillName, cooldownTime);
+};
 
+// Load basic functions (unchanged)
 if (parent.caracAL) {
   parent.caracAL
     .load_scripts([
@@ -15,7 +22,7 @@ if (parent.caracAL) {
   load_code(8);
 }
 
-// Kiting settings
+// Kiting settings (unchanged)
 const originRangeRate = 0.9;
 rangeRate = originRangeRate;
 
@@ -30,201 +37,218 @@ const bosses = {
 
 // Main fight function
 async function fight(target) {
+  const blastRadius = character.explosion / 3.6 || BLAST_RADIUS;
+
   const haveIgnoreMobAroundTarget = (targetMob) => {
-    return mobsListAroundTarget(
-      targetMob,
-      character.explosion / 3.6 || BLAST_RADIUS,
-    ).some((mob) => MELEE_IGNORE_LIST.includes(mob.mtype));
+    return mobsListAroundTarget(targetMob, blastRadius).some((mob) =>
+      MELEE_IGNORE_LIST.includes(mob.mtype),
+    );
   };
 
+  // --- Target Aggregation & Selection (usePullStrategies) ---
   if (currentStrategy === usePullStrategies) {
-    const aggroedMobs = Object.values(parent.entities).filter((entity) => {
-      return (
-        entity.type === "monster" &&
-        !MELEE_IGNORE_LIST.includes(entity.mtype) &&
-        entity.target &&
-        !haveFormidableMonsterAroundTarget(entity) &&
-        distance(entity, character) <
-          character.range +
-            character.xrange * 0.9 +
-            extraDistanceWithinHitbox(character) &&
-        !haveIgnoreMobAroundTarget(entity)
-      );
-    });
+    const attackRange = character.range + character.xrange;
+    const maxPullDistance =
+      attackRange * 0.9 + extraDistanceWithinHitbox(character);
+
+    const aggroedMobs = Object.values(parent.entities)
+      .filter((entity) => {
+        return (
+          entity.type === "monster" &&
+          !MELEE_IGNORE_LIST.includes(entity.mtype) &&
+          entity.target &&
+          !haveFormidableMonsterAroundTarget(entity) &&
+          distance(entity, character) <
+            maxPullDistance + extraDistanceWithinHitbox(entity) &&
+          !haveIgnoreMobAroundTarget(entity)
+        );
+      })
+      // Optimization: Pre-calculate the cluster count BEFORE sorting
+      .map((mob) => {
+        mob.cluster_count = numberOfMonsterAroundTarget(mob, blastRadius);
+        return mob;
+      });
 
     if (aggroedMobs.length) {
       const aoeMob = aggroedMobs
         .sort((lhs, rhs) => {
-          const lhsNumberOfSurrounding = numberOfMonsterAroundTarget(
-            lhs,
-            character.explosion / 3.6 || BLAST_RADIUS,
-          );
-          const rhsNumberOfSurrounding = numberOfMonsterAroundTarget(
-            rhs,
-            character.explosion / 3.6 || BLAST_RADIUS,
-          );
-          if (lhsNumberOfSurrounding === rhsNumberOfSurrounding)
-            return rhs.hp - lhs.hp;
-          return rhsNumberOfSurrounding - lhsNumberOfSurrounding;
-        })
-        .shift();
+          // Prioritize highest cluster count (using pre-calculated value)
+          if (lhs.cluster_count !== rhs.cluster_count) {
+            return rhs.cluster_count - lhs.cluster_count;
+          }
 
-      target =
-        !target.cooperative &&
+          // Hit one with more HP
+          return rhs.hp - lhs.hp;
+        })
+        .shift(); // Get the first of list (best for AOE)
+
+      // Prioritize the AOE mob if it's better than the current target (or if the current is cooperative)
+      const isAoeMobBetter =
         aoeMob &&
         mobsToFarm.findIndex((id) => id === aoeMob.mtype) <=
-          mobsToFarm.findIndex((id) => id === target.mtype)
-          ? aoeMob
-          : target;
+          mobsToFarm.findIndex((id) => id === target?.mtype);
+
+      if (!target?.cooperative && isAoeMobBetter) {
+        target = aoeMob;
+      }
       change_target(target);
     }
   }
 
   if (!target) return;
 
+  // --- Ignore blasting mobs on blacklist ---
   if (haveIgnoreMobAroundTarget(target)) {
     changeToNormalStrategies();
   }
 
   const promisesToAwait = [];
 
-  if (
-    ms_to_next_skill("attack") === 0 &&
-    !character.s.penalty_cd &&
-    distance(target, character) <
-      character.range +
-        character.xrange * 0.9 +
-        extraDistanceWithinHitbox(target) +
-        extraDistanceWithinHitbox(character) &&
-    shouldAttack()
-  ) {
+  // --- Attack & Warcry Logic ---
+  const isAttackReady =
+    ms_to_next_skill("attack") === 0 && !character.s.penalty_cd;
+  const attackRange =
+    character.range +
+    character.xrange * 0.9 +
+    extraDistanceWithinHitbox(character) +
+    extraDistanceWithinHitbox(target);
+  const isTargetInAttackRange = distance(target, character) < attackRange;
+
+  if (isAttackReady && isTargetInAttackRange && shouldAttack()) {
     set_message("Attacking");
-    // Main attack logic
+
+    // Main attack execution
     promisesToAwait.push(
       currentStrategy(target),
       attack(target)
-        .then(() => reduce_cooldown("attack", Math.min(...parent.pings)))
+        .then(() => reduceCd("attack")) // <-- Use reduceCd()
         .catch((e) => attackErrorHandler(e)),
     );
 
-    // Offhand swap logic
-    if (
+    // Offhand swap logic: Use Candy Canes for farming
+    const shouldUseCandyCanes =
       !isEquipingItems &&
       (character.slots.offhand?.name === "fireblade" ||
         character.slots.mainhand?.name === "fireblade") &&
       character.slots.offhand?.name !== "mshield" &&
       character.cc < 100 &&
-      !character.s.sugarrush
-    ) {
+      !character.s.sugarrush;
+
+    if (shouldUseCandyCanes) {
       const candycane1 = findMaxLevelItem("candycanesword");
       const candycane2 = findMaxLevelItem("candycanesword", 1);
+
       if (candycane1 !== -1 && candycane2 !== -1) {
         isEquipingItems = true;
-        const equipPromises = Promise.all([
-          Promise.all([
-            equip(candycane1, "mainhand"),
-            equip(candycane2, "offhand"),
-          ]),
+        const equipPromise = Promise.all([
+          equip(candycane1, "mainhand"),
+          equip(candycane2, "offhand"),
         ])
-          .then(async () => {
+          .then(() =>
             Promise.all([
+              // Swap back to proc the previous weapon effect
               equip(candycane1, "mainhand"),
               equip(candycane2, "offhand"),
-            ]);
-          })
+            ]),
+          )
           .finally(() => {
             isEquipingItems = false;
           });
 
-        promisesToAwait.push(equipPromises);
+        promisesToAwait.push(equipPromise);
       }
     }
 
-    if (
+    // Warcry check (placed here to potentially benefit from a new attack)
+    const canWarcry =
       character.mp > G.skills["warcry"].mp &&
       !is_on_cooldown("warcry") &&
-      !character.s["warcry"]
-    ) {
+      !character.s["warcry"];
+
+    if (canWarcry) {
       promisesToAwait.push(
-        use_skill("warcry").then(() =>
-          reduce_cooldown("warcry", character.ping * 0.95),
-        ),
+        use_skill("warcry").then(() => reduceCd("warcry", false)), // Use full reduction for Warcry
       );
     }
   }
 
-  // Defensive abilities
-  if (
+  // --- Defensive Abilities ---
+
+  // Hardshell
+  const shouldUseHardShell =
     character.mp > G.skills["hardshell"].mp &&
     !is_on_cooldown("hardshell") &&
     avgDmgTaken(character) > 500 &&
-    character.hp < character.max_hp * 0.5
-  ) {
+    character.hp < character.max_hp * 0.5;
+
+  if (shouldUseHardShell) {
     promisesToAwait.push(use_skill("hardshell"));
   }
 
-  if (
-    locate_item("basher") !== -1 &&
-    (parent.party_list.length ? parent.party_list : [character])
-      .map((id) => get_player(id))
-      .filter((entity) => entity)
-      .some((player) => player.hp < player.max_hp * 0.4)
-  ) {
+  // Warrior Stomp (Basher logic)
+  const hasBasherEquipped = locate_item("basher") !== -1;
+  const partyHasInjured = (
+    parent.party_list.length ? parent.party_list : [character]
+  )
+    .map((id) => get_player(id))
+    .filter((entity) => entity)
+    .some((player) => player.hp < player.max_hp * 0.4);
+
+  if (hasBasherEquipped && partyHasInjured) {
     promisesToAwait.push(warriorStomp());
   }
 
-  // Taunt logic to protect allies
+  // --- Taunt Logic ---
+  const isTanker = isAssignedAsTanker();
+  const canTaunt =
+    isTanker && character.mp > G.skills["taunt"].mp && !is_on_cooldown("taunt");
   const partyHealer = get_player(HEALER);
-  if (
-    isAssignedAsTanker() &&
-    character.mp > G.skills["taunt"].mp &&
-    !is_on_cooldown("taunt") &&
-    partyHealer &&
-    !partyHealer.rip
-  ) {
+  const isHealerAlive = partyHealer && !partyHealer.rip;
+
+  if (canTaunt && isHealerAlive) {
+    // --- If Mobs targeting allies
     const mobsTargetingAlly = Object.values(parent.entities).find(
       (mob) =>
         mob.type === "monster" &&
         partyMems.some(
           (ally) => ally !== character.name && mob.target === ally,
         ) &&
-        mob.attack > 120 &&
-        calculateDamage(mob, character) < 1800 &&
-        !mob.cooperative,
+        mob.attack > 120 && // Mob is dangerous enough
+        calculateDamage(mob, character) < 1800 && // Warrior can take the damage
+        !mob.cooperative &&
+        is_in_range(mob, "taunt"),
     );
 
-    if (mobsTargetingAlly && is_in_range(mobsTargetingAlly, "taunt")) {
+    if (mobsTargetingAlly) {
       promisesToAwait.push(
         use_skill("taunt", mobsTargetingAlly).then(() =>
-          reduce_cooldown("taunt", character.ping * 0.95),
-        ),
+          reduceCd("taunt", false),
+        ), // Use full reduction for Taunt
       );
-    } else if (
+    }
+
+    // --- Taunt the current target if it's not already targeting the warrior and is weak enough
+    const shouldTauntTarget =
       !target.target ||
       (target.target !== character.name &&
         target.attack < 1500 &&
         !target.cooperative &&
-        is_in_range(target, "taunt"))
-    ) {
+        is_in_range(target, "taunt"));
+
+    if (mobsTargetingAlly === undefined && shouldTauntTarget) {
       promisesToAwait.push(
-        use_skill("taunt", target).then(() =>
-          reduce_cooldown("taunt", character.ping * 0.95),
-        ),
+        use_skill("taunt", target).then(() => reduceCd("taunt", false)), // Use full reduction for Taunt
       );
     }
   }
 
-  // Emergency scare if overwhelmed
+  // --- Emergency Scare Logic ---
   const isDangerouslyLow =
     !partyHealer || partyHealer.rip || character.hp < character.max_hp * 0.3;
-
-  // 2. Is the character being targeted by too many mobs?
   const isOverwhelmed =
     Object.values(parent.entities).filter(
       (mob) => mob.target === character.name,
     ).length > 2;
-
-  // 3. Are the ability resources/cooldowns ready?
   const isReadyToScare =
     !is_on_cooldown("scare") && character.mp > 100 && character.cc < 100;
 
@@ -232,16 +256,14 @@ async function fight(target) {
     scareAwayMobs();
   }
 
-  if (
-    target &&
-    target.range <= character.range &&
-    target.speed > character.speed
-  ) {
-    rangeRate = target.speed / character.speed;
-  } else {
-    rangeRate = originRangeRate;
-  }
+  // --- Kiting Rate Adjustment ---
+  const needsKiteAdjustment =
+    target && target.range <= character.range && target.speed > character.speed;
+  rangeRate = needsKiteAdjustment
+    ? target.speed / character.speed
+    : originRangeRate;
 
+  // --- Await and Error Handling ---
   try {
     await withTimeout(Promise.all(promisesToAwait), 1000);
   } catch (e) {
@@ -249,42 +271,50 @@ async function fight(target) {
   }
 }
 
-// Main game loop
+// Main game loop (cleaveLoop is separate for timing)
 async function cleaveLoop() {
   try {
-    if (
+    const shouldCleave =
       smart.moving ||
       ms_to_next_skill("attack") > 50 ||
       distance(character, get_targeted_monster()) >
-        character.range + character.xrange * 1.1
-    )
+        character.range + character.xrange * 1.1;
+
+    if (shouldCleave) {
       await withTimeout(
         warriorCleave(
           currentStrategy === usePullStrategies ? "pull" : "normal",
         ),
       );
+    }
   } catch (e) {
     console.log("Error while cleaving: ", e);
   }
 
+  // Cleave loop runs on its own dedicated timer
   setTimeout(cleaveLoop, Math.max(ms_to_next_skill("cleave"), 100));
 }
 
 if (!parent.caracAL) cleaveLoop();
 
+// Main control loop
 async function mainLoop() {
   try {
+    // --- Initialization and Status Checks ---
     desiredElixir = isAssignedAsTanker() ? "elixirluck" : "pumpkinspice";
     assignRoles();
 
-    if (
+    // Use Charge if moving (for speed boost)
+    const canCharge =
       character.moving &&
       character.mp > G.skills["charge"].mp &&
-      !is_on_cooldown("charge")
-    ) {
+      !is_on_cooldown("charge");
+
+    if (canCharge) {
       use_skill("charge");
     }
 
+    // Handle immediate death state
     if (character.rip) {
       respawn();
       throw new Error("Character's down", {
@@ -292,58 +322,60 @@ async function mainLoop() {
       });
     }
 
-    // if (
-    //   smart.moving ||
-    //   ms_to_next_skill("attack") > 50 ||
-    //   distance(character, get_targeted_monster()) >
-    //     character.range + character.xrange * 1.1
-    // )
-    //   await warriorCleave(
-    //     currentStrategy === usePullStrategies ? "pull" : "normal",
-    //   );
-
-    if ((smart.moving || isAdvanceSmartMoving) && !smartmoveDebug)
+    // Halt logic if character is performing a controlled move
+    const isMovingControlled =
+      (smart.moving || isAdvanceSmartMoving) && !smartmoveDebug;
+    if (isMovingControlled) {
       throw new Error("Smart moving", {
         cause: "smart_move",
       });
+    }
 
+    // --- Target Selection ---
     let target = getTarget();
 
-    // Crypt & Event logic
+    // Prioritize Crypt/Event targets
     if (get("cryptInstance")) {
       target = await useCryptStrategy(target);
     } else {
       target = await changeToDailyEventTargets();
     }
 
-    // Targeting & movement logic
+    // --- Movement Logic ---
     if (!target) {
-      if (
-        !smart.moving &&
-        !isAdvanceSmartMoving &&
-        get("cryptInstance") &&
-        character.map !== "crypt"
-      ) {
+      const needsToEnterCrypt =
+        get("cryptInstance") && character.map !== "crypt";
+      const isPartyLeaderOrAlone =
+        partyMems[0] === character.name || !get_entity(partyMems[0]);
+      const isFarFromPartyLeader =
+        distance(character, { x: mapX, y: mapY, map }) > 500;
+
+      // Only move to farm location if not doing crypt and either the leader/alone or far away.
+      const needsToMoveToFarmLocation =
+        !get("cryptInstance") && (isPartyLeaderOrAlone || isFarFromPartyLeader);
+
+      if (needsToEnterCrypt) {
         advanceSmartMove(CRYPT_STARTING_LOCATION);
-      } else if (
-        !smart.moving &&
-        !get("cryptInstance") &&
-        (partyMems[0] === character.name ||
-          !get_entity(partyMems[0]) ||
-          distance(character, { x: mapX, y: mapY, map }) > 500)
-      ) {
-        changeToNormalStrategies();
+      } else if (needsToMoveToFarmLocation) {
+        changeToNormalStrategies(); // Ensure correct strategy is set before move
         advanceSmartMove({
           map,
           x: mapX,
           y: mapY,
         });
       }
-    } else await fight(target);
+    } else {
+      // Target found, engage in combat
+      await fight(target);
+    }
   } catch (e) {
-    console.error(e);
+    // Only log unhandled errors
+    if (e.cause !== "smart_move" && e.cause !== "death") {
+      console.error(e);
+    }
   }
 
+  // Schedule the next loop execution
   setTimeout(mainLoop, getLoopInterval());
 }
 

--- a/basic_warrior.9.js
+++ b/basic_warrior.9.js
@@ -15,7 +15,7 @@ if (parent.caracAL) {
 }
 
 // Kiting settings
-const originRangeRate = 0.97;
+const originRangeRate = 0.9;
 rangeRate = originRangeRate;
 
 const bosses = {
@@ -96,30 +96,26 @@ async function fight(target) {
     shouldAttack()
   ) {
     set_message("Attacking");
-    currentStrategy(target);
     // Main attack logic
-    const attackPromise = attack(target).catch((e) => {
-      if (e.failed && e.response !== "cooldown") {
-        reduce_cooldown("attack", -e.ms);
-      }
-    });
-
-    const promisesToAwait = [attackPromise];
+    const promisesToAwait = [currentStrategy(target), attack(target)];
 
     // Offhand swap logic
     if (
       (character.slots.offhand?.name === "fireblade" ||
         character.slots.mainhand?.name === "fireblade") &&
-      !isEquipingItems
+      character.cc < 100 &&
+      !character.s.penalty_cd &&
+      !character.s.sugarrush
     ) {
+      isEquipingItems = true;
       const warriorItems = calculateWarriorItems();
-      const equipPromises = equipBatch(
-        {
-          mainhand: "candycanesword",
-          offhand: "candycanesword",
-        },
-        true,
-      ).then(() => equipBatch(warriorItems, true));
+      const equipPromises = Promise.all([
+        equip(findMaxLevelItem("candycanesword"), "mainhand"),
+        equip(findMaxLevelItem("candycanesword", 1), "offhand"),
+      ]).then(async () => {
+        await equipBatch(warriorItems, true);
+      });
+
       promisesToAwait.push(equipPromises);
     }
 
@@ -128,7 +124,9 @@ async function fight(target) {
       reduce_cooldown("attack", Math.min(...parent.pings));
     } catch (e) {
       // Handle any errors from the combined promises here
-      console.error("An error occurred during attack or equip:", e);
+      if (e.failed && e.response !== "cooldown") {
+        reduce_cooldown("attack", -e.ms);
+      }
     }
     if (
       character.mp > G.skills["warcry"].mp &&
@@ -248,9 +246,9 @@ async function mainLoop() {
 
     if (
       smart.moving ||
-      is_on_cooldown("attack") ||
+      ms_to_next_skill("attack") > 50 ||
       distance(character, get_targeted_monster()) >
-        character.range + character.xrange
+        character.range + character.xrange * 1.1
     )
       await warriorCleave(
         currentStrategy === usePullStrategies ? "pull" : "normal",
@@ -296,7 +294,7 @@ async function mainLoop() {
           y: mapY,
         });
       }
-    } else fight(target);
+    } else await fight(target);
   } catch (e) {
     console.error(e);
   }

--- a/basic_warrior.9.js
+++ b/basic_warrior.9.js
@@ -38,6 +38,8 @@ const bosses = {
 // Main fight function
 async function fight(target) {
   const blastRadius = character.explosion / 3.6 || BLAST_RADIUS;
+  const attackRange = character.range + character.xrange;
+  const inRange = (entity) => distance(entity, character) < attackRange;
 
   const haveIgnoreMobAroundTarget = (targetMob) => {
     return mobsListAroundTarget(targetMob, blastRadius).some((mob) =>
@@ -47,10 +49,6 @@ async function fight(target) {
 
   // --- Target Aggregation & Selection (usePullStrategies) ---
   if (currentStrategy === usePullStrategies) {
-    const attackRange = character.range + character.xrange;
-    const maxPullDistance =
-      attackRange * 0.9 + extraDistanceWithinHitbox(character);
-
     const aggroedMobs = Object.values(parent.entities)
       .filter((entity) => {
         return (
@@ -58,8 +56,7 @@ async function fight(target) {
           !MELEE_IGNORE_LIST.includes(entity.mtype) &&
           entity.target &&
           !haveFormidableMonsterAroundTarget(entity) &&
-          distance(entity, character) <
-            maxPullDistance + extraDistanceWithinHitbox(entity) &&
+          inRange(entity) &&
           !haveIgnoreMobAroundTarget(entity)
         );
       })
@@ -107,14 +104,8 @@ async function fight(target) {
   // --- Attack & Warcry Logic ---
   const isAttackReady =
     ms_to_next_skill("attack") === 0 && !character.s.penalty_cd;
-  const attackRange =
-    character.range +
-    character.xrange * 0.9 +
-    extraDistanceWithinHitbox(character) +
-    extraDistanceWithinHitbox(target);
-  const isTargetInAttackRange = distance(target, character) < attackRange;
 
-  if (isAttackReady && isTargetInAttackRange && shouldAttack()) {
+  if (isAttackReady && inRange(target) && shouldAttack()) {
     set_message("Attacking");
 
     // Main attack execution
@@ -127,12 +118,13 @@ async function fight(target) {
 
     // Offhand swap logic: Use Candy Canes for farming
     const shouldUseCandyCanes =
+      character.ping < 1000 &&
+      !character.s.sugarrush &&
       !isEquipingItems &&
       (character.slots.offhand?.name === "fireblade" ||
         character.slots.mainhand?.name === "fireblade") &&
       character.slots.offhand?.name !== "mshield" &&
-      character.cc < 100 &&
-      !character.s.sugarrush;
+      character.cc < 100;
 
     if (shouldUseCandyCanes) {
       const candycane1 = findMaxLevelItem("candycanesword");
@@ -141,19 +133,26 @@ async function fight(target) {
       if (candycane1 !== -1 && candycane2 !== -1) {
         isEquipingItems = true;
         const equipPromise = Promise.all([
-          equip(candycane1, "mainhand"),
-          equip(candycane2, "offhand"),
-        ])
-          .then(() =>
-            Promise.all([
-              // Swap back to proc the previous weapon effect
-              equip(candycane1, "mainhand"),
-              equip(candycane2, "offhand"),
-            ]),
-          )
-          .finally(() => {
-            isEquipingItems = false;
-          });
+          // Immediate equip
+          Promise.all([
+            equip(candycane1, "mainhand"),
+            equip(candycane2, "offhand"),
+          ]),
+
+          // Delayed re-equip
+          new Promise((resolve) => {
+            setTimeout(() => {
+              resolve(
+                Promise.all([
+                  equip(candycane1, "mainhand"),
+                  equip(candycane2, "offhand"),
+                ]),
+              );
+            }, 150);
+          }),
+        ]).finally(() => {
+          isEquipingItems = false;
+        });
 
         promisesToAwait.push(equipPromise);
       }
@@ -202,7 +201,7 @@ async function fight(target) {
   const isTanker = isAssignedAsTanker();
   const canTaunt =
     isTanker && character.mp > G.skills["taunt"].mp && !is_on_cooldown("taunt");
-  const partyHealer = get_player(HEALER);
+  const partyHealer = get_player(HEALER) || get_player(RANGER);
   const isHealerAlive = partyHealer && !partyHealer.rip;
 
   if (canTaunt && isHealerAlive) {
@@ -265,7 +264,7 @@ async function fight(target) {
 
   // --- Await and Error Handling ---
   try {
-    await withTimeout(Promise.all(promisesToAwait), 1000);
+    await withTimeout(Promise.allSettled(promisesToAwait), 1000);
   } catch (e) {
     console.error("Error while attacking", e);
   }

--- a/basic_warrior.9.js
+++ b/basic_warrior.9.js
@@ -125,13 +125,10 @@ async function fight(target) {
         equip(candycane1, "mainhand"),
         equip(candycane2, "offhand"),
       ]).then(async () => {
-        await equipBatch(
-          {
-            mainhand: warriorItems.mainhand,
-            offhand: warriorItems.offhand,
-          },
-          true,
-        );
+        await equipBatch({
+          mainhand: warriorItems.mainhand,
+          offhand: warriorItems.offhand,
+        });
       });
 
       promisesToAwait.push(equipPromises);

--- a/basic_warrior.9.js
+++ b/basic_warrior.9.js
@@ -109,29 +109,40 @@ async function fight(target) {
 
     // Offhand swap logic
     if (
+      !isEquipingItems &&
       (character.slots.offhand?.name === "fireblade" ||
         character.slots.mainhand?.name === "fireblade") &&
-      character.cc < 105 &&
+      character.slots.offhand?.name !== "mshield" &&
+      character.cc < 100 &&
       !character.s.sugarrush
     ) {
       const warriorItems = calculateWarriorItems();
       const candycane1 = findMaxLevelItem("candycanesword");
       const candycane2 = findMaxLevelItem("candycanesword", 1);
-      const equipPromises = Promise.all([
-        equip(candycane1, "mainhand"),
-        equip(candycane2, "offhand"),
-      ]).then(async () => {
-        await equipBatch({
-          mainhand: warriorItems.mainhand,
-          offhand: warriorItems.offhand,
-        });
-      });
+      if (candycane1 !== -1 && candycane2 !== -1) {
+        isEquipingItems = true;
+        const equipPromises = Promise.all([
+          Promise.all([
+            equip(candycane1, "mainhand"),
+            equip(candycane2, "offhand"),
+          ]),
+        ])
+          .then(async () => {
+            Promise.all([
+              equip(candycane1, "mainhand"),
+              equip(candycane2, "offhand"),
+            ]);
+          })
+          .finally(() => {
+            isEquipingItems = false;
+          });
 
-      promisesToAwait.push(equipPromises);
+        promisesToAwait.push(equipPromises);
+      }
     }
 
     try {
-      await withTimeout(Promise.all(promisesToAwait), 2500);
+      await withTimeout(Promise.all(promisesToAwait), 1000);
     } catch (e) {}
 
     if (
@@ -155,12 +166,12 @@ async function fight(target) {
 
   if (
     locate_item("basher") !== -1 &&
-    (Object.keys(get_party()) ?? [character])
+    (parent.party_list.length ? parent.party_list : [character])
       .map((id) => get_player(id))
       .filter((entity) => entity)
       .some((player) => player.hp < player.max_hp * 0.4)
   ) {
-    await warriorStomp();
+    warriorStomp();
   }
 
   // Taunt logic to protect allies
@@ -241,7 +252,7 @@ async function cleaveLoop() {
         currentStrategy === usePullStrategies ? "pull" : "normal",
       );
   } catch (e) {
-    console.log("Error while cleaving: " + e);
+    console.log("Error while cleaving: ", e);
   }
 
   setTimeout(cleaveLoop, Math.max(ms_to_next_skill("cleave"), 100));

--- a/basic_warrior.9.js
+++ b/basic_warrior.9.js
@@ -7,6 +7,7 @@ if (parent.caracAL) {
       "adventure-land-scripts-backup/other_class_msg_listener.8.js",
     ])
     .then(() => {
+      cleaveLoop();
       mainLoop();
     });
 } else {
@@ -90,44 +91,56 @@ async function fight(target) {
     !character.s.penalty_cd &&
     distance(target, character) <
       character.range +
-        character.xrange +
+        character.xrange * 0.9 +
         extraDistanceWithinHitbox(target) +
         extraDistanceWithinHitbox(character) &&
     shouldAttack()
   ) {
     set_message("Attacking");
     // Main attack logic
-    const promisesToAwait = [currentStrategy(target), attack(target)];
+    const promisesToAwait = [
+      currentStrategy(target),
+      withTimeout(attack(target), 2500)
+        .then(() => {
+          reduce_cooldown("attack", Math.min(...parent.pings));
+        })
+        .catch((e) => {
+          if (e.failed && e.response !== "cooldown") {
+            reduce_cooldown("attack", -e.ms);
+          }
+        }),
+    ];
 
     // Offhand swap logic
     if (
       (character.slots.offhand?.name === "fireblade" ||
         character.slots.mainhand?.name === "fireblade") &&
-      character.cc < 100 &&
-      !character.s.penalty_cd &&
+      character.cc < 105 &&
       !character.s.sugarrush
     ) {
-      isEquipingItems = true;
       const warriorItems = calculateWarriorItems();
+      const candycane1 = findMaxLevelItem("candycanesword");
+      const candycane2 = findMaxLevelItem("candycanesword", 1);
       const equipPromises = Promise.all([
-        equip(findMaxLevelItem("candycanesword"), "mainhand"),
-        equip(findMaxLevelItem("candycanesword", 1), "offhand"),
+        equip(candycane1, "mainhand"),
+        equip(candycane2, "offhand"),
       ]).then(async () => {
-        await equipBatch(warriorItems, true);
+        await equipBatch(
+          {
+            mainhand: warriorItems.mainhand,
+            offhand: warriorItems.offhand,
+          },
+          true,
+        );
       });
 
       promisesToAwait.push(equipPromises);
     }
 
     try {
-      await Promise.all(promisesToAwait);
-      reduce_cooldown("attack", Math.min(...parent.pings));
-    } catch (e) {
-      // Handle any errors from the combined promises here
-      if (e.failed && e.response !== "cooldown") {
-        reduce_cooldown("attack", -e.ms);
-      }
-    }
+      await withTimeout(Promise.all(promisesToAwait), 2500);
+    } catch (e) {}
+
     if (
       character.mp > G.skills["warcry"].mp &&
       !is_on_cooldown("warcry") &&
@@ -224,6 +237,26 @@ async function fight(target) {
 
 // Main game loop
 
+async function cleaveLoop() {
+  try {
+    if (
+      smart.moving ||
+      ms_to_next_skill("attack") > 50 ||
+      distance(character, get_targeted_monster()) >
+        character.range + character.xrange * 1.1
+    )
+      await warriorCleave(
+        currentStrategy === usePullStrategies ? "pull" : "normal",
+      );
+  } catch (e) {
+    console.log("Error while cleaving: " + e);
+  }
+
+  setTimeout(cleaveLoop, Math.max(ms_to_next_skill("cleave"), 100));
+}
+
+if (!parent.caracAL) cleaveLoop();
+
 async function mainLoop() {
   try {
     desiredElixir = isAssignedAsTanker() ? "elixirluck" : "pumpkinspice";
@@ -244,15 +277,15 @@ async function mainLoop() {
       });
     }
 
-    if (
-      smart.moving ||
-      ms_to_next_skill("attack") > 50 ||
-      distance(character, get_targeted_monster()) >
-        character.range + character.xrange * 1.1
-    )
-      await warriorCleave(
-        currentStrategy === usePullStrategies ? "pull" : "normal",
-      );
+    // if (
+    //   smart.moving ||
+    //   ms_to_next_skill("attack") > 50 ||
+    //   distance(character, get_targeted_monster()) >
+    //     character.range + character.xrange * 1.1
+    // )
+    //   await warriorCleave(
+    //     currentStrategy === usePullStrategies ? "pull" : "normal",
+    //   );
 
     if ((smart.moving || isAdvanceSmartMoving) && !smartmoveDebug)
       throw new Error("Smart moving", {
@@ -303,63 +336,3 @@ async function mainLoop() {
 }
 
 if (!parent.caracAL) mainLoop();
-
-// setInterval(async function () {
-//   assignRoles();
-
-//   buff();
-
-//   if (
-//     character.moving &&
-//     character.mp > G.skills["charge"].mp &&
-//     !is_on_cooldown("charge")
-//   ) {
-//     use_skill("charge");
-//   }
-
-//   if (character.rip) {
-//     respawn();
-//     return;
-//   }
-
-//   if (
-//     smart.moving ||
-//     is_on_cooldown("attack") ||
-//     distance(character, get_targeted_monster()) >
-//       character.range + character.xrange
-//   )
-//     await warriorCleave(
-//       currentStrategy === usePullStrategies ? "pull" : "normal"
-//     );
-
-//   if ((smart.moving || isAdvanceSmartMoving) && !smartmoveDebug) return;
-
-//   let target = getTarget();
-
-//   // Boss handling
-//   if (goToBoss()) return;
-
-//   // Crypt & Event logic
-//   if (get("cryptInstance")) {
-//     target = await useCryptStrategy(target);
-//   } else {
-//     target = await changeToDailyEventTargets();
-//   }
-
-//   // Targeting & movement logic
-//   if (!target) {
-//     if (!smart.moving && !isAdvanceSmartMoving) {
-//       if (get("cryptInstance") && character.map !== "crypt") {
-//         changeToNormalStrategies();
-//         await advanceSmartMove(CRYPT_STARTING_LOCATION);
-//       } else if (!get("cryptInstance")) {
-//         changeToNormalStrategies();
-//         const scareInterval = setInterval(scareAwayMobs, 5000);
-//         await advanceSmartMove({ map, x: mapX, y: mapY });
-//         clearInterval(scareInterval);
-//       }
-//     }
-//   } else {
-//     await fight(target);
-//   }
-// }, loopInterval);

--- a/basic_warrior.9.js
+++ b/basic_warrior.9.js
@@ -102,36 +102,15 @@ async function fight(target) {
         character.slots.mainhand?.name === "fireblade") &&
       !isEquipingItems
     ) {
-      isEquipingItems = true;
       const warriorItems = calculateWarriorItems();
-
-      const equipPromise = equip_batch([
+      const equipPromises = equipBatch(
         {
-          slot: "mainhand",
-          num: findMaxLevelItem("candycanesword"),
+          mainhand: "candycanesword",
+          offhand: "candycanesword",
         },
-        {
-          slot: "offhand",
-          num: findMaxLevelItem("candycanesword", 1),
-        },
-      ])
-        .then(() =>
-          equip_batch([
-            {
-              slot: "mainhand",
-              num: findMaxLevelItem(warriorItems.mainhand),
-            },
-            {
-              slot: "offhand",
-              num: findMaxLevelItem(warriorItems.offhand),
-            },
-          ]),
-        )
-        .finally(() => {
-          isEquipingItems = false;
-        });
-
-      promisesToAwait.push(equipPromise);
+        true,
+      ).then(() => equipBatch(warriorItems, true));
+      promisesToAwait.push(equipPromises);
     }
 
     try {
@@ -292,14 +271,12 @@ async function mainLoop() {
         get("cryptInstance") &&
         character.map !== "crypt"
       ) {
-        changeToNormalStrategies();
         advanceSmartMove(CRYPT_STARTING_LOCATION);
       } else if (
         !smart.moving &&
         !get("cryptInstance") &&
         (partyMems[0] === character.name ||
           !get_entity(partyMems[0]) ||
-          character.map === "crypt" ||
           distance(character, { x: mapX, y: mapY, map }) > 500)
       ) {
         changeToNormalStrategies();

--- a/crypt_strategy.16 - Copy.js
+++ b/crypt_strategy.16 - Copy.js
@@ -1,0 +1,422 @@
+const DEFEATABLE_BOSSES = ["a3", "a7", "a2"];
+const SCARABLE_BOSSES = ["a3", "a7", "a2", "a8", "a5", "a4"];
+
+const VBAT_LOCATION = {
+  name: "vbat",
+  map: "crypt",
+  x: 1191,
+  y: -384.5,
+};
+
+const CRYPT_STARTING_LOCATION = {
+  map: "crypt",
+  x: 0,
+  y: -226,
+};
+
+var snowballThreshold = 10;
+var currentJunction = 0;
+const CRYPT_JUNCTION = [
+  CRYPT_STARTING_LOCATION,
+  { x: -210, y: -1085 },
+  { x: 375, y: -1085 },
+  { x: 741, y: -1085 },
+  { x: 726, y: -636 },
+  { x: 1185, y: -465 },
+  { x: 1544, y: -879 },
+  { x: 2039, y: -879 },
+  { x: 2491, y: -681 },
+  { x: 2682, y: -1100 },
+  { x: 2732, y: -1729 },
+  { x: 1997, y: -1754 },
+  { x: 1216, y: -1485 },
+  { x: 373, y: -1305 },
+];
+/**
+ * Executes the Crypt strategy, prioritizing Vbats (up to 7) then specific bosses.
+ * Manages movement, target selection, and combat reactions (taunt, absorb, snowball).
+ *
+ * @param {object} target - The current combat target (will be updated or returned).
+ * @returns {object | undefined} The updated combat target.
+ */
+async function useCryptStrategy(target) {
+  // 1. Initial Checks and Setup
+  if (!get("cryptInstance") || character.map !== "crypt") {
+    return;
+  }
+
+  // Recalculate range only if necessary (keeping this logic from original)
+  rangeRate = calculateRangeRate() ?? originRangeRate ?? basicRangeRate;
+
+  // Get current state
+  const defeatedMobs = get("cryptDefeatedMobs") ?? [];
+  const defeatedVbatsCount = defeatedMobs.filter(
+    (mtype) => mtype === "vbat",
+  ).length;
+  const defeatedBossesCount = defeatedMobs.filter(
+    (mtype) => mtype !== "vbat",
+  ).length;
+
+  // Check for Completion
+  if (
+    defeatedVbatsCount >= 7 &&
+    defeatedBossesCount >= DEFEATABLE_BOSSES.length
+  ) {
+    set("cryptInstance", undefined);
+    log("Crypt strategy complete!");
+    return;
+  }
+
+  let newTarget = target;
+
+  // 2. Vbat Phase (Prioritize up to 7 Vbats)
+  if (defeatedVbatsCount < 7) {
+    newTarget = await handleVbatPhase();
+  }
+  // 3. Boss Phase (Prioritize remaining Defeatable Bosses)
+  else {
+    newTarget = await handleBossPhase(target);
+  }
+
+  // 4. Combat Reaction and Safety Checks
+  await handleCombatReactions(newTarget);
+
+  // 5. Class-Specific Combat Skills
+  handleClassSkills(newTarget);
+
+  return newTarget;
+}
+
+// --- Helper Functions ---
+
+/**
+ * Handles the logic for the Vbat phase (collecting 7 Vbat kills).
+ * @returns {object | undefined} The selected target for this phase.
+ */
+async function handleVbatPhase() {
+  // Check if Vbat requirement is already met during current movement
+  if (
+    !get_nearest_monster({ type: "vbat" }) &&
+    distance(character, VBAT_LOCATION) < 200
+  ) {
+    const defeatedCryptMobs = get("cryptDefeatedMobs") ?? [];
+    // Add remaining vbats to reach the count of 7
+    const vbatsToAdd =
+      7 - defeatedCryptMobs.filter((mtype) => mtype === "vbat").length;
+    if (vbatsToAdd > 0) {
+      defeatedCryptMobs.push(...Array(vbatsToAdd).fill("vbat"));
+      set("cryptDefeatedMobs", defeatedCryptMobs);
+    }
+    return; // Vbat objective met at location
+  }
+
+  // Move to Vbat Location if no Vbat is near
+  if (
+    !get_nearest_monster({ type: "vbat" }) &&
+    distance(character, VBAT_LOCATION) > 200
+  ) {
+    advanceSmartMove(VBAT_LOCATION);
+    return;
+  }
+
+  // Target Selection for Vbat Phase
+  const vbatTarget = isAssignedAsTanker()
+    ? get_nearest_monster({ type: "a2" }) ||
+      get_target() ||
+      get_nearest_monster({ type: "vbat" })
+    : get_target_of(get_entity(TANKER)) ||
+      get_nearest_monster({ type: "a2" }) ||
+      get_nearest_monster({ target: TANKER }) ||
+      get_nearest_monster({ target: HEALER }) ||
+      get_nearest_monster({ target: MAGE }) ||
+      get_nearest_monster({ type: "vbat" });
+
+  // Safety check for dangerous mobs
+  if (isTooDangerous()) {
+    log("Too dangerous in Vbat phase, retreating to safer junction.");
+    advanceSmartMove(getNearestJunction());
+    return;
+  }
+
+  return vbatTarget;
+}
+
+/**
+ * Handles the logic for the Boss phase (clearing remaining defeatable bosses).
+ * @param {object} currentTarget - The current assigned target.
+ * @returns {object | undefined} The selected target for this phase.
+ */
+async function handleBossPhase(currentTarget) {
+  const lastSeenBoss = get("lastSeenDefeatableCryptBoss");
+
+  // Case 1: No current target or current target is not the last seen boss (i.e., we are searching/moving)
+  if (!currentTarget || currentTarget?.mtype !== lastSeenBoss?.mtype) {
+    if (lastSeenBoss) {
+      // Move to last seen boss location
+      await advanceSmartMove(lastSeenBoss);
+      const boss = get_nearest_monster({ type: lastSeenBoss.mtype });
+
+      if (!boss) {
+        // Boss is gone, reset and search
+        set("lastSeenDefeatableCryptBoss", undefined);
+      } else {
+        // Boss found, set as target
+        setBossLocation(boss);
+        change_target(boss);
+        return boss;
+      }
+    }
+
+    // Case 1b: Search for a new boss
+    return searchForNewBoss();
+  }
+
+  // Case 2: We are fighting the last seen boss
+  const mobsNearTarget = getMobsListNearTarget(currentTarget);
+  const elena = Object.values(parent.entities).find(
+    (entity) => entity.type === "monster" && entity.mtype === "a5",
+  );
+
+  // Safety: Retreat if non-scarable bosses are nearby
+  if (mobsNearTarget.some((mob) => !SCARABLE_BOSSES.includes(mob.mtype))) {
+    log("Non-scarable boss detected near target, retreating!");
+    advanceSmartMove(CRYPT_STARTING_LOCATION);
+    set("lastSeenDefeatableCryptBoss", undefined);
+    return;
+  }
+
+  // Elena's focus logic
+  if (elena && elena.focus === currentTarget.id) {
+    log("Elena focused on current target, switching to Elena.");
+    setBossLocation(elena);
+    change_target(elena);
+    return elena;
+  } else if (currentTarget && elena && currentTarget.mtype === elena.mtype) {
+    const elenaPartner = elena.focus ? parent.entities[elena.focus] : undefined;
+    if (elenaPartner && !elenaPartner.target) {
+      log("Elena's partner found and untargeted, switching to partner.");
+      setBossLocation(elenaPartner);
+      change_target(elenaPartner);
+      return elenaPartner;
+    }
+  }
+
+  // Default: Continue targeting the current boss
+  setBossLocation(currentTarget);
+  return currentTarget;
+}
+
+/**
+ * Searches for a nearby defeatable boss that doesn't have too many mobs nearby.
+ * Moves through junctions if no boss is found immediately.
+ * @returns {object | undefined} The found boss or undefined.
+ */
+function searchForNewBoss() {
+  return new Promise(async (resolve) => {
+    const checkBossInterval = setInterval(() => {
+      const nearbyBoss = Object.values(parent.entities).find(
+        (mob) =>
+          mob.type === "monster" &&
+          DEFEATABLE_BOSSES.includes(mob.mtype) &&
+          getMobsListNearTarget(mob).length < 2,
+      );
+
+      if (nearbyBoss) {
+        log(`Found new boss: ${nearbyBoss.mtype}`);
+        setBossLocation(nearbyBoss);
+        change_target(nearbyBoss);
+        clearInterval(checkBossInterval);
+        resolve(nearbyBoss);
+      }
+    }, 2000);
+
+    // Advance to the next junction while searching
+    await advanceSmartMove(
+      CRYPT_JUNCTION[currentJunction++ % CRYPT_JUNCTION.length],
+    ).then(() => {
+      clearInterval(checkBossInterval);
+      // This is necessary because the advanceSmartMove might finish before the interval finds a target
+      // and we need to ensure the promise resolves. If a boss was found, it already resolved.
+      // If no boss was found during the movement, we resolve with undefined.
+      if (!get("lastSeenDefeatableCryptBoss")) resolve(undefined);
+    });
+  });
+}
+
+/**
+ * Helper to check for dangerous conditions (too many non-scarable bosses or too many total mobs).
+ * @returns {boolean} True if the situation is deemed too dangerous.
+ */
+function isTooDangerous() {
+  const nearestKillableBosses = Object.values(parent.entities).filter(
+    (mob) =>
+      mob.type === "monster" &&
+      DEFEATABLE_BOSSES.includes(mob.mtype) &&
+      distance(character, mob) < 200,
+  );
+
+  const partyPriest = get_player(HEALER);
+
+  // const nearestFormidableBosses = Object.values(parent.entities).filter(
+  //   (mob) =>
+  //     mob.type === "monster" &&
+  //     !mob.s.sleeping &&
+  //     ![...SCARABLE_BOSSES, "vbat"].includes(mob.mtype) &&
+  //     distance(character, mob) < 300,
+  // );
+
+  // Retreat if formidable bosses exist OR if too many killable bosses are present
+  return (
+    nearestFormidableBosses.length > 0 ||
+    avgPartyDmgTaken() > (partyPriest?.heal ?? 500)
+  );
+}
+
+/**
+ * Gets the safest junction to retreat to (the farthest one).
+ * @returns {object} The location object of the safest junction.
+ */
+function getNearestJunction() {
+  return CRYPT_JUNCTION.sort(
+    (lhs, rhs) => distance(character, lhs) - distance(character, rhs),
+  ).pop();
+}
+
+/**
+ * Sets the last seen boss in global state.
+ * @param {object} boss - The monster entity.
+ */
+function setBossLocation(boss) {
+  if (!boss) return;
+  set("lastSeenDefeatableCryptBoss", {
+    mtype: boss.mtype,
+    x: boss.x,
+    y: boss.y,
+    map: character.map,
+  });
+}
+
+/**
+ * Handles emergency combat reactions like scaring away mobs or retreating.
+ * @param {object} currentTarget - The current target.
+ */
+async function handleCombatReactions(currentTarget) {
+  const isOverwhelmed =
+    listOfMonsterAttacking(character).length >
+      (currentStrategy === usePullStrategies ? 4 : 1) ||
+    character.hp < character.max_hp * 0.6;
+
+  if (isOverwhelmed) {
+    log("Overwhelmed or low HP, scaring away mobs!");
+    await scareAwayMobs();
+
+    if (!get_entity(HEALER)) {
+      advanceSmartMove(CRYPT_STARTING_LOCATION);
+    }
+  }
+
+  // Switch strategies based on target type
+  if (currentTarget?.mtype === "vbat") {
+    changeToPullStrategies();
+  } else {
+    changeToNormalStrategies();
+  }
+}
+
+/**
+ * Handles class-specific skills (Snowball, Taunt, Absorb).
+ * @param {object} target - The current combat target.
+ */
+function handleClassSkills(target) {
+  const mobTargetingAlly = Object.values(parent.entities).find((mob) => {
+    return (
+      [...DEFEATABLE_BOSSES, "vbat"].includes(mob.mtype) &&
+      partyMems.includes(mob.target) &&
+      mob.target !== character.name
+    );
+  });
+
+  switch (character.ctype) {
+    case "warrior":
+      handleWarriorSkills(target, mobTargetingAlly);
+      break;
+    case "priest":
+      handlePriestSkills(mobTargetingAlly);
+      break;
+    case "mage":
+      break;
+    default:
+      break;
+  }
+}
+
+function handleWarriorSkills(target, mobTargetingAlly) {
+  // Snowball logic
+  if (
+    target &&
+    (target.mtype === "a2" ||
+      ![...DEFEATABLE_BOSSES, "vbat"].includes(target.mtype)) &&
+    (!target.s?.frozen || target.s.frozen.ms < 300) &&
+    locate_item("snowball") !== -1 &&
+    is_in_range(target, "snowball") &&
+    !is_on_cooldown("snowball")
+  ) {
+    if (snowballThreshold < 0) {
+      use_skill("snowball", target);
+      snowballThreshold = 10;
+    } else {
+      snowballThreshold--;
+    }
+  }
+
+  // Taunt logic
+  if (
+    isAssignedAsTanker() &&
+    character.mp > G.skills["taunt"].mp &&
+    !is_on_cooldown("taunt") &&
+    mobTargetingAlly &&
+    character.hp > character.max_hp * 0.4
+  ) {
+    use_skill("taunt", mobTargetingAlly).then(() =>
+      reduce_cooldown("taunt", character.ping * 0.95),
+    );
+  }
+}
+
+function handlePriestSkills(mobTargetingAlly) {
+  // Absorb for party
+  const lowHpMember = partyMems
+    .map((id) => get_entity(id))
+    .filter((char) => char)
+    .find((char) => char.hp < char.max_hp * 0.3);
+
+  const absorbTarget =
+    isAssignedAsTanker() && mobTargetingAlly
+      ? get_player(mobTargetingAlly.target) // Absorb for ally tanked by mob
+      : lowHpMember; // Absorb for lowest HP member
+
+  if (
+    absorbTarget &&
+    is_in_range(absorbTarget, "absorb") &&
+    character.mp > G.skills["absorb"].mp &&
+    !is_on_cooldown("absorb")
+  ) {
+    use_skill("absorb", absorbTarget);
+  }
+}
+
+function addToDefeatedList(mobs) {
+  const defeatedCryptMobs = get("cryptDefeatedMobs");
+  defeatedCryptMobs.push(...mobs);
+  set("cryptDefeatedMobs", defeatedCryptMobs);
+}
+
+character.on("target_hit", (data) => {
+  if (data.kill) {
+    const target = parent.entities[data?.target]?.mtype;
+    if ([...DEFEATABLE_BOSSES, "vbat"].includes(target)) {
+      addToDefeatedList([target]);
+      set("lastSeenDefeatableCryptBoss", undefined);
+    }
+  }
+});

--- a/crypt_strategy.16.js
+++ b/crypt_strategy.16.js
@@ -38,7 +38,7 @@ function getMobsListNearTarget(mob) {
     (othermob) =>
       othermob.type === "monster" &&
       othermob.mtype !== mob.mtype &&
-      distance(othermob, mob) < 250,
+      distance(othermob, mob) < 250
   );
 }
 
@@ -81,22 +81,22 @@ async function useCryptStrategy(target) {
       (mobs) =>
         mobs.type === "monster" &&
         defeatableBosses.includes(mobs.mtype) &&
-        distance(character, mobs) < 200,
+        distance(character, mobs) < 200
     );
 
     const nearestFormiddableBosses = Object.values(parent.entities).filter(
       (mobs) =>
         mobs.type === "monster" &&
         ![...scarableBosses, "vbat"].includes(mobs.mtype) &&
-        distance(character, mobs) < 300,
+        distance(character, mobs) < 300
     );
 
     if (nearestFormiddableBosses.length || nearestKillableBosses.length > 2) {
       log("Too dangerous");
       await advanceSmartMove(
         CRYPT_JUNCTION.sort(
-          (lhs, rhs) => distance(character, rhs) - distance(character, lhs),
-        ).pop(),
+          (lhs, rhs) => distance(character, rhs) - distance(character, lhs)
+        ).pop()
       );
     } else {
       if (
@@ -137,7 +137,7 @@ async function useCryptStrategy(target) {
             (mob) =>
               mob.type === "monster" &&
               defeatableBosses.includes(mob.mtype) &&
-              getMobsListNearTarget(mob).length < 1,
+              getMobsListNearTarget(mob).length < 1
           );
           if (nearbyBoss.length) {
             set("lastSeenDefeatableCryptBoss", {
@@ -153,7 +153,7 @@ async function useCryptStrategy(target) {
           }
         }, 2000);
         await advanceSmartMove(
-          CRYPT_JUNCTION[currentJunction++ % CRYPT_JUNCTION.length],
+          CRYPT_JUNCTION[currentJunction++ % CRYPT_JUNCTION.length]
         );
       }
     } else {
@@ -163,7 +163,7 @@ async function useCryptStrategy(target) {
         otherBossNearCurrentTarget.length >
           (currentTarget.mtype === "a5" ? 2 : 1) ||
         otherBossNearCurrentTarget.some(
-          (mob) => !defeatableBosses.includes(mob.mtype),
+          (mob) => !defeatableBosses.includes(mob.mtype)
         )
       ) {
         await advanceSmartMove(CRYPT_STARTING_LOCATION);
@@ -205,6 +205,14 @@ async function useCryptStrategy(target) {
   if (get_targeted_monster()?.mtype === "vbat") changeToPullStrategies;
   else changeToNormalStrategies();
 
+  const mobTargetingAlly = Object.values(parent.entities).find((mob) => {
+    return (
+      [...defeatableBosses, "vbat"].includes(mob.mtype) &&
+      partyMems.includes(mob.target) &&
+      mob.target !== character.name
+    );
+  });
+
   switch (character.ctype) {
     case "warrior":
       if (
@@ -224,14 +232,6 @@ async function useCryptStrategy(target) {
         }
       }
 
-      const mobTargetingAlly = Object.values(parent.entities).find((mob) => {
-        return (
-          [...defeatableBosses, "vbat"].includes(mob.mtype) &&
-          partyMems.includes(mob.target) &&
-          mob.target !== character.name
-        );
-      });
-
       if (
         character.name === TANKER &&
         character.mp > G.skills["taunt"].mp &&
@@ -240,12 +240,22 @@ async function useCryptStrategy(target) {
         character.hp > character.max_hp * 0.4
       )
         use_skill("taunt", mobTargetingAlly).then(() =>
-          reduce_cooldown("taunt", character.ping * 0.95),
+          reduce_cooldown("taunt", character.ping * 0.95)
         );
 
       break;
 
     case "priest":
+      if (character.name === TANKER && mobTargetingAlly) {
+        const allyToAbsorb = get_player(mobTargetingAlly.target);
+        if (
+          allyToAbsorb &&
+          is_in_range(allyToAbsorb, "absorb") &&
+          character.mp > G.skills["absorb"].mp &&
+          !is_on_cooldown("absorb")
+        )
+          use_skill("absorb", allyToAbsorb);
+      }
       const lowHpMember = partyMems
         .map((id) => get_entity(id))
         .filter((char) => char)

--- a/crypt_strategy.16.js
+++ b/crypt_strategy.16.js
@@ -38,7 +38,7 @@ function getMobsListNearTarget(mob) {
     (othermob) =>
       othermob.type === "monster" &&
       othermob.mtype !== mob.mtype &&
-      distance(othermob, mob) < 250
+      distance(othermob, mob) < 250,
   );
 }
 
@@ -65,38 +65,37 @@ async function useCryptStrategy(target) {
       await advanceSmartMove(VBAT_LOCATION);
     }
 
-    const vbat =
-      character.name === TANKER
-        ? get_nearest_monster({ type: "a2" }) ||
-          get_targeted_monster() ||
-          get_nearest_monster({ type: "vbat" })
-        : get_nearest_monster({ type: "a2" }) ||
-          get_target_of(get_entity(TANKER)) ||
-          get_nearest_monster({ target: TANKER }) ||
-          get_nearest_monster({ target: HEALER }) ||
-          get_nearest_monster({ target: MAGE }) ||
-          get_nearest_monster({ type: "vbat" });
+    const vbat = isAssignedAsTanker()
+      ? get_nearest_monster({ type: "a2" }) ||
+        get_targeted_monster() ||
+        get_nearest_monster({ type: "vbat" })
+      : get_nearest_monster({ type: "a2" }) ||
+        get_target_of(get_entity(TANKER)) ||
+        get_nearest_monster({ target: TANKER }) ||
+        get_nearest_monster({ target: HEALER }) ||
+        get_nearest_monster({ target: MAGE }) ||
+        get_nearest_monster({ type: "vbat" });
 
     const nearestKillableBosses = Object.values(parent.entities).filter(
       (mobs) =>
         mobs.type === "monster" &&
         defeatableBosses.includes(mobs.mtype) &&
-        distance(character, mobs) < 200
+        distance(character, mobs) < 200,
     );
 
     const nearestFormiddableBosses = Object.values(parent.entities).filter(
       (mobs) =>
         mobs.type === "monster" &&
         ![...scarableBosses, "vbat"].includes(mobs.mtype) &&
-        distance(character, mobs) < 300
+        distance(character, mobs) < 300,
     );
 
     if (nearestFormiddableBosses.length || nearestKillableBosses.length > 2) {
       log("Too dangerous");
       await advanceSmartMove(
         CRYPT_JUNCTION.sort(
-          (lhs, rhs) => distance(character, rhs) - distance(character, lhs)
-        ).pop()
+          (lhs, rhs) => distance(character, rhs) - distance(character, lhs),
+        ).pop(),
       );
     } else {
       if (
@@ -137,7 +136,7 @@ async function useCryptStrategy(target) {
             (mob) =>
               mob.type === "monster" &&
               defeatableBosses.includes(mob.mtype) &&
-              getMobsListNearTarget(mob).length < 1
+              getMobsListNearTarget(mob).length < 1,
           );
           if (nearbyBoss.length) {
             set("lastSeenDefeatableCryptBoss", {
@@ -153,7 +152,7 @@ async function useCryptStrategy(target) {
           }
         }, 2000);
         await advanceSmartMove(
-          CRYPT_JUNCTION[currentJunction++ % CRYPT_JUNCTION.length]
+          CRYPT_JUNCTION[currentJunction++ % CRYPT_JUNCTION.length],
         );
       }
     } else {
@@ -163,7 +162,7 @@ async function useCryptStrategy(target) {
         otherBossNearCurrentTarget.length >
           (currentTarget.mtype === "a5" ? 2 : 1) ||
         otherBossNearCurrentTarget.some(
-          (mob) => !defeatableBosses.includes(mob.mtype)
+          (mob) => !defeatableBosses.includes(mob.mtype),
         )
       ) {
         await advanceSmartMove(CRYPT_STARTING_LOCATION);
@@ -233,20 +232,20 @@ async function useCryptStrategy(target) {
       }
 
       if (
-        character.name === TANKER &&
+        isAssignedAsTanker() &&
         character.mp > G.skills["taunt"].mp &&
         !is_on_cooldown("taunt") &&
         mobTargetingAlly &&
         character.hp > character.max_hp * 0.4
       )
         use_skill("taunt", mobTargetingAlly).then(() =>
-          reduce_cooldown("taunt", character.ping * 0.95)
+          reduce_cooldown("taunt", character.ping * 0.95),
         );
 
       break;
 
     case "priest":
-      if (character.name === TANKER && mobTargetingAlly) {
+      if (isAssignedAsTanker() && mobTargetingAlly) {
         const allyToAbsorb = get_player(mobTargetingAlly.target);
         if (
           allyToAbsorb &&

--- a/crypt_strategy.16.js
+++ b/crypt_strategy.16.js
@@ -69,8 +69,8 @@ async function useCryptStrategy(target) {
       ? get_nearest_monster({ type: "a2" }) ||
         get_targeted_monster() ||
         get_nearest_monster({ type: "vbat" })
-      : get_nearest_monster({ type: "a2" }) ||
-        get_target_of(get_entity(TANKER)) ||
+      : get_target_of(get_entity(TANKER)) ||
+        get_nearest_monster({ type: "a2" }) ||
         get_nearest_monster({ target: TANKER }) ||
         get_nearest_monster({ target: HEALER }) ||
         get_nearest_monster({ target: MAGE }) ||

--- a/crypt_strategy.16.js
+++ b/crypt_strategy.16.js
@@ -45,11 +45,11 @@ function getMobsListNearTarget(mob) {
 async function useCryptStrategy(target) {
   if (!get("cryptInstance") || character.map !== "crypt") return;
   rangeRate = calculateRangeRate() ?? originRangeRate ?? basicRangeRate;
-  const defeatedCrybtMobs = get("cryptDefeatedMobs") ?? [];
+  const defeatedCryptMobs = get("cryptDefeatedMobs") ?? [];
 
   if (
-    defeatedCrybtMobs.filter((mtype) => mtype === "vbat").length >= 7 &&
-    defeatedCrybtMobs.filter((mtype) => mtype !== "vbat").length >=
+    defeatedCryptMobs.filter((mtype) => mtype === "vbat").length >= 7 &&
+    defeatedCryptMobs.filter((mtype) => mtype !== "vbat").length >=
       defeatableBosses.length
   ) {
     set("cryptInstance", undefined);
@@ -57,12 +57,12 @@ async function useCryptStrategy(target) {
   }
 
   // Check for 7 vbats
-  if (defeatedCrybtMobs.filter((mtype) => mtype === "vbat").length < 7) {
+  if (defeatedCryptMobs.filter((mtype) => mtype === "vbat").length < 7) {
     if (
       !get_nearest_monster({ type: "vbat" }) &&
-      !get_nearest_monster({ type: "a2" })
+      distance(character, VBAT_LOCATION) > 200
     ) {
-      await advanceSmartMove(VBAT_LOCATION);
+      advanceSmartMove(VBAT_LOCATION);
     }
 
     const vbat = isAssignedAsTanker()
@@ -86,13 +86,14 @@ async function useCryptStrategy(target) {
     const nearestFormiddableBosses = Object.values(parent.entities).filter(
       (mobs) =>
         mobs.type === "monster" &&
+        !mobs.s.sleeping &&
         ![...scarableBosses, "vbat"].includes(mobs.mtype) &&
         distance(character, mobs) < 300,
     );
 
-    if (nearestFormiddableBosses.length || nearestKillableBosses.length > 2) {
+    if (nearestFormiddableBosses.length || nearestKillableBosses.length > 3) {
       log("Too dangerous");
-      await advanceSmartMove(
+      advanceSmartMove(
         CRYPT_JUNCTION.sort(
           (lhs, rhs) => distance(character, rhs) - distance(character, lhs),
         ).pop(),
@@ -103,8 +104,8 @@ async function useCryptStrategy(target) {
         distance(character, VBAT_LOCATION) < 200
       ) {
         // const defeatedCryptMobs = get("cryptDefeatedMobs");
-        // defeatedCryptMobs.push(...Array(7).fill("vbat"));
-        // set("cryptDefeatedMobs", defeatedCryptMobs);
+        defeatedCryptMobs.push(...Array(7).fill("vbat"));
+        set("cryptDefeatedMobs", defeatedCryptMobs);
       } else target = vbat;
     }
   }
@@ -136,7 +137,7 @@ async function useCryptStrategy(target) {
             (mob) =>
               mob.type === "monster" &&
               defeatableBosses.includes(mob.mtype) &&
-              getMobsListNearTarget(mob).length < 1,
+              getMobsListNearTarget(mob).length < 2,
           );
           if (nearbyBoss.length) {
             set("lastSeenDefeatableCryptBoss", {
@@ -148,37 +149,53 @@ async function useCryptStrategy(target) {
             change_target(nearbyBoss[0]);
             target = nearbyBoss[0];
             clearInterval(checkBossInterval);
-            stop("smart");
+            stop();
           }
         }, 2000);
-        await advanceSmartMove(
+        advanceSmartMove(
           CRYPT_JUNCTION[currentJunction++ % CRYPT_JUNCTION.length],
-        );
+        ).then(() => clearInterval(checkBossInterval));
       }
     } else {
       const otherBossNearCurrentTarget = getMobsListNearTarget(currentTarget);
+      const elena = Object.values(parent.entities).find(
+        (entity) => entity.type === "monster" && entity.mtype === "a5",
+      );
 
       if (
-        otherBossNearCurrentTarget.length >
-          (currentTarget.mtype === "a5" ? 2 : 1) ||
         otherBossNearCurrentTarget.some(
-          (mob) => !defeatableBosses.includes(mob.mtype),
+          (mob) => !scarableBosses.includes(mob.mtype),
         )
       ) {
-        await advanceSmartMove(CRYPT_STARTING_LOCATION);
+        advanceSmartMove(CRYPT_STARTING_LOCATION);
         set("lastSeenDefeatableCryptBoss", undefined);
-      } else if (
-        otherBossNearCurrentTarget.length === 1 &&
-        otherBossNearCurrentTarget[0]?.mtype === "a5"
-      ) {
+      } else if (elena && elena.focus === currentTarget.id) {
         set("lastSeenDefeatableCryptBoss", {
-          mtype: otherBossNearCurrentTarget[0]?.mtype,
-          x: otherBossNearCurrentTarget[0]?.x,
-          y: otherBossNearCurrentTarget[0]?.y,
+          mtype: elena.mtype,
+          x: elena.x,
+          y: elena.y,
           map: character.map,
         });
-        change_target(otherBossNearCurrentTarget[0]);
-        target = otherBossNearCurrentTarget;
+        change_target(elena);
+        target = elena;
+      } else if (
+        currentTarget &&
+        elena &&
+        currentTarget.mtype === elena.mtype
+      ) {
+        const elenaPartner = elena.focus
+          ? parent.entities[elena.focus]
+          : undefined;
+        if (elenaPartner && !elenaPartner.target) {
+          set("lastSeenDefeatableCryptBoss", {
+            mtype: elenaPartner.mtype,
+            x: elenaPartner.x,
+            y: elenaPartner.y,
+            map: character.map,
+          });
+          change_target(elenaPartner);
+          target = elenaPartner;
+        }
       } else {
         set("lastSeenDefeatableCryptBoss", {
           mtype: currentTarget?.mtype,
@@ -193,16 +210,17 @@ async function useCryptStrategy(target) {
 
   if (
     listOfMonsterAttacking(character).length >
-      (character.ctype === "warrior" ? 1 : 0) ||
+      (currentStrategy === usePullStrategies ? 4 : 1) ||
     character.hp < character.max_hp * 0.6
   ) {
     await scareAwayMobs();
 
-    if (!get_entity(HEALER)) await advanceSmartMove(CRYPT_STARTING_LOCATION);
+    if (!get_entity(HEALER)) advanceSmartMove(CRYPT_STARTING_LOCATION);
   }
 
-  if (get_targeted_monster()?.mtype === "vbat") changeToPullStrategies;
+  if (get_targeted_monster()?.mtype === "vbat") changeToPullStrategies();
   else changeToNormalStrategies();
+  // changeToPullStrategies();
 
   const mobTargetingAlly = Object.values(parent.entities).find((mob) => {
     return (
@@ -279,13 +297,17 @@ async function useCryptStrategy(target) {
   return target;
 }
 
+function addToDefeatedList(mobs) {
+  const defeatedCryptMobs = get("cryptDefeatedMobs");
+  defeatedCryptMobs.push(...mobs);
+  set("cryptDefeatedMobs", defeatedCryptMobs);
+}
+
 character.on("target_hit", (data) => {
   if (data.kill) {
     const target = parent.entities[data?.target]?.mtype;
-    if (defeatableBosses.includes(target) || target === "vbat") {
-      const defeatedCryptMobs = get("cryptDefeatedMobs");
-      defeatedCryptMobs.push(target);
-      set("cryptDefeatedMobs", defeatedCryptMobs);
+    if ([...defeatableBosses, "vbat"].includes(target)) {
+      addToDefeatedList([target]);
       set("lastSeenDefeatableCryptBoss", undefined);
     }
   }

--- a/merchant_crafting.10.js
+++ b/merchant_crafting.10.js
@@ -228,6 +228,9 @@ async function compoundInv() {
       }
 
       const scrollType = `cscroll${itemGrade}`;
+      if (getItemBankSlots(scrollType)) {
+        await retrieveBankItem(scrollType);
+      }
       let scrollSlot = locate_item(scrollType);
       if (scrollSlot === -1) {
         if (itemGrade >= 2 && character.gold < IGNORE_RARE_GOLD_THRESHOLD)
@@ -320,7 +323,7 @@ async function upgradeInv() {
     if (itemInfo.upgrade) {
       if (
         (character.items[i]?.level > maxUpgrade || itemGrade >= 2) &&
-        character.items[i]?.level >= ITEMS_HIGHEST_LEVEL[itemName].level
+        character.items[i]?.level >= (ITEMS_HIGHEST_LEVEL[itemName]?.level ?? 0)
       )
         if (
           !(
@@ -343,6 +346,9 @@ async function upgradeInv() {
       }
 
       const scrollType = `scroll${itemGrade}`;
+      if (getItemBankSlots(scrollType)) {
+        await retrieveBankItem(scrollType);
+      }
       let scrollSlot = locate_item(scrollType);
       if (scrollSlot === -1) {
         if (itemGrade >= 2 && character.gold < IGNORE_RARE_GOLD_THRESHOLD)

--- a/merchant_crafting.10.js
+++ b/merchant_crafting.10.js
@@ -6,7 +6,7 @@ if (parent.caracAL) {
   load_code(7);
 }
 
-let BANK_CACHE = undefined;
+var BANK_CACHE = undefined;
 const bankPosition = { map: "bank", x: 0, y: -280 };
 
 const IGNORE_RARE_GOLD_THRESHOLD = 50e8;
@@ -45,11 +45,11 @@ async function retrieveBankItem(searchId, level = 0) {
   }
 
   for (const [bankPack, items] of Object.entries(character.bank).filter(
-    ([key, value]) => key !== "gold"
+    ([key, value]) => key !== "gold",
   )) {
     const slot = items.findIndex(
       (item) =>
-        item && item.name === searchId && (!level || level === item.level)
+        item && item.name === searchId && (!level || level === item.level),
     );
     if (slot !== -1) {
       return bank_retrieve(bankPack, slot).then(
@@ -64,7 +64,7 @@ async function retrieveMaxItemsLevel() {
 
   // Reset counter;
   Object.keys(ITEMS_HIGHEST_LEVEL).forEach(
-    (key) => delete ITEMS_HIGHEST_LEVEL[key]
+    (key) => delete ITEMS_HIGHEST_LEVEL[key],
   );
 
   BANK_CACHE = character.bank;
@@ -164,7 +164,7 @@ function retrievedBankItemToUpgrade() {
   desiredItems = desiredItems.splice(
     0,
     desiredItems.length -
-      (KEEP_THRESHOLD[ITEMS_HIGHEST_LEVEL[desiredItemId].type] ?? 2)
+      (KEEP_THRESHOLD[ITEMS_HIGHEST_LEVEL[desiredItemId].type] ?? 2),
   );
 
   let inventoryEmptySlots = character.items.filter((item) => !item).length - 4;
@@ -220,11 +220,8 @@ async function compoundInv() {
         if (
           ITEMS_HIGHEST_LEVEL[itemName] &&
           ITEMS_HIGHEST_LEVEL[itemName].quantity <
-            (KEEP_THRESHOLD[
-              ITEMS_HIGHEST_LEVEL[itemName].type
-            ] + 3 ?? 5) &&
-          character.items[i].level ===
-            ITEMS_HIGHEST_LEVEL[itemName].level
+            (KEEP_THRESHOLD[ITEMS_HIGHEST_LEVEL[itemName].type] + 3 ?? 5) &&
+          character.items[i].level === ITEMS_HIGHEST_LEVEL[itemName].level
         ) {
           continue;
         }
@@ -287,7 +284,7 @@ async function compoundInv() {
             scrollSlot,
             isRareItem && locate_item("offeringp") !== -1
               ? locate_item("offeringp")
-              : undefined
+              : undefined,
           )
             .then(() => {
               breakFlag = true;
@@ -390,7 +387,7 @@ async function upgradeInv() {
           scrollSlot,
           isRareItem && locate_item("offeringp") !== -1
             ? locate_item("offeringp")
-            : undefined
+            : undefined,
         )
           .then(async (e) => {
             if (e?.success === true) {
@@ -404,7 +401,7 @@ async function upgradeInv() {
               if (e?.level >= ITEMS_HIGHEST_LEVEL[itemName].level - 1 ?? 0) {
                 close_stand();
                 smart_move(bankPosition).then(() =>
-                  bank_store(findMaxLevelItem(itemName))
+                  bank_store(findMaxLevelItem(itemName)),
                 );
               }
             }
@@ -426,7 +423,7 @@ if (Object.keys(ITEMS_HIGHEST_LEVEL).length === 0) {
     retrievedBankItemToUpgrade();
   });
 }
-setInterval(() => {
+setInterval(async () => {
   if (
     character.map === "main" &&
     !onDuty &&
@@ -445,38 +442,38 @@ setInterval(() => {
   ) {
     onDuty = true;
     close_stand();
-    smart_move(bankPosition).then(() => {
-      character.items.forEach((item, index) => {
-        if (!item) return;
-        const isRareItem = item_grade(item) >= 2;
-        const isHighLevelItem =
-          item?.level >= (ITEMS_HIGHEST_LEVEL[item.name]?.level ?? 1) - 1;
+    await smart_move(bankPosition);
+    BANK_CACHE = character.bank;
+    character.items.forEach((item, index) => {
+      if (!item) return;
+      const isRareItem = item_grade(item) >= 2;
+      const isHighLevelItem =
+        item?.level >= (ITEMS_HIGHEST_LEVEL[item.name]?.level ?? 1) - 1;
 
-        const isStoreable = STORE_ABLE.includes(item.name);
-        const isEquipable = item_info(item).compound || item_info(item).upgrade;
-        const shouldItemBeIgnore = IGNORE.includes(item.name);
+      const isStoreable = STORE_ABLE.includes(item.name);
+      const isEquipable = item_info(item).compound || item_info(item).upgrade;
+      const shouldItemBeIgnore = IGNORE.includes(item.name);
 
-        if (
-          item &&
-          ((!shouldItemBeIgnore &&
-            (isRareItem || (isEquipable && isHighLevelItem))) ||
-            isStoreable ||
-            RETRIEVE_HISTORY?.[RETRIEVE_HISTORY.length - 1] === item?.name)
-        )
-          bank_store(index);
-      });
-      retrieveMaxItemsLevel();
-      retrievedBankItemToUpgrade();
-
-      if (parent.S.egghunt) {
-        for (let index = 0; index < 9; index++) {
-          retrieveBankItem(`egg${index}`);
-        }
-      }
-
-      retrieveBankItem("gemfragment");
-
-      onDuty = false;
+      if (
+        item &&
+        ((!shouldItemBeIgnore &&
+          (isRareItem || (isEquipable && isHighLevelItem))) ||
+          isStoreable ||
+          RETRIEVE_HISTORY?.[RETRIEVE_HISTORY.length - 1] === item?.name)
+      )
+        bank_store(index);
     });
+    retrieveMaxItemsLevel();
+    retrievedBankItemToUpgrade();
+
+    if (parent.S.egghunt) {
+      for (let index = 0; index < 9; index++) {
+        retrieveBankItem(`egg${index}`);
+      }
+    }
+
+    retrieveBankItem("gemfragment");
+
+    onDuty = false;
   }
 }, 120000);

--- a/merchant_crafting.10.js
+++ b/merchant_crafting.10.js
@@ -9,7 +9,7 @@ if (parent.caracAL) {
 var BANK_CACHE = undefined;
 const bankPosition = { map: "bank", x: 0, y: -280 };
 
-const IGNORE_RARE_GOLD_THRESHOLD = 50e8;
+const IGNORE_RARE_GOLD_THRESHOLD = 40e8;
 
 const KEEP_THRESHOLD = {
   // Every character needs
@@ -38,6 +38,8 @@ const ITEMS_HIGHEST_LEVEL = {};
 const RETRIEVE_HISTORY = [];
 
 async function retrieveBankItem(searchId, level = 0) {
+  if (smart.moving) return;
+
   if (character.map !== "bank") {
     close_stand();
     await smart_move(bankPosition);
@@ -228,7 +230,11 @@ async function compoundInv() {
       }
 
       const scrollType = `cscroll${itemGrade}`;
-      if (getItemBankSlots(scrollType)) {
+      if (
+        !character.c.fishing &&
+        !character.c.mining &&
+        getItemBankSlots(scrollType).length > 0
+      ) {
         await retrieveBankItem(scrollType);
       }
       let scrollSlot = locate_item(scrollType);
@@ -346,7 +352,11 @@ async function upgradeInv() {
       }
 
       const scrollType = `scroll${itemGrade}`;
-      if (getItemBankSlots(scrollType)) {
+      if (
+        !character.c.fishing &&
+        !character.c.mining &&
+        getItemBankSlots(scrollType).length > 0
+      ) {
         await retrieveBankItem(scrollType);
       }
       let scrollSlot = locate_item(scrollType);

--- a/merchant_crafting.10.js
+++ b/merchant_crafting.10.js
@@ -355,7 +355,8 @@ async function upgradeInv() {
       if (
         !character.c.fishing &&
         !character.c.mining &&
-        getItemBankSlots(scrollType).length > 0
+        getItemBankSlots(scrollType).length > 0 &&
+        character.esize
       ) {
         await retrieveBankItem(scrollType);
       }

--- a/normal_strategy.12.js
+++ b/normal_strategy.12.js
@@ -1,7 +1,5 @@
 async function useNormalStrategy(target) {
-  const partyHealer = get_entity(HEALER);
-  const partyTanker = get_entity(TANKER);
-
+  const promises = [];
   switch (character.ctype) {
     case "mage":
       const suggestedMageItems = calculateMageItems(target);
@@ -11,7 +9,7 @@ async function useNormalStrategy(target) {
           (slot) => character.slots[slot]?.name !== suggestedMageItems[slot],
         )
       ) {
-        await equipBatch(suggestedMageItems);
+        promises.push(equipBatch(suggestedMageItems));
       }
 
       if (
@@ -23,7 +21,7 @@ async function useNormalStrategy(target) {
             entity.type === "monster" && entity.target === character.name,
         )
       )
-        scareAwayMobs();
+        promises.push(scareAwayMobs());
 
       break;
 
@@ -35,7 +33,7 @@ async function useNormalStrategy(target) {
           (slot) => character.slots[slot]?.name !== suggestedWarriorItems[slot],
         )
       ) {
-        await equipBatch(suggestedWarriorItems);
+        promises.push(equipBatch(suggestedWarriorItems));
       }
       break;
 
@@ -47,7 +45,7 @@ async function useNormalStrategy(target) {
           (slot) => character.slots[slot]?.name !== suggestedRangerItems[slot],
         )
       ) {
-        await equipBatch(suggestedRangerItems);
+        promises.push(equipBatch(suggestedRangerItems));
       }
       break;
 
@@ -58,10 +56,11 @@ async function useNormalStrategy(target) {
           (slot) => character.slots[slot]?.name !== suggestedPriestItems[slot],
         )
       ) {
-        await equipBatch(suggestedPriestItems);
+        promises.push(equipBatch(suggestedPriestItems));
       }
 
-      if (!isAssignedAsTanker()) await scareAwayMobs();
+      if (!isAssignedAsTanker()) promises.push(scareAwayMobs());
       break;
   }
+  return Promise.all(promises);
 }

--- a/normal_strategy.12.js
+++ b/normal_strategy.12.js
@@ -8,7 +8,7 @@ async function useNormalStrategy(target) {
 
       if (
         Object.keys(suggestedMageItems).some(
-          (slot) => character.slots[slot]?.name !== suggestedMageItems[slot]
+          (slot) => character.slots[slot]?.name !== suggestedMageItems[slot],
         )
       ) {
         await equipBatch(suggestedMageItems);
@@ -20,7 +20,7 @@ async function useNormalStrategy(target) {
         target.max_hp > 3000 &&
         Object.values(parent.entities).some(
           (entity) =>
-            entity.type === "monster" && entity.target === character.name
+            entity.type === "monster" && entity.target === character.name,
         )
       )
         scareAwayMobs();
@@ -32,7 +32,7 @@ async function useNormalStrategy(target) {
 
       if (
         Object.keys(suggestedWarriorItems).some(
-          (slot) => character.slots[slot]?.name !== suggestedWarriorItems[slot]
+          (slot) => character.slots[slot]?.name !== suggestedWarriorItems[slot],
         )
       ) {
         await equipBatch(suggestedWarriorItems);
@@ -44,7 +44,7 @@ async function useNormalStrategy(target) {
 
       if (
         Object.keys(suggestedRangerItems).some(
-          (slot) => character.slots[slot]?.name !== suggestedRangerItems[slot]
+          (slot) => character.slots[slot]?.name !== suggestedRangerItems[slot],
         )
       ) {
         await equipBatch(suggestedRangerItems);
@@ -52,16 +52,16 @@ async function useNormalStrategy(target) {
       break;
 
     case "priest":
-      const suggestedPriestItems = calculatePriestItems();
+      const suggestedPriestItems = calculatePriestItems(target);
       if (
         Object.keys(suggestedPriestItems).some(
-          (slot) => character.slots[slot]?.name !== suggestedPriestItems[slot]
+          (slot) => character.slots[slot]?.name !== suggestedPriestItems[slot],
         )
       ) {
         await equipBatch(suggestedPriestItems);
       }
 
-      await scareAwayMobs();
+      if (!isAssignedAsTanker()) await scareAwayMobs();
       break;
   }
 }

--- a/normal_strategy.12.js
+++ b/normal_strategy.12.js
@@ -38,7 +38,7 @@ async function useNormalStrategy(target) {
       break;
 
     case "ranger":
-      const suggestedRangerItems = calculateRangerItems();
+      const suggestedRangerItems = calculateRangerItems(target);
 
       if (
         Object.keys(suggestedRangerItems).some(
@@ -46,6 +46,17 @@ async function useNormalStrategy(target) {
         )
       ) {
         promises.push(equipBatch(suggestedRangerItems));
+      }
+      break;
+
+    case "rogue":
+      const suggestedRogueItems = calculateRogueItems(target);
+      if (
+        Object.keys(suggestedRogueItems).some(
+          (slot) => character.slots[slot]?.name !== suggestedRogueItems[slot],
+        )
+      ) {
+        promises.push(equipBatch(suggestedRogueItems));
       }
       break;
 

--- a/pull_strategy.13.js
+++ b/pull_strategy.13.js
@@ -198,7 +198,7 @@ async function usePullStrategies(target) {
       break;
 
     case "priest":
-      const suggestedPriestItems = calculatePriestItems();
+      const suggestedPriestItems = calculatePriestItems(target);
       if (
         Object.keys(suggestedPriestItems).some(
           (slot) => character.slots[slot]?.name !== suggestedPriestItems[slot]

--- a/pull_strategy.13.js
+++ b/pull_strategy.13.js
@@ -1,8 +1,8 @@
 async function usePullStrategies(target) {
   const partyHealer = get_entity(HEALER);
   const partyTanker = get_entity(TANKER);
-  const mobsList = Object.keys(parent.entities).filter(
-    (id) => parent.entities[id]?.type === "monster",
+  const mobsList = Object.values(parent.entities).filter(
+    (mob) => mob.type === "monster"
   );
 
   switch (character.ctype) {
@@ -10,7 +10,7 @@ async function usePullStrategies(target) {
       const suggestedMageItems = calculateMageItems(target);
       if (
         Object.keys(suggestedMageItems).some(
-          (slot) => character.slots[slot]?.name !== suggestedMageItems[slot],
+          (slot) => character.slots[slot]?.name !== suggestedMageItems[slot]
         )
       ) {
         await equipBatch(suggestedMageItems);
@@ -39,7 +39,7 @@ async function usePullStrategies(target) {
         getMonstersToCBurst().length >= 1
       ) {
         use_skill("cburst", getMonstersToCBurst()).then(() =>
-          reduce_cooldown("cburst", -2000),
+          reduce_cooldown("cburst", -2000)
         );
         reduce_cooldown("cburst", -2000);
       }
@@ -51,7 +51,7 @@ async function usePullStrategies(target) {
         character.hp < character.max_hp * 0.7 &&
         Object.values(parent.entities).some(
           (entity) =>
-            entity.type === "monster" && entity.target === character.name,
+            entity.type === "monster" && entity.target === character.name
         )
       )
         scareAwayMobs();
@@ -63,41 +63,36 @@ async function usePullStrategies(target) {
 
       if (
         Object.keys(suggestedWarriorItems).some(
-          (slot) => character.slots[slot]?.name !== suggestedWarriorItems[slot],
+          (slot) => character.slots[slot]?.name !== suggestedWarriorItems[slot]
         )
       ) {
         await equipBatch(suggestedWarriorItems);
       }
 
       const formidableMonsterAppeared = mobsList.find(
-        (id) =>
-          parent.entities[id]?.attack * parent.entities[id]?.frequency >
-          MAX_MOB_DPS,
+        (mob) => mob.attack * mob?.frequency > MAX_MOB_DPS
       );
 
       const havePulledEnoughMobs =
-        mobsList.filter((id) => parent.entities[id]?.target === character.name)
-          .length >= MAX_TARGET;
+        mobsList.filter((mob) => mob?.target === character.name).length >=
+        MAX_TARGET;
 
-      const numberOfMonsterInRange = mobsList.filter((id) =>
-        is_in_range(parent.entities[id], "agitate"),
+      const numberOfMonsterInRange = mobsList.filter((mob) =>
+        is_in_range(mob, "agitate")
       ).length;
 
       const listOfNoTargetMonsterInRange = mobsList.filter(
-        (id) =>
-          is_in_range(parent.entities[id], "agitate") &&
-          parent.entities[id].target !== TANKER,
+        (mob) => is_in_range(mob, "agitate") && mob.target !== TANKER
       );
 
       const magicalMobsTargetingSelf = Object.values(parent.entities).filter(
-        (mob) => mob.damage_type === "magical" && mob.target === character.name,
+        (mob) => mob.damage_type === "magical" && mob.target === character.name
       );
       const physicalMobsTargetingSelf = Object.values(parent.entities).filter(
-        (mob) =>
-          mob.damage_type === "physical" && mob.target === character.name,
+        (mob) => mob.damage_type === "physical" && mob.target === character.name
       );
       const pureMobsTargetingSelf = Object.values(parent.entities).filter(
-        (mob) => mob.damage_type === "pure" && mob.target === character.name,
+        (mob) => mob.damage_type === "pure" && mob.target === character.name
       );
 
       let magicalMobsAfterAgitating = magicalMobsTargetingSelf.length;
@@ -134,15 +129,15 @@ async function usePullStrategies(target) {
         !is_on_cooldown("agitate") &&
         // numberOfMonsterInRange <= MAX_TARGET + 2 &&
         listOfNoTargetMonsterInRange.length >= 2 &&
-        !listOfNoTargetMonsterInRange.some((id) =>
-          MELEE_IGNORE_LIST.includes(parent.entities[id].mtype),
+        !listOfNoTargetMonsterInRange.some((mob) =>
+          MELEE_IGNORE_LIST.includes(mob.mtype)
         ) &&
         Object.values(parent.entities)
           .filter(
             (entity) =>
               entity.type === "monster" &&
               is_in_range(entity, "agitate") &&
-              entity.target !== character,
+              entity.target !== character
           )
           .reduce((prev, curr) => prev + calculateDamage(curr, character), 0) <
           partyHealer.heal * partyHealer.frequency +
@@ -168,23 +163,23 @@ async function usePullStrategies(target) {
         !is_on_cooldown("taunt")
       ) {
         const mobToPull = mobsList.find(
-          (id) =>
-            calculateDamage(parent.entities[id], character) < 4000 &&
-            is_in_range(parent.entities[id], "taunt") &&
-            (!parent.entities[id].target ||
+          (mob) =>
+            calculateDamage(mob, character) < 4000 &&
+            is_in_range(mob, "taunt") &&
+            (!mob.target ||
               partyMems
                 .filter((id) => id !== character.name)
-                .includes(parent.entities[id].target)) &&
-            (parent.entities[id].damage_type === "physical"
+                .includes(mob.target)) &&
+            (mob.damage_type === "physical"
               ? physicalMobsTargetingSelf.length < character.courage
-              : parent.entities[id].damage_type === "magical"
+              : mob.damage_type === "magical"
               ? magicalMobsTargetingSelf.length < character.mcourage
-              : pureMobsTargetingSelf.length < character.pcourage),
+              : pureMobsTargetingSelf.length < character.pcourage)
         );
 
         if (mobToPull)
           use_skill("taunt", parent.entities[mobToPull]).then(() =>
-            reduce_cooldown("taunt", character.ping * 0.95),
+            reduce_cooldown("taunt", character.ping * 0.95)
           );
       }
 
@@ -195,7 +190,7 @@ async function usePullStrategies(target) {
 
       if (
         Object.keys(suggestedRangerItems).some(
-          (slot) => character.slots[slot]?.name !== suggestedRangerItems[slot],
+          (slot) => character.slots[slot]?.name !== suggestedRangerItems[slot]
         )
       ) {
         await equipBatch(suggestedRangerItems);
@@ -206,7 +201,7 @@ async function usePullStrategies(target) {
       const suggestedPriestItems = calculatePriestItems();
       if (
         Object.keys(suggestedPriestItems).some(
-          (slot) => character.slots[slot]?.name !== suggestedPriestItems[slot],
+          (slot) => character.slots[slot]?.name !== suggestedPriestItems[slot]
         )
       ) {
         await equipBatch(suggestedPriestItems);

--- a/pull_strategy.13.js
+++ b/pull_strategy.13.js
@@ -216,9 +216,9 @@ async function usePullStrategies(target) {
       }
 
       if (
-        (avgPartyDmgTaken(partyMems) > character.heal * 0.95 * character.frequency &&
-          character.hp <
-            (character.name === TANKER ? 0.3 : 0.5) * character.max_hp) &&
+        avgPartyDmgTaken(partyMems) >
+          character.heal * 0.95 * character.frequency &&
+        character.hp < (isAssignedAsTanker() ? 0.3 : 0.5) * character.max_hp &&
         !is_on_cooldown("scare") &&
         character.cc < 100
       ) {

--- a/pull_strategy.13.js
+++ b/pull_strategy.13.js
@@ -129,8 +129,12 @@ async function usePullStrategies(target) {
         !is_on_cooldown("agitate") &&
         // numberOfMonsterInRange <= MAX_TARGET + 2 &&
         listOfNoTargetMonsterInRange.length >= 2 &&
-        !listOfNoTargetMonsterInRange.some((mob) =>
-          MELEE_IGNORE_LIST.includes(mob.mtype)
+        !listOfNoTargetMonsterInRange.some(
+          (mob) =>
+            MELEE_IGNORE_LIST.includes(mob.mtype) ||
+            WATCHOUT_ABILITIES.some((skill) =>
+              Object.keys(mob.abilities).includes(skill)
+            )
         ) &&
         Object.values(parent.entities)
           .filter(
@@ -209,7 +213,7 @@ async function usePullStrategies(target) {
 
       if (
         (avgDmgTaken(character) > character.heal * 0.95 * character.frequency ||
-          character.hp < 0.5 * character.max_hp) &&
+          character.hp < (character.name === TANKER ? 0.3: 0.5) * character.max_hp) &&
         !is_on_cooldown("scare") &&
         character.cc < 100
       ) {

--- a/pull_strategy.13.js
+++ b/pull_strategy.13.js
@@ -2,7 +2,7 @@ async function usePullStrategies(target) {
   const partyHealer = get_entity(HEALER);
   const partyTanker = get_entity(TANKER);
   const mobsList = Object.values(parent.entities).filter(
-    (mob) => mob.type === "monster"
+    (mob) => mob.type === "monster",
   );
 
   switch (character.ctype) {
@@ -10,7 +10,7 @@ async function usePullStrategies(target) {
       const suggestedMageItems = calculateMageItems(target);
       if (
         Object.keys(suggestedMageItems).some(
-          (slot) => character.slots[slot]?.name !== suggestedMageItems[slot]
+          (slot) => character.slots[slot]?.name !== suggestedMageItems[slot],
         )
       ) {
         await equipBatch(suggestedMageItems);
@@ -39,7 +39,7 @@ async function usePullStrategies(target) {
         getMonstersToCBurst().length >= 1
       ) {
         use_skill("cburst", getMonstersToCBurst()).then(() =>
-          reduce_cooldown("cburst", -2000)
+          reduce_cooldown("cburst", -2000),
         );
         reduce_cooldown("cburst", -2000);
       }
@@ -51,7 +51,7 @@ async function usePullStrategies(target) {
         character.hp < character.max_hp * 0.7 &&
         Object.values(parent.entities).some(
           (entity) =>
-            entity.type === "monster" && entity.target === character.name
+            entity.type === "monster" && entity.target === character.name,
         )
       )
         scareAwayMobs();
@@ -63,14 +63,14 @@ async function usePullStrategies(target) {
 
       if (
         Object.keys(suggestedWarriorItems).some(
-          (slot) => character.slots[slot]?.name !== suggestedWarriorItems[slot]
+          (slot) => character.slots[slot]?.name !== suggestedWarriorItems[slot],
         )
       ) {
         await equipBatch(suggestedWarriorItems);
       }
 
       const formidableMonsterAppeared = mobsList.find(
-        (mob) => mob.attack * mob?.frequency > MAX_MOB_DPS
+        (mob) => mob.attack * mob?.frequency > MAX_MOB_DPS,
       );
 
       const havePulledEnoughMobs =
@@ -78,21 +78,22 @@ async function usePullStrategies(target) {
         MAX_TARGET;
 
       const numberOfMonsterInRange = mobsList.filter((mob) =>
-        is_in_range(mob, "agitate")
+        is_in_range(mob, "agitate"),
       ).length;
 
       const listOfNoTargetMonsterInRange = mobsList.filter(
-        (mob) => is_in_range(mob, "agitate") && mob.target !== TANKER
+        (mob) => is_in_range(mob, "agitate") && mob.target !== TANKER,
       );
 
       const magicalMobsTargetingSelf = Object.values(parent.entities).filter(
-        (mob) => mob.damage_type === "magical" && mob.target === character.name
+        (mob) => mob.damage_type === "magical" && mob.target === character.name,
       );
       const physicalMobsTargetingSelf = Object.values(parent.entities).filter(
-        (mob) => mob.damage_type === "physical" && mob.target === character.name
+        (mob) =>
+          mob.damage_type === "physical" && mob.target === character.name,
       );
       const pureMobsTargetingSelf = Object.values(parent.entities).filter(
-        (mob) => mob.damage_type === "pure" && mob.target === character.name
+        (mob) => mob.damage_type === "pure" && mob.target === character.name,
       );
 
       let magicalMobsAfterAgitating = magicalMobsTargetingSelf.length;
@@ -133,15 +134,15 @@ async function usePullStrategies(target) {
           (mob) =>
             MELEE_IGNORE_LIST.includes(mob.mtype) ||
             WATCHOUT_ABILITIES.some((skill) =>
-              Object.keys(mob.abilities).includes(skill)
-            )
+              Object.keys(mob.abilities).includes(skill),
+            ),
         ) &&
         Object.values(parent.entities)
           .filter(
             (entity) =>
               entity.type === "monster" &&
               is_in_range(entity, "agitate") &&
-              entity.target !== character
+              entity.target !== character,
           )
           .reduce((prev, curr) => prev + calculateDamage(curr, character), 0) <
           partyHealer.heal * partyHealer.frequency +
@@ -170,6 +171,9 @@ async function usePullStrategies(target) {
           (mob) =>
             calculateDamage(mob, character) < 4000 &&
             is_in_range(mob, "taunt") &&
+            !WATCHOUT_ABILITIES.some((skill) =>
+              Object.keys(mob.abilities).includes(skill),
+            ) &&
             (!mob.target ||
               partyMems
                 .filter((id) => id !== character.name)
@@ -178,12 +182,12 @@ async function usePullStrategies(target) {
               ? physicalMobsTargetingSelf.length < character.courage
               : mob.damage_type === "magical"
               ? magicalMobsTargetingSelf.length < character.mcourage
-              : pureMobsTargetingSelf.length < character.pcourage)
+              : pureMobsTargetingSelf.length < character.pcourage),
         );
 
         if (mobToPull)
           use_skill("taunt", parent.entities[mobToPull]).then(() =>
-            reduce_cooldown("taunt", character.ping * 0.95)
+            reduce_cooldown("taunt", character.ping * 0.95),
           );
       }
 
@@ -194,7 +198,7 @@ async function usePullStrategies(target) {
 
       if (
         Object.keys(suggestedRangerItems).some(
-          (slot) => character.slots[slot]?.name !== suggestedRangerItems[slot]
+          (slot) => character.slots[slot]?.name !== suggestedRangerItems[slot],
         )
       ) {
         await equipBatch(suggestedRangerItems);
@@ -205,15 +209,16 @@ async function usePullStrategies(target) {
       const suggestedPriestItems = calculatePriestItems(target);
       if (
         Object.keys(suggestedPriestItems).some(
-          (slot) => character.slots[slot]?.name !== suggestedPriestItems[slot]
+          (slot) => character.slots[slot]?.name !== suggestedPriestItems[slot],
         )
       ) {
         await equipBatch(suggestedPriestItems);
       }
 
       if (
-        (avgDmgTaken(character) > character.heal * 0.95 * character.frequency ||
-          character.hp < (character.name === TANKER ? 0.3: 0.5) * character.max_hp) &&
+        (avgPartyDmgTaken(partyMems) > character.heal * 0.95 * character.frequency &&
+          character.hp <
+            (character.name === TANKER ? 0.3 : 0.5) * character.max_hp) &&
         !is_on_cooldown("scare") &&
         character.cc < 100
       ) {

--- a/pull_strategy.13.js
+++ b/pull_strategy.13.js
@@ -134,7 +134,7 @@ async function usePullStrategies(target) {
           (mob) =>
             MELEE_IGNORE_LIST.includes(mob.mtype) ||
             WATCHOUT_ABILITIES.some((skill) =>
-              Object.keys(mob.abilities).includes(skill),
+              Object.keys(mob.abilities ?? {}).includes(skill),
             ),
         ) &&
         Object.values(parent.entities)
@@ -172,7 +172,7 @@ async function usePullStrategies(target) {
             calculateDamage(mob, character) < 4000 &&
             is_in_range(mob, "taunt") &&
             !WATCHOUT_ABILITIES.some((skill) =>
-              Object.keys(mob.abilities).includes(skill),
+              Object.keys(mob.abilities ?? '').includes(skill),
             ) &&
             (!mob.target ||
               partyMems

--- a/pull_strategy.13.js
+++ b/pull_strategy.13.js
@@ -4,6 +4,7 @@ async function usePullStrategies(target) {
   const mobsList = Object.values(parent.entities).filter(
     (mob) => mob.type === "monster",
   );
+  const promises = [];
 
   switch (character.ctype) {
     case "mage":
@@ -13,20 +14,8 @@ async function usePullStrategies(target) {
           (slot) => character.slots[slot]?.name !== suggestedMageItems[slot],
         )
       ) {
-        await equipBatch(suggestedMageItems);
+        promises.push(equipBatch(suggestedMageItems));
       }
-
-      // if (!is_on_cooldown("energize")) {
-      //   if (character.mp > 4000)
-      //     use_skill("energize", get_entity(TANKER)).then(() =>
-      //       reduce_cooldown("energize", character.ping * 0.95)
-      //     );
-      //   else {
-      //     use_skill("energize", character).then(() =>
-      //       reduce_cooldown("energize", character.ping * 0.95)
-      //     );
-      //   }
-      // }
 
       if (
         ms_to_next_skill("cburst") === 0 &&
@@ -38,10 +27,14 @@ async function usePullStrategies(target) {
         partyHealer?.hp > 0.6 * partyHealer?.max_hp &&
         getMonstersToCBurst().length >= 1
       ) {
-        use_skill("cburst", getMonstersToCBurst()).then(() =>
-          reduce_cooldown("cburst", -2000),
+        promises.push(
+          withTimeout(
+            use_skill("cburst", getMonstersToCBurst()).then(() =>
+              reduce_cooldown("cburst", -2000),
+            ),
+            2500,
+          ),
         );
-        reduce_cooldown("cburst", -2000);
       }
 
       if (
@@ -54,7 +47,7 @@ async function usePullStrategies(target) {
             entity.type === "monster" && entity.target === character.name,
         )
       )
-        scareAwayMobs();
+        promises.push(scareAwayMobs());
 
       break;
 
@@ -66,7 +59,7 @@ async function usePullStrategies(target) {
           (slot) => character.slots[slot]?.name !== suggestedWarriorItems[slot],
         )
       ) {
-        await equipBatch(suggestedWarriorItems);
+        promises.push(equipBatch(suggestedWarriorItems));
       }
 
       const formidableMonsterAppeared = mobsList.find(
@@ -77,22 +70,18 @@ async function usePullStrategies(target) {
         mobsList.filter((mob) => mob?.target === character.name).length >=
         MAX_TARGET;
 
-      const numberOfMonsterInRange = mobsList.filter((mob) =>
-        is_in_range(mob, "agitate"),
-      ).length;
-
       const listOfNoTargetMonsterInRange = mobsList.filter(
-        (mob) => is_in_range(mob, "agitate") && mob.target !== TANKER,
+        (mob) => is_in_range(mob, "agitate") && mob.target !== character.name,
       );
 
-      const magicalMobsTargetingSelf = Object.values(parent.entities).filter(
+      const magicalMobsTargetingSelf = mobsList.filter(
         (mob) => mob.damage_type === "magical" && mob.target === character.name,
       );
-      const physicalMobsTargetingSelf = Object.values(parent.entities).filter(
+      const physicalMobsTargetingSelf = mobsList.filter(
         (mob) =>
           mob.damage_type === "physical" && mob.target === character.name,
       );
-      const pureMobsTargetingSelf = Object.values(parent.entities).filter(
+      const pureMobsTargetingSelf = mobsList.filter(
         (mob) => mob.damage_type === "pure" && mob.target === character.name,
       );
 
@@ -101,7 +90,7 @@ async function usePullStrategies(target) {
       let pureMobsAfterAgitating = pureMobsTargetingSelf.length;
 
       for (const mob of listOfNoTargetMonsterInRange) {
-        switch (parent.entities[mob]?.damage_type) {
+        switch (mob.damage_type) {
           case "magical":
             magicalMobsAfterAgitating++;
             break;
@@ -129,6 +118,9 @@ async function usePullStrategies(target) {
         character.mp > G.skills["agitate"].mp &&
         !is_on_cooldown("agitate") &&
         // numberOfMonsterInRange <= MAX_TARGET + 2 &&
+        !listOfNoTargetMonsterInRange.some(
+          (mob) => mob.cooperative && !partyMems.includes(mob.target),
+        ) &&
         listOfNoTargetMonsterInRange.length >= 2 &&
         !listOfNoTargetMonsterInRange.some(
           (mob) =>
@@ -153,7 +145,7 @@ async function usePullStrategies(target) {
             partyDmgRecieved &&
         !isFearedAfterAgitating
       ) {
-        use_skill("agitate");
+        promises.push(withTimeout(use_skill("agitate"), 2500));
       }
 
       if (
@@ -172,7 +164,7 @@ async function usePullStrategies(target) {
             calculateDamage(mob, character) < 4000 &&
             is_in_range(mob, "taunt") &&
             !WATCHOUT_ABILITIES.some((skill) =>
-              Object.keys(mob.abilities ?? '').includes(skill),
+              Object.keys(mob.abilities ?? "").includes(skill),
             ) &&
             (!mob.target ||
               partyMems
@@ -186,8 +178,13 @@ async function usePullStrategies(target) {
         );
 
         if (mobToPull)
-          use_skill("taunt", parent.entities[mobToPull]).then(() =>
-            reduce_cooldown("taunt", character.ping * 0.95),
+          promises.push(
+            withTimeout(
+              use_skill("taunt", parent.entities[mobToPull]).then(() =>
+                reduce_cooldown("taunt", character.ping * 0.95),
+              ),
+              2500,
+            ),
           );
       }
 
@@ -201,7 +198,7 @@ async function usePullStrategies(target) {
           (slot) => character.slots[slot]?.name !== suggestedRangerItems[slot],
         )
       ) {
-        await equipBatch(suggestedRangerItems);
+        promises.push(equipBatch(suggestedRangerItems));
       }
       break;
 
@@ -212,7 +209,7 @@ async function usePullStrategies(target) {
           (slot) => character.slots[slot]?.name !== suggestedPriestItems[slot],
         )
       ) {
-        await equipBatch(suggestedPriestItems);
+        promises.push(equipBatch(suggestedPriestItems));
       }
 
       if (
@@ -222,12 +219,14 @@ async function usePullStrategies(target) {
         !is_on_cooldown("scare") &&
         character.cc < 100
       ) {
-        scareAwayMobs();
+        promises.push(scareAwayMobs());
       }
       break;
     default:
       break;
   }
+
+  return Promise.all(promises);
 }
 
 game.on("hit", (data) => {});

--- a/pull_strategy.13.js
+++ b/pull_strategy.13.js
@@ -1,5 +1,6 @@
 async function usePullStrategies(target) {
-  const partyHealer = get_entity(HEALER);
+  const partyHealer = get_entity(HEALER) ?? get_entity(RANGER);
+  const healerPower = partyHealer?.heal || partyHealer?.attack || 0;
   const partyTanker = get_entity(TANKER);
   const mobsList = Object.values(parent.entities).filter(
     (mob) => mob.type === "monster",
@@ -137,7 +138,7 @@ async function usePullStrategies(target) {
               entity.target !== character,
           )
           .reduce((prev, curr) => prev + calculateDamage(curr, character), 0) <
-          partyHealer.heal * partyHealer.frequency +
+          healerPower * partyHealer.frequency +
             (parent.entities["$Caroline"]?.focus &&
             distance(parent.entities["$Caroline"], character) < 250
               ? 1200
@@ -150,7 +151,7 @@ async function usePullStrategies(target) {
 
       if (
         partyDmgRecieved <
-          partyHealer.heal * partyHealer.frequency * 0.9 +
+          healerPower * partyHealer.frequency * 0.9 +
             (parent.entities["$Caroline"]?.focus &&
             distance(parent.entities["$Caroline"], character) < 250
               ? 1200
@@ -190,8 +191,19 @@ async function usePullStrategies(target) {
 
       break;
 
+    case "rogue":
+      const suggestedRogueItems = calculateRogueItems(target);
+      if (
+        Object.keys(suggestedRogueItems).some(
+          (slot) => character.slots[slot]?.name !== suggestedRogueItems[slot],
+        )
+      ) {
+        promises.push(equipBatch(suggestedRogueItems));
+      }
+      break;
+
     case "ranger":
-      const suggestedRangerItems = calculateRangerItems();
+      const suggestedRangerItems = calculateRangerItems(target);
 
       if (
         Object.keys(suggestedRangerItems).some(
@@ -228,7 +240,3 @@ async function usePullStrategies(target) {
 
   return Promise.all(promises);
 }
-
-game.on("hit", (data) => {});
-
-character.on("mobbing", (data) => {});

--- a/pull_strategy.13.js
+++ b/pull_strategy.13.js
@@ -66,7 +66,9 @@ async function usePullStrategies(target) {
       }
 
       const formidableMonsterAppeared = mobsList.find(
-        (mob) => mob.attack * mob?.frequency > MAX_MOB_DPS,
+        (mob) =>
+          mob.attack * mob.frequency > MAX_MOB_DPS ||
+          MELEE_IGNORE_LIST.includes(mob.mtype),
       );
 
       const havePulledEnoughMobs =

--- a/pull_strategy.13.js
+++ b/pull_strategy.13.js
@@ -1,6 +1,7 @@
 async function usePullStrategies(target) {
   const partyHealer = get_entity(HEALER) ?? get_entity(RANGER);
   const healerPower = partyHealer?.heal || partyHealer?.attack || 0;
+  const healerFreq = partyHealer?.frequency || 1;
   const partyTanker = get_entity(TANKER);
   const mobsList = Object.values(parent.entities).filter(
     (mob) => mob.type === "monster",
@@ -22,6 +23,7 @@ async function usePullStrategies(target) {
         ms_to_next_skill("cburst") === 0 &&
         character.mp > 400 &&
         !get_targeted_monster()?.["1hp"] &&
+        partyHealer &&
         partyHealer.ctype === "priest" &&
         distance(partyHealer, character) <
           (partyHealer.range ?? character.range * 0.7) &&
@@ -138,7 +140,7 @@ async function usePullStrategies(target) {
               entity.target !== character,
           )
           .reduce((prev, curr) => prev + calculateDamage(curr, character), 0) <
-          healerPower * partyHealer.frequency +
+          healerPower * healerFreq +
             (parent.entities["$Caroline"]?.focus &&
             distance(parent.entities["$Caroline"], character) < 250
               ? 1200
@@ -151,7 +153,7 @@ async function usePullStrategies(target) {
 
       if (
         partyDmgRecieved <
-          healerPower * partyHealer.frequency * 0.9 +
+          healerPower * healerFreq * 0.9 +
             (parent.entities["$Caroline"]?.focus &&
             distance(parent.entities["$Caroline"], character) < 250
               ? 1200
@@ -225,8 +227,7 @@ async function usePullStrategies(target) {
       }
 
       if (
-        avgPartyDmgTaken(partyMems) >
-          character.heal * 0.95 * character.frequency &&
+        avgPartyDmgTaken(partyMems) > character.heal * 0.95 * healerFreq &&
         character.hp < (isAssignedAsTanker() ? 0.3 : 0.5) * character.max_hp &&
         !is_on_cooldown("scare") &&
         character.cc < 100

--- a/server_hop.14.js
+++ b/server_hop.14.js
@@ -3,8 +3,8 @@ const HOP_SERVERS = ["US", "ASIA", "EU"];
 const ignoreServer = [];
 
 const HOME_SERVER = {
-  serverRegion: "ASIA",
-  serverIdentifier: "I",
+  serverRegion: "EU",
+  serverIdentifier: "II",
 };
 
 const tankableBoss = ["snowman", "pinkgoo"];

--- a/server_hop.14.js
+++ b/server_hop.14.js
@@ -3,7 +3,7 @@ const HOP_SERVERS = ["US", "ASIA", "EU"];
 const ignoreServer = [];
 
 const HOME_SERVER = {
-  serverRegion: "EU",
+  serverRegion: "ASIA",
   serverIdentifier: "I",
 };
 
@@ -12,8 +12,8 @@ const tankableBoss = ["snowman", "pinkgoo"];
 const bosses = {
   icegolem: { type: "icegolem", threshold: 0.7, hoppable: 0.999 },
   franky: { type: "franky", threshold: 0.7, hoppable: 0.965 },
-  mrpumpkin: { type: "mrpumpkin", threshold: 0.7, hoppable: 0.95 },
-  mrgreen: { type: "mrgreen", threshold: 0.7, hoppable: 0.95 },
+  mrpumpkin: { type: "mrpumpkin", threshold: 0.3, hoppable: 0.9999 },
+  mrgreen: { type: "mrgreen", threshold: 0.3, hoppable: 0.9999 },
   crabxx: { type: "crabxx", threshold: 0.95, hoppable: 0.9999 },
   dragold: { type: "dragold", threshold: 0.99, hoppable: 1 },
 };
@@ -55,7 +55,7 @@ setInterval(async () => {
         parent.S[boss] &&
         parent.S[boss].target &&
         parent.S[boss].hp <
-          (bosses[boss]?.threshold ?? 0.93) * parent.S[boss].max_hp
+          (bosses[boss]?.threshold ?? 0.93) * parent.S[boss].max_hp,
     ) ||
     get("cryptInstance")
   )
@@ -85,7 +85,7 @@ setInterval(async () => {
       .filter((serverBoss) => {
         return (
           !ignoreServer.includes(
-            `${serverBoss.serverRegion}${serverBoss.serverIdentifier}`
+            `${serverBoss.serverRegion}${serverBoss.serverIdentifier}`,
           ) &&
           serverBoss.serverIdentifier !== "PVP" &&
           HOP_SERVERS.includes(serverBoss.serverRegion) &&

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -12,7 +12,7 @@ function mobsListAroundTarget(target, blastRadius = BLAST_RADIUS) {
     (entity) =>
       entity.type === "monster" &&
       distance(target, entity) < blastRadius &&
-      entity.target
+      entity.target,
   );
 }
 
@@ -25,7 +25,7 @@ function numberOfMonsterAroundTarget(target, blastRadius = BLAST_RADIUS) {
       (entity) =>
         distance(target, entity) < blastRadius &&
         !entity.target &&
-        entity.type === "monster"
+        entity.type === "monster",
     )
   )
     return 0;
@@ -34,7 +34,7 @@ function numberOfMonsterAroundTarget(target, blastRadius = BLAST_RADIUS) {
     (entity) =>
       entity.type === "monster" &&
       distance(target, entity) < blastRadius &&
-      entity.target
+      entity.target,
   ).length;
 }
 
@@ -49,7 +49,7 @@ function haveFormidableMonsterAroundTarget(target, blastRadius = BLAST_RADIUS) {
         parent.distance(target, entity) < blastRadius &&
         entity.attack > 1100 &&
         entity.type === "monster" &&
-        !entity.target
+        !entity.target,
     ).length > 0
   );
 }
@@ -65,7 +65,7 @@ function calculateMageItems() {
   const haveLowHpMobsNearby = Object.values(parent.entities).some(
     (mob) =>
       (partyMems.includes(mob.target) || mob.cooperative) &&
-      mob.hp <= mob.max_hp * 0.15
+      mob.hp <= mob.max_hp * 0.15,
   );
 
   return {
@@ -77,7 +77,7 @@ function calculateMageItems() {
         : character.map === "crypt" && !get_targeted_monster()?.s?.frozen
         ? "froststaff"
         : ["pinkgoo", "snowman", "wabbit", "crab"].includes(
-            get_targeted_monster()?.mtype
+            get_targeted_monster()?.mtype,
           ) || get_targeted_monster()?.max_hp < 2000
         ? "pinkie"
         : "firestaff",
@@ -104,7 +104,7 @@ function calculateWarriorItems() {
   const haveLowHpMobsNearby = Object.values(parent.entities).some(
     (mobs) =>
       (mobs.target === character.name || mobs.cooperative) &&
-      mobs.hp <= mobs.max_hp * 0.15
+      mobs.hp <= mobs.max_hp * 0.15,
   );
 
   if (["pinkgoo", "snowman", "wabbit"].includes(get_targeted_monster()?.mtype))
@@ -130,7 +130,7 @@ function calculateWarriorItems() {
     offhand:
       (character.map === "crypt" &&
         Object.values(parent.entities).some(
-          (mob) => mob.target === character.name && mob.mtype === "a2"
+          (mob) => mob.target === character.name && mob.mtype === "a2",
         )) ||
       haveLowHpMobsNearby
         ? "mshield"
@@ -139,7 +139,7 @@ function calculateWarriorItems() {
         : "fireblade",
     amulet: haveLowHpMobsNearby
       ? "spookyamulet"
-      : (character.name === TANKER &&
+      : (isAssignedAsTanker() &&
           Object.values(parent.entities)
             .filter((entity) => entity.type === "monster")
             .some((mob) => mob.target === character.name)) ||
@@ -174,7 +174,7 @@ function calculatePriestItems(target) {
   const haveLowHpMobsNearby = Object.values(parent.entities).some(
     (mobs) =>
       (mobs.target === character.name || mobs.cooperative) &&
-      mobs.hp <= mobs.max_hp * 0.15
+      mobs.hp <= mobs.max_hp * 0.15,
   );
   const currentTarget = get_targeted_monster();
   return {
@@ -182,7 +182,7 @@ function calculatePriestItems(target) {
       target?.type !== "monster"
         ? "oozingterror"
         : ["pinkgoo", "snowman", "wabbit", "crab"].includes(
-            get_targeted_monster()?.mtype
+            get_targeted_monster()?.mtype,
           )
         ? "pinkie"
         : character.map === "crypt"
@@ -200,7 +200,7 @@ function calculatePriestItems(target) {
     offhand:
       character.map === "crypt"
         ? "wbook1"
-        : character.name === TANKER && character.s.burned
+        : isAssignedAsTanker() && character.s.burned
         ? "wbookhs"
         : haveLowHpMobsNearby
         ? "mshield"
@@ -209,20 +209,20 @@ function calculatePriestItems(target) {
             (mob) =>
               mob.type === "monster" &&
               mob.target === character.name &&
-              mob.damage_type === "magical"
+              mob.damage_type === "magical",
           ) ||
           character.fear
         ? "wbookhs"
         : "wbook1",
     orb:
-      character.name === TANKER && character.s.burned
+      isAssignedAsTanker() && character.s.burned
         ? "orba"
         : haveLowHpMobsNearby
         ? "rabbitsfoot"
         : target?.type !== "monster"
         ? "jacko"
         : "test_orb",
-    amulet: character.name === TANKER ? "t2stramulet" : "intamulet",
+    amulet: isAssignedAsTanker() ? "t2stramulet" : "intamulet",
   };
 }
 
@@ -308,20 +308,20 @@ async function equipBatch(suggestedItems, forced = false) {
             suggestedItems[slot] &&
             (suggestedItems[slot] !== character.slots[slot]?.name ||
               character.items[findMaxLevelItem(suggestedItems[slot])]?.level >
-                character.slots[slot]?.level)
+                character.slots[slot]?.level),
         )
         .map((slot) => ({
           slot,
           num: findMaxLevelItem(suggestedItems[slot]),
         }))
-        .filter((equipInfo) => equipInfo.num >= 0)
+        .filter((equipInfo) => equipInfo.num >= 0),
     )
       .then(() => {
         isEquipingItems = false;
       })
       .catch(() => {
         isEquipingItems = false;
-      })
+      }),
   );
   return promises;
 }
@@ -337,7 +337,7 @@ function calculateDamage(target, characterEntity, recursion = true) {
             characterEntity.resistance -
               (target.type === "monster"
                 ? G.monsters[target.mtype].rpiercing ?? 0
-                : 0)
+                : 0),
           ) *
           (target.frequency < 0.9 ? 0.9 : target.frequency) +
         (target.dreturn && recursion
@@ -358,7 +358,7 @@ function calculateDamage(target, characterEntity, recursion = true) {
                 : 0) -
               (target.type === "monster"
                 ? G.monsters[target.mtype].apiercing ?? 0
-                : 0)
+                : 0),
           ) *
           (target.frequency < 0.9 ? 0.9 : target.frequency) +
         (target.dreturn && recursion
@@ -378,7 +378,7 @@ function listOfMonsterAttacking(characterEntity) {
   if (!characterEntity) return [];
   return Object.values(parent.entities).filter(
     (entity) =>
-      entity.type === "monster" && entity.target === characterEntity.name
+      entity.type === "monster" && entity.target === characterEntity.name,
   );
 }
 
@@ -393,7 +393,7 @@ function avgDmgTaken(characterEntity, dmgType = null) {
     (mob) =>
       mob.target === characterEntity.name &&
       mob.type === "monster" &&
-      (!dmgType || mob.damage_type === dmgType)
+      (!dmgType || mob.damage_type === dmgType),
   );
 
   // Burn Damage padding
@@ -416,7 +416,7 @@ function avgDmgTaken(characterEntity, dmgType = null) {
           : highestBurningMob.damage_type === "magical"
           ? characterEntity.resistance -
             (G.monsters[highestBurningMob.mtype].rpiercing ?? 0)
-          : 1
+          : 1,
       ) *
       ((100 -
         (characterEntity.firesistance ??
@@ -430,7 +430,7 @@ function avgDmgTaken(characterEntity, dmgType = null) {
     listOfAttackingMobs.reduce(
       (accummulator, currentMob) =>
         accummulator + calculateDamage(currentMob, characterEntity),
-      0
+      0,
     ) *
       mobbingMultiplier(numberOfAttackingMobs) +
     Math.max(characterEntity.s.burn?.intensity ?? 0, burnPadding)
@@ -441,7 +441,7 @@ function avgPartyDmgTaken(partyMems, dmgType = null) {
   return partyMems.reduce(
     (accumulator, current) =>
       accumulator + avgDmgTaken(get_player(current), dmgType),
-    0
+    0,
   );
 }
 
@@ -466,6 +466,10 @@ function assignRoles() {
   }
 }
 
+function isAssignedAsTanker() {
+  return character.name === TANKER;
+}
+
 function getMonstersToCBurst() {
   const partyHealer = get_entity(HEALER);
   const partyTanker = get_entity(TANKER);
@@ -480,8 +484,8 @@ function getMonstersToCBurst() {
         calculateDamage(mob, partyTanker) < MAX_MOB_DPS &&
         mob.range < character.range - 20 &&
         !WATCHOUT_ABILITIES.some((skill) =>
-          Object.keys(mob.abilities).includes(skill)
-        )
+          Object.keys(mob.abilities).includes(skill),
+        ),
     )
     .sort((lhs, rhs) => distance(character, rhs) - distance(character, lhs));
 
@@ -524,7 +528,7 @@ async function warriorCleave(currentStrategy) {
       (mob) =>
         mob.type === "monster" &&
         distance(mob, character) < G.skills["cleave"].range &&
-        mob.mtype !== "porcupine"
+        mob.mtype !== "porcupine",
     ).length === 0 ||
     isCleaving
   )
@@ -559,7 +563,7 @@ async function warriorCleave(currentStrategy) {
               1.5 &&
           mob.attack > 150
         );
-      }
+      },
     );
 
     // Categorize additional mobs that would be cleaved
@@ -577,7 +581,7 @@ async function warriorCleave(currentStrategy) {
 
     // Identify strong mobs that might be risky
     const formidableMob = listOfNoTargetMonsterInRange.some(
-      (mob) => mob.attack * mob.frequency > MAX_MOB_DPS
+      (mob) => mob.attack * mob.frequency > MAX_MOB_DPS,
     );
 
     // Calculate DPS after cleaving
@@ -601,8 +605,8 @@ async function warriorCleave(currentStrategy) {
         (mob) =>
           MELEE_IGNORE_LIST.includes(mob.mtype) ||
           WATCHOUT_ABILITIES.some((skill) =>
-            Object.keys(mob.abilities).includes(skill)
-          )
+            Object.keys(mob.abilities).includes(skill),
+          ),
       ) &&
       !listOfNoTargetMonsterInRange.some((mob) => mob.abilities.burn) &&
       !isFeared &&
@@ -649,7 +653,7 @@ async function warriorStomp() {
     Object.values(parent.entities).filter(
       (mob) =>
         mob.type === "monster" &&
-        distance(mob, character) < G.skills["stomp"].range
+        distance(mob, character) < G.skills["stomp"].range,
     ).length === 0 ||
     isStomping
   )
@@ -676,7 +680,7 @@ async function warriorStomp() {
           num: findMaxLevelItem(warriorItems.offhand),
         },
       ]);
-    })
+    }),
   );
 
   return Promise.all(promises)

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -11,7 +11,7 @@ function mobsListAroundTarget(target, blastRadius = BLAST_RADIUS) {
     (entity) =>
       entity.type === "monster" &&
       distance(target, entity) < blastRadius &&
-      entity.target
+      entity.target,
   );
 }
 
@@ -24,7 +24,7 @@ function numberOfMonsterAroundTarget(target, blastRadius = BLAST_RADIUS) {
       (entity) =>
         distance(target, entity) < blastRadius &&
         !entity.target &&
-        entity.type === "monster"
+        entity.type === "monster",
     )
   )
     return 0;
@@ -33,7 +33,7 @@ function numberOfMonsterAroundTarget(target, blastRadius = BLAST_RADIUS) {
     (entity) =>
       entity.type === "monster" &&
       distance(target, entity) < blastRadius &&
-      entity.target
+      entity.target,
   ).length;
 }
 
@@ -48,7 +48,7 @@ function haveFormidableMonsterAroundTarget(target, blastRadius = BLAST_RADIUS) {
         parent.distance(target, entity) < blastRadius &&
         entity.attack > 1100 &&
         entity.type === "monster" &&
-        !entity.target
+        !entity.target,
     ).length > 0
   );
 }
@@ -64,7 +64,7 @@ function calculateMageItems() {
   const haveLowHpMobsNearby = Object.values(parent.entities).some(
     (mob) =>
       (partyMems.includes(mob.target) || mob.cooperative) &&
-      mob.hp <= mob.max_hp * 0.15
+      mob.hp <= mob.max_hp * 0.15,
   );
 
   return {
@@ -76,7 +76,7 @@ function calculateMageItems() {
         : character.map === "crypt" && !get_targeted_monster()?.s?.frozen
         ? "froststaff"
         : ["pinkgoo", "snowman", "wabbit", "crab"].includes(
-            get_targeted_monster()?.mtype
+            get_targeted_monster()?.mtype,
           ) || get_targeted_monster()?.max_hp < 2000
         ? "pinkie"
         : "firestaff",
@@ -103,7 +103,7 @@ function calculateWarriorItems() {
   const haveLowHpMobsNearby = Object.values(parent.entities).some(
     (mobs) =>
       (mobs.target === character.name || mobs.cooperative) &&
-      mobs.hp <= mobs.max_hp * 0.15
+      mobs.hp <= mobs.max_hp * 0.15,
   );
 
   if (["pinkgoo", "snowman", "wabbit"].includes(get_targeted_monster()?.mtype))
@@ -129,7 +129,7 @@ function calculateWarriorItems() {
     offhand:
       (character.map === "crypt" &&
         Object.values(parent.entities).some(
-          (mob) => mob.target === character.name && mob.mtype === "a2"
+          (mob) => mob.target === character.name && mob.mtype === "a2",
         )) ||
       haveLowHpMobsNearby
         ? "mshield"
@@ -169,33 +169,33 @@ function calculateCupidItems() {
   };
 }
 
-function calculatePriestItems() {
+function calculatePriestItems(target) {
   const haveLowHpMobsNearby = Object.values(parent.entities).some(
     (mobs) =>
       (mobs.target === character.name || mobs.cooperative) &&
-      mobs.hp <= mobs.max_hp * 0.15
+      mobs.hp <= mobs.max_hp * 0.15,
   );
   const currentTarget = get_targeted_monster();
   return {
-    mainhand: ["pinkgoo", "snowman", "wabbit", "crab"].includes(
-      get_targeted_monster()?.mtype
-    )
-      ? "pinkie"
-      : character.map === "crypt"
-      ? "froststaff"
-      : currentTarget &&
-        (currentTarget.cooperative ||
-          currentTarget["1hp"] ||
-          currentTarget["avoidance"] > 90)
-      ? "firestaff"
-      : haveLowHpMobsNearby
-      ? "lmace"
-      : character.name === TANKER ||
-        (currentTarget &&
-          currentTarget.type === "monster " &&
-          currentTarget.max_hp < 8000)
-      ? "harbringer"
-      : "oozingterror",
+    mainhand:
+      target.type !== "monster"
+        ? "oozingterror"
+        : ["pinkgoo", "snowman", "wabbit", "crab"].includes(
+            get_targeted_monster()?.mtype,
+          )
+        ? "pinkie"
+        : character.map === "crypt"
+        ? currentTarget.s["frozen"]
+          ? "oozingterror"
+          : "froststaff"
+        : currentTarget &&
+          (currentTarget.cooperative ||
+            currentTarget["1hp"] ||
+            currentTarget["avoidance"] > 90)
+        ? "firestaff"
+        : haveLowHpMobsNearby
+        ? "lmace"
+        : "oozingterror",
     offhand:
       character.map === "crypt"
         ? "wbook1"
@@ -203,12 +203,19 @@ function calculatePriestItems() {
         ? "mshield"
         : TANKER === character.name ||
           Object.values(parent.entities).some(
-            (mob) => mob.type === "monster" && mob.target === character.name
+            (mob) => mob.type === "monster" && mob.target === character.name,
           ) ||
           character.fear
         ? "wbookhs"
         : "wbook1",
-    orb: haveLowHpMobsNearby ? "rabbitsfoot" : "test_orb",
+    orb:
+      character.name === TANKER && character.s.burned
+        ? "orba"
+        : haveLowHpMobsNearby
+        ? "rabbitsfoot"
+        : target.type !== "monster"
+        ? "jacko"
+        : "test_orb",
     amulet: "intamulet",
   };
 }
@@ -295,20 +302,20 @@ async function equipBatch(suggestedItems, forced = false) {
             suggestedItems[slot] &&
             (suggestedItems[slot] !== character.slots[slot]?.name ||
               character.items[findMaxLevelItem(suggestedItems[slot])]?.level >
-                character.slots[slot]?.level)
+                character.slots[slot]?.level),
         )
         .map((slot) => ({
           slot,
           num: findMaxLevelItem(suggestedItems[slot]),
         }))
-        .filter((equipInfo) => equipInfo.num >= 0)
+        .filter((equipInfo) => equipInfo.num >= 0),
     )
       .then(() => {
         isEquipingItems = false;
       })
       .catch(() => {
         isEquipingItems = false;
-      })
+      }),
   );
   return promises;
 }
@@ -338,7 +345,7 @@ function calculateDamage(target, characterEntity, recursion = true) {
               (characterEntity.s["hardshell"]
                 ? G.conditions.hardshell.armor
                 : 0) -
-              (target.apiercing ?? 0)
+              (target.apiercing ?? 0),
           ) *
           (target.frequency < 0.9 ? 0.9 : target.frequency) +
         (target.dreturn && recursion
@@ -358,7 +365,7 @@ function listOfMonsterAttacking(characterEntity) {
   if (!characterEntity) return [];
   return Object.values(parent.entities).filter(
     (entity) =>
-      entity.type === "monster" && entity.target === characterEntity.name
+      entity.type === "monster" && entity.target === characterEntity.name,
   );
 }
 
@@ -373,7 +380,7 @@ function avgDmgTaken(characterEntity, dmgType = null) {
     (mob) =>
       mob.target === characterEntity.name &&
       mob.type === "monster" &&
-      (!dmgType || mob.damage_type === dmgType)
+      (!dmgType || mob.damage_type === dmgType),
   );
 
   // Burn Damage padding
@@ -390,7 +397,7 @@ function avgDmgTaken(characterEntity, dmgType = null) {
           ? characterEntity.armor - highestBurningMob.apiercing
           : highestBurningMob.damage_type === "magical"
           ? characterEntity.resistance - highestBurningMob.rpiercing
-          : 1
+          : 1,
       ) *
       ((100 -
         (characterEntity.firesistance ??
@@ -406,7 +413,7 @@ function avgDmgTaken(characterEntity, dmgType = null) {
     listOfAttackingMobs.reduce(
       (accummulator, currentMob) =>
         accummulator + calculateDamage(currentMob, characterEntity),
-      0
+      0,
     ) *
       mobbingMultiplier(numberOfAttackingMobs) +
     Math.max(characterEntity.s.burn?.intensity ?? 0, burnPadding)
@@ -417,7 +424,7 @@ function avgPartyDmgTaken(partyMems, dmgType = null) {
   return partyMems.reduce(
     (accumulator, current) =>
       accumulator + avgDmgTaken(get_player(current), dmgType),
-    0
+    0,
   );
 }
 
@@ -454,7 +461,7 @@ function getMonstersToCBurst() {
         mob.type === "monster" &&
         is_in_range(mob, "cburst") &&
         calculateDamage(mob, partyTanker) < MAX_MOB_DPS &&
-        mob.range < character.range - 20
+        mob.range < character.range - 20,
     )
     .sort((lhs, rhs) => distance(character, rhs) - distance(character, lhs));
 
@@ -497,7 +504,7 @@ async function warriorCleave(currentStrategy) {
       (mob) =>
         mob.type === "monster" &&
         distance(mob, character) < G.skills["cleave"].range &&
-        mob.mtype !== "porcupine"
+        mob.mtype !== "porcupine",
     ).length === 0 ||
     isCleaving
   )
@@ -532,7 +539,7 @@ async function warriorCleave(currentStrategy) {
               1.5 &&
           mob.attack > 150
         );
-      }
+      },
     );
 
     // Categorize additional mobs that would be cleaved
@@ -550,7 +557,7 @@ async function warriorCleave(currentStrategy) {
 
     // Identify strong mobs that might be risky
     const formidableMob = listOfNoTargetMonsterInRange.some(
-      (mob) => mob.attack * mob.frequency > MAX_MOB_DPS
+      (mob) => mob.attack * mob.frequency > MAX_MOB_DPS,
     );
 
     // Calculate DPS after cleaving
@@ -615,7 +622,7 @@ async function warriorStomp() {
     Object.values(parent.entities).filter(
       (mob) =>
         mob.type === "monster" &&
-        distance(mob, character) < G.skills["stomp"].range
+        distance(mob, character) < G.skills["stomp"].range,
     ).length === 0 ||
     isStomping
   )
@@ -642,7 +649,7 @@ async function warriorStomp() {
           num: findMaxLevelItem(warriorItems.offhand),
         },
       ]);
-    })
+    }),
   );
 
   return Promise.all(promises)

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -384,22 +384,23 @@ function avgDmgTaken(characterEntity, dmgType = null) {
       return prev.attack > current.attack ? prev : current;
     }, undefined);
 
-  const burnPadding =
-    dps_multiplier(
-      highestBurningMob.damage_type === "physical"
-        ? characterEntity.armor - highestBurningMob.apiercing
-        : highestBurningMob.damage_type === "magical"
-        ? characterEntity.resistance - highestBurningMob.rpiercing
-        : 1
-    ) *
-    ((100 -
-      (characterEntity.firesistance ??
-      characterEntity.slots.orb?.name === "orba"
-        ? 15
-        : 0)) /
-      100) *
-    (highestBurningMob.abilities.burn.unlimited ? 3 : 1.5) *
-    highestBurningMob.attack;
+  const burnPadding = highestBurningMob
+    ? dps_multiplier(
+        highestBurningMob.damage_type === "physical"
+          ? characterEntity.armor - highestBurningMob.apiercing
+          : highestBurningMob.damage_type === "magical"
+          ? characterEntity.resistance - highestBurningMob.rpiercing
+          : 1
+      ) *
+      ((100 -
+        (characterEntity.firesistance ??
+        characterEntity.slots.orb?.name === "orba"
+          ? 15
+          : 0)) /
+        100) *
+      (highestBurningMob.abilities.burn.unlimited ? 3 : 1.5) *
+      highestBurningMob.attack
+    : 0;
 
   return (
     listOfAttackingMobs.reduce(
@@ -421,9 +422,9 @@ function avgPartyDmgTaken(partyMems, dmgType = null) {
 }
 
 function rotateLeader(mems, value) {
-  const idx = arr.indexOf(value);
-  if (idx === -1) return arr; // not found
-  return arr.slice(idx).concat(arr.slice(0, idx));
+  const idx = mems.indexOf(value);
+  if (idx === -1) return mems; // not found
+  return mems.slice(idx).concat(mems.slice(0, idx));
 }
 
 function assignRoles() {
@@ -455,11 +456,7 @@ function getMonstersToCBurst() {
         calculateDamage(mob, partyTanker) < MAX_MOB_DPS &&
         mob.range < character.range - 20
     )
-    .sort(
-      (lhs, rhs) =>
-        distance(character,rhs) -
-        distance(character, lhs)
-    );
+    .sort((lhs, rhs) => distance(character, rhs) - distance(character, lhs));
 
   const result = [];
 

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -200,6 +200,8 @@ function calculatePriestItems(target) {
     offhand:
       character.map === "crypt"
         ? "wbook1"
+        : character.name === TANKER && character.s.burned
+        ? "wbookhs"
         : haveLowHpMobsNearby
         ? "mshield"
         : TANKER === character.name ||

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -179,7 +179,7 @@ function calculatePriestItems(target) {
   const currentTarget = get_targeted_monster();
   return {
     mainhand:
-      target.type !== "monster"
+      target?.type !== "monster"
         ? "oozingterror"
         : ["pinkgoo", "snowman", "wabbit", "crab"].includes(
             get_targeted_monster()?.mtype
@@ -219,7 +219,7 @@ function calculatePriestItems(target) {
         ? "orba"
         : haveLowHpMobsNearby
         ? "rabbitsfoot"
-        : target.type !== "monster"
+        : target?.type !== "monster"
         ? "jacko"
         : "test_orb",
     amulet: character.name === TANKER ? "t2stramulet" : "intamulet",

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -54,6 +54,14 @@ function haveFormidableMonsterAroundTarget(target, blastRadius = BLAST_RADIUS) {
   );
 }
 
+function shouldWearLuckGear() {
+  return Object.values(parent.entities).some(
+    (mob) =>
+      (mob.target === character.name || mob.cooperative) &&
+      mob.hp <= Math.min(mob.max_hp * 0.15, 300000),
+  );
+}
+
 // Class Items logic
 function calculateMageItems() {
   const shouldUseBlaster =
@@ -62,11 +70,7 @@ function calculateMageItems() {
     !get_targeted_monster()?.["1hp"] &&
     character.mp > G.skills["magiport"].mp + G.skills["blink"].mp;
 
-  const haveLowHpMobsNearby = Object.values(parent.entities).some(
-    (mob) =>
-      (character.name === mob.target || mob.cooperative) &&
-      mob.hp <= Math.min(mob.max_hp * 0.15, 30000),
-  );
+  const haveLowHpMobsNearby = shouldWearLuckGear();
 
   return {
     mainhand:
@@ -101,11 +105,7 @@ function calculateWarriorItems() {
   const shouldUseBlaster =
     numberOfMonsterAroundTarget(currentTarget) >= 2 && !currentTarget["1hp"];
 
-  const haveLowHpMobsNearby = Object.values(parent.entities).some(
-    (mob) =>
-      (mob.target === character.name || mob.cooperative) &&
-      mob.hp <= Math.min(mob.max_hp * 0.15, 30000),
-  );
+  const haveLowHpMobsNearby = shouldWearLuckGear();
 
   if (
     currentTarget &&
@@ -161,27 +161,32 @@ function calculateWarriorItems() {
   };
 }
 
-function calculateRangerItems() {
+function calculateRangerItems(target) {
+  const haveLowHpMobsNearby = shouldWearLuckGear();
+
   return {
-    mainhand: get_targeted_monster()?.cooperative ? "firebow" : "crossbow",
-    orb: "rabbitsfoot",
+    helmet: "wcap",
+    mainhand: target && target.cooperative ? "firebow" : "crossbow",
+    orb: haveLowHpMobsNearby ? "rabbitsfoot" : "orbofdex",
+    amulet: haveLowHpMobsNearby ? "spookyamulet" : "dexamulet",
+    shoes: haveLowHpMobsNearby ? "wshoes" : "wingedboots",
+    gloves: haveLowHpMobsNearby ? "wgloves" : "mittens",
   };
 }
 
 function calculateCupidItems() {
+  const haveLowHpMobsNearby = shouldWearLuckGear();
   return {
     mainhand: get_targeted_monster()?.cooperative ? "firebow" : "merry",
-    orb: "talkingskull",
+    orb: haveLowHpMobsNearby ? "rabbitsfoot" : "orbofdex",
   };
 }
 
 function calculatePriestItems(target) {
-  const haveLowHpMobsNearby = Object.values(parent.entities).some(
-    (mob) =>
-      (mob.target === character.name || mob.cooperative) &&
-      mob.hp <= Math.min(mob.max_hp * 0.15, 100000),
-  );
+  const haveLowHpMobsNearby = shouldWearLuckGear();
   const currentTarget = get_targeted_monster();
+  const isTanking = isAssignedAsTanker();
+
   return {
     mainhand:
       target &&
@@ -190,11 +195,11 @@ function calculatePriestItems(target) {
         character.slots.mainhand?.name,
       )
         ? "oozingterror"
-        : ["pinkgoo", "snowman", "wabbit", "crab"].includes(
-            get_targeted_monster()?.mtype,
-          )
-        ? "pinkie"
-        : character.map === "crypt"
+        : // : ["pinkgoo", "snowman", "wabbit", "crab"].includes(
+        //     get_targeted_monster()?.mtype,
+        //   )
+        // ? "pinkie"
+        character.map === "crypt"
         ? currentTarget && currentTarget.s["frozen"]
           ? "oozingterror"
           : "froststaff"
@@ -209,7 +214,7 @@ function calculatePriestItems(target) {
     offhand:
       character.map === "crypt"
         ? "wbook1"
-        : isAssignedAsTanker() && character.s.burned
+        : isTanking && character.s.burned
         ? "wbookhs"
         : haveLowHpMobsNearby
         ? "mshield"
@@ -224,43 +229,66 @@ function calculatePriestItems(target) {
         ? "wbookhs"
         : "wbook1",
     orb:
-      isAssignedAsTanker() && character.s.burned
+      isTanking && character.s.burned
         ? "orba"
         : haveLowHpMobsNearby
         ? "rabbitsfoot"
         : target?.type !== "monster"
         ? "jacko"
         : "test_orb",
-    amulet: isAssignedAsTanker() ? "t2stramulet" : "intamulet",
+    gloves: "supermittens",
+    amulet: isTanking ? "t2stramulet" : "intamulet",
   };
 }
 
 function calculateRogueItems(target) {
+  const haveLowHpMobsNearby = shouldWearLuckGear();
   const fieryWeapon = "firestars";
-  const targetStacks = target.s.stack?.s ?? 0;
+
+  // Safely handle missing target
+  if (!target) {
+    return {
+      helmet: haveLowHpMobsNearby ? "wcap" : "fury",
+      mainhand: "daggerofthedead",
+      offhand: "daggerofthedead",
+      shoes: haveLowHpMobsNearby ? "wshoes" : "wingedboots",
+      gloves: haveLowHpMobsNearby ? "wgloves" : "supermittens",
+      amulet: haveLowHpMobsNearby ? "spookyamulet" : "dexamulet",
+      orb: haveLowHpMobsNearby ? "rabbitsfoot" : "orbofdex",
+      chest: "wattire",
+      pants: "wbreeches",
+    };
+  }
+
+  const targetStacks = target.s?.stack?.s ?? 0;
   const fieryWeaponSlot = locate_item(fieryWeapon);
+
   const characterFireStars =
     fieryWeaponSlot !== -1
       ? character.items[fieryWeaponSlot]
       : character.slots.offhand?.name === fieryWeapon
       ? character.slots.offhand
       : undefined;
+
   const equipItemAttackOffset =
-    item_info(character.slots.offhand).attack ??
-    0 - item_info(characterFireStars).attack ??
-    0;
+    (item_info(character.slots.offhand)?.attack ?? 0) -
+    (item_info(characterFireStars)?.attack ?? 0);
+
   const rogueBurnDmg = characterFireStars
-    ? dps_multiplier(target.armor - character.apiercing) *
+    ? dps_multiplier((target.armor ?? 0) - (character.apiercing ?? 0)) *
       ((100 - (target.firesistance ?? 0)) / 100) *
       1.5 *
       (character.attack - equipItemAttackOffset + targetStacks) *
       0.9
     : 0;
 
-  const shouldEquipFireStar = rogueBurnDmg > target.s.burn?.intensity;
+  const shouldEquipFireStar = rogueBurnDmg > (target.s?.burned?.intensity ?? 0);
 
   return {
+    helmet: haveLowHpMobsNearby ? "wcap" : "fury",
     mainhand: "daggerofthedead",
+    shoes: haveLowHpMobsNearby ? "wshoes" : "wingedboots",
+    gloves: haveLowHpMobsNearby ? "wgloves" : "mittens",
     offhand: shouldEquipFireStar ? fieryWeapon : "daggerofthedead",
     amulet: haveLowHpMobsNearby ? "spookyamulet" : "dexamulet",
     orb: haveLowHpMobsNearby ? "rabbitsfoot" : "orbofdex",
@@ -276,7 +304,7 @@ function calculateBestItems(characterClass = character.ctype) {
     case "warrior":
       return calculateWarriorItems();
     case "ranger":
-      return calculateRangerItems();
+      return calculateRangerItems(get_target());
     case "cupid":
       return calculateCupidItems();
     case "priest":
@@ -474,7 +502,7 @@ function avgDmgTaken(characterEntity, dmgType = null) {
       0,
     ) *
       mobbingMultiplier(numberOfAttackingMobs) +
-    Math.max(characterEntity.s.burn?.intensity ?? 0, burnPadding)
+    Math.max(characterEntity.s.burned?.intensity ?? 0, burnPadding)
   );
 }
 
@@ -512,8 +540,9 @@ function isAssignedAsTanker() {
 }
 
 function getMonstersToCBurst() {
-  const partyHealer = get_entity(HEALER);
+  const partyHealer = get_entity(HEALER) ?? get_entity(RANGER);
   const partyTanker = get_entity(TANKER);
+  const healerPower = partyHealer?.heal || partyHealer?.attack || 0;
 
   if (!(partyHealer && partyTanker)) return [];
 
@@ -536,8 +565,7 @@ function getMonstersToCBurst() {
   let tankerNumberOfAggroedMobs = listOfMonsterAttacking(partyHealer).length;
 
   for (const mob of mobsList) {
-    if (partyDmgRecieved >= partyHealer.heal * partyHealer.frequency * 0.95)
-      break;
+    if (partyDmgRecieved >= healerPower * partyHealer.frequency * 0.95) break;
 
     if (
       is_in_range(mob, "cburst") &&
@@ -545,7 +573,7 @@ function getMonstersToCBurst() {
       partyDmgRecieved +
         calculateDamage(mob, partyTanker) *
           mobbingMultiplier(tankerNumberOfAggroedMobs + 1) <
-        partyHealer.heal * partyHealer.frequency * 0.9
+        healerPower * partyHealer.frequency * 0.9
     ) {
       result.push([mob, 2]);
       tankerNumberOfAggroedMobs += 1;
@@ -637,9 +665,9 @@ async function warriorCleave(currentStrategy) {
         .reduce((acc, dmg) => acc + dmg, 0) * mobbingMultiplier(allMobs.length);
 
     // Check if cleaving is safe and beneficial
-    const healer = get_entity(HEALER);
-    const healThreshold =
-      currentStrategy === "pull" ? (healer?.heal ?? 0) * 0.9 : 0;
+    const healer = get_entity(HEALER) ?? get_entity(RANGER);
+    const healerPower = healer?.heal ?? healer?.attack ?? 0;
+    const healThreshold = currentStrategy === "pull" ? healerPower * 0.9 : 0;
 
     if (
       (currentStrategy === "pull"
@@ -720,7 +748,10 @@ async function warriorStomp() {
 
 function shouldAttack() {
   const currentTarget = get_targeted_monster();
-  const partyHealer = get_entity(HEALER);
+  const partyPriest = parent.party_list
+    .map((id) => get_player(id))
+    .filter((player) => player && player.ctype === "priest");
+  const partyHealer = get_entity(HEALER) ?? get_entity(RANGER);
   return character.map === "crypt"
     ? partyHealer && !partyHealer.rip
     : ["warrior", "rogue"].includes(character.ctype) &&
@@ -728,6 +759,6 @@ function shouldAttack() {
       MELEE_IGNORE_LIST.includes(currentTarget.mtype ?? currentTarget.ctype)
     ? false
     : currentTarget && currentTarget.attack > 600 && !currentTarget.target
-    ? partyHealer && !partyHealer.rip
+    ? partyPriest.length > 0 || (partyHealer && !partyHealer.rip)
     : true;
 }

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -106,6 +106,7 @@ function calculateWarriorItems() {
     numberOfMonsterAroundTarget(currentTarget) >= 2 && !currentTarget["1hp"];
 
   const haveLowHpMobsNearby = shouldWearLuckGear();
+  const isTanker = isAssignedAsTanker();
 
   if (
     currentTarget &&
@@ -129,7 +130,7 @@ function calculateWarriorItems() {
     mainhand:
       currentStrategy === usePullStrategies && shouldUseBlaster
         ? "vhammer"
-        : "xmace",
+        : "fireblade",
     offhand:
       (character.map === "crypt" &&
         Object.values(parent.entities).some(
@@ -142,7 +143,7 @@ function calculateWarriorItems() {
         : "fireblade",
     amulet: haveLowHpMobsNearby
       ? "spookyamulet"
-      : (isAssignedAsTanker() &&
+      : (isTanker &&
           Object.values(parent.entities)
             .filter((entity) => entity.type === "monster")
             .some((mob) => mob.target === character.name)) ||
@@ -155,7 +156,7 @@ function calculateWarriorItems() {
       : character.map === "crypt"
       ? "xarmor"
       : "coat1",
-    pants: character.map === "crypt" ? "frankypants" : "frankypants",
+    pants: isTanker ? "frankypants" : "fallen",
     ring2:
       currentTarget && currentTarget.armor > 125 ? "suckerpunch" : "strring",
   };
@@ -282,13 +283,14 @@ function calculateRogueItems(target) {
       0.9
     : 0;
 
-  const shouldEquipFireStar = rogueBurnDmg > (target.s?.burned?.intensity ?? 0);
+  const shouldEquipFireStar =
+    rogueBurnDmg > (target.s?.burned?.intensity ?? 0) || target.cooperative;
 
   return {
     helmet: haveLowHpMobsNearby ? "wcap" : "fury",
     mainhand: "daggerofthedead",
     shoes: haveLowHpMobsNearby ? "wshoes" : "wingedboots",
-    gloves: haveLowHpMobsNearby ? "wgloves" : "mittens",
+    gloves: haveLowHpMobsNearby ? "wgloves" : "supermittens",
     offhand: shouldEquipFireStar ? fieryWeapon : "daggerofthedead",
     amulet: haveLowHpMobsNearby ? "spookyamulet" : "dexamulet",
     orb: haveLowHpMobsNearby ? "rabbitsfoot" : "orbofdex",
@@ -686,16 +688,20 @@ async function warriorCleave(currentStrategy) {
       !formidableMob &&
       !isEquipingItems
     ) {
+      isEquipingItems = true;
       const warriorItems = calculateWarriorItems();
       promises.push(
         // equipBatch({ mainhand: "bataxe" }),
         Promise.all([unequip("offhand"), equip(findMaxLevelItem("bataxe"))]),
         withTimeout(use_skill("cleave"), 2500).then(async () => {
           reduce_cooldown("cleave", 0.95 * character.ping);
-          await equipBatch({
-            mainhand: warriorItems.mainhand,
-            offhand: warriorItems.offhand,
-          });
+          await equipBatch(
+            {
+              mainhand: warriorItems.mainhand,
+              offhand: warriorItems.offhand,
+            },
+            true,
+          );
         }),
       );
     }
@@ -714,7 +720,6 @@ async function warriorStomp() {
   if (
     character.mp < G.skills["stomp"].mp ||
     is_on_cooldown("stomp") ||
-    character.cc >= 100 ||
     Object.values(parent.entities).filter(
       (mob) =>
         mob.type === "monster" &&
@@ -729,21 +734,16 @@ async function warriorStomp() {
 
   promises.push(
     equipBatch({ mainhand: "basher", offhand: undefined }, true),
-    use_skill("stomp").then(() => {
+    use_skill("stomp").then(async () => {
       reduce_cooldown("stomp", 0.95 * character.ping);
-      equipBatch(warriorItems, true);
+      await equipBatch(warriorItems, true);
     }),
   );
 
-  return Promise.all(promises)
-    .then(() => {
-      isStomping = false;
-      isEquipingItems = false;
-    })
-    .catch(() => {
-      isStomping = false;
-      isEquipingItems = false;
-    });
+  return Promise.all(promises).finally(() => {
+    isStomping = false;
+    isEquipingItems = false;
+  });
 }
 
 function shouldAttack() {

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -57,8 +57,18 @@ function haveFormidableMonsterAroundTarget(target, blastRadius = BLAST_RADIUS) {
 function shouldWearLuckGear() {
   return Object.values(parent.entities).some(
     (mob) =>
+      mob.type === "monster" &&
       (mob.target === character.name || mob.cooperative) &&
       mob.hp <= Math.min(mob.max_hp * 0.15, 300000),
+  );
+}
+
+function shouldWearExpGear() {
+  return Object.values(parent.entities).some(
+    (mob) =>
+      mob.type === "monster" &&
+      (parent.party_list.includes(mob.target) || mob.cooperative) &&
+      mob.hp <= Math.min(mob.max_hp * 0.1, 300000),
   );
 }
 
@@ -70,7 +80,8 @@ function calculateMageItems() {
     !get_targeted_monster()?.["1hp"] &&
     character.mp > G.skills["magiport"].mp + G.skills["blink"].mp;
 
-  const haveLowHpMobsNearby = shouldWearLuckGear();
+  const feelingLucky = shouldWearLuckGear();
+  const feelingWise = shouldWearExpGear();
 
   return {
     mainhand:
@@ -91,17 +102,19 @@ function calculateMageItems() {
           ? undefined
           : "wbook1"
         : "wbook1",
-    helmet: haveLowHpMobsNearby ? "eears" : "gphelmet",
+    helmet: feelingLucky ? "eears" : "gphelmet",
     chest: "epyjamas",
     pants: "starkillers",
     shoes: "wingedboots",
     gloves: "supermittens",
-    amulet: haveLowHpMobsNearby ? "spookyamulet" : "intamulet",
+    orb: feelingLucky ? "rabbitsfoot" : feelingWise ? "talkingskull" : "jacko",
+    amulet: feelingWise ? "spookyamulet" : "intamulet",
   };
 }
 
+const STUN_FOCUS_LIST = ["crabxx"];
 function calculateWarriorItems() {
-  const currentTarget = get_targeted_monster();
+  const currentTarget = get_target();
   const shouldUseBlaster =
     numberOfMonsterAroundTarget(currentTarget) >= 2 && !currentTarget["1hp"];
 
@@ -130,6 +143,8 @@ function calculateWarriorItems() {
     mainhand:
       currentStrategy === usePullStrategies && shouldUseBlaster
         ? "vhammer"
+        : currentTarget && STUN_FOCUS_LIST.includes(currentTarget.mtype)
+        ? "xmace"
         : "fireblade",
     offhand:
       (character.map === "crypt" &&
@@ -162,12 +177,107 @@ function calculateWarriorItems() {
   };
 }
 
+const RANGER_INV_ITEMS = {
+  poucher: "pouchbow",
+  fireBow: "firebow",
+  crossBow: "crossbow",
+};
 function calculateRangerItems(target) {
+  // Sanitize input
+  const targets = !target ? [] : Array.isArray(target) ? target : [target];
   const haveLowHpMobsNearby = shouldWearLuckGear();
+  const someTargetCooperative = targets.some((mob) => mob.cooperative);
+
+  // Start with current mainhand
+  let mainhand = character.slots.mainhand?.name;
+
+  const poucherAvailable = findMaxLevelItem(RANGER_INV_ITEMS.poucher) !== -1;
+
+  // --- Poucher priority for pull strategy ---
+  if (targets.length)
+    if (
+      (poucherAvailable || mainhand === RANGER_INV_ITEMS.poucher) &&
+      currentStrategy === usePullStrategies &&
+      targets.some(
+        (mob) =>
+          numberOfMonsterAroundTarget(
+            mob,
+            character.explosion / 3.6 ?? BLAST_RADIUS,
+          ) > 1,
+      )
+    ) {
+      mainhand = RANGER_INV_ITEMS.poucher;
+    }
+    // --- Cooperative ---
+    else if (
+      someTargetCooperative
+      // || targets.every((mob) => mob.target)
+    ) {
+      mainhand = RANGER_INV_ITEMS.fireBow;
+    }
+    // --- Calculate oneshot with crossbow ---
+    else {
+      const currentEquippedBowInfo = character.slots.mainhand
+        ? item_info(character.slots.mainhand)
+        : {
+            name: undefined,
+            attack: 0,
+            apiercing: 0,
+          };
+
+      const fireBowInfo =
+        currentEquippedBowInfo.name === RANGER_INV_ITEMS.fireBow
+          ? currentEquippedBowInfo
+          : item_info(
+              character.items[findMaxLevelItem(RANGER_INV_ITEMS.fireBow)],
+            );
+      const crossbowInfo =
+        currentEquippedBowInfo.name === RANGER_INV_ITEMS.crossBow
+          ? currentEquippedBowInfo
+          : item_info(
+              character.items[findMaxLevelItem(RANGER_INV_ITEMS.crossBow)],
+            );
+      if (crossbowInfo && fireBowInfo) {
+        // Effective attack with crossbow
+        const attackStatEquippingCrossbow =
+          character.attack +
+          (crossbowInfo.attack - currentEquippedBowInfo.attack);
+
+        // Effective AP for crossbow
+        let aPiercingAfterEquipingCrossbow = character.apiercing;
+        if (currentEquippedBowInfo.name !== crossbowInfo.name) {
+          aPiercingAfterEquipingCrossbow += 120;
+        }
+
+        // Calculate damage per target
+        const attackDealtByCrossbow = targets.map(
+          (mob) =>
+            dps_multiplier(mob.armor - aPiercingAfterEquipingCrossbow) *
+            attackStatEquippingCrossbow,
+        );
+
+        const shotMultiplier =
+          targets.length >= 4 ? 0.5 : targets.length >= 2 ? 0.7 : 1;
+
+        // Check if any target can be oneshot by crossbow
+        const oneshotableWithCrossbow = targets.some(
+          (mob, i) =>
+            mob.max_hp <= attackDealtByCrossbow[i] * 0.9 * shotMultiplier,
+        );
+
+        mainhand = oneshotableWithCrossbow
+          ? RANGER_INV_ITEMS.crossBow
+          : RANGER_INV_ITEMS.fireBow;
+      }
+      // --- Fallback if only one bow is available ---
+      else if (!crossbowInfo) mainhand = RANGER_INV_ITEMS.fireBow;
+      else if (!fireBowInfo) mainhand = RANGER_INV_ITEMS.crossBow;
+      else mainhand = "bow";
+    }
 
   return {
     helmet: "wcap",
-    mainhand: target && target.cooperative ? "firebow" : "crossbow",
+    mainhand,
     orb: haveLowHpMobsNearby ? "rabbitsfoot" : "orbofdex",
     amulet: haveLowHpMobsNearby ? "spookyamulet" : "dexamulet",
     shoes: haveLowHpMobsNearby ? "wshoes" : "wingedboots",
@@ -178,15 +288,16 @@ function calculateRangerItems(target) {
 function calculateCupidItems() {
   const haveLowHpMobsNearby = shouldWearLuckGear();
   return {
-    mainhand: get_targeted_monster()?.cooperative ? "firebow" : "merry",
+    mainhand,
     orb: haveLowHpMobsNearby ? "rabbitsfoot" : "orbofdex",
   };
 }
 
 function calculatePriestItems(target) {
-  const haveLowHpMobsNearby = shouldWearLuckGear();
   const currentTarget = get_targeted_monster();
   const isTanking = isAssignedAsTanker();
+  const feelingLucky = shouldWearLuckGear();
+  const feelingWise = shouldWearExpGear();
 
   return {
     mainhand:
@@ -204,7 +315,7 @@ function calculatePriestItems(target) {
         ? currentTarget && currentTarget.s["frozen"]
           ? "oozingterror"
           : "froststaff"
-        : haveLowHpMobsNearby
+        : feelingLucky
         ? "lmace"
         : currentTarget &&
           (currentTarget.cooperative ||
@@ -217,7 +328,7 @@ function calculatePriestItems(target) {
         ? "wbook1"
         : isTanking && character.s.burned
         ? "wbookhs"
-        : haveLowHpMobsNearby
+        : feelingLucky
         ? "mshield"
         : TANKER === character.name ||
           Object.values(parent.entities).some(
@@ -232,10 +343,12 @@ function calculatePriestItems(target) {
     orb:
       isTanking && character.s.burned
         ? "orba"
-        : haveLowHpMobsNearby
+        : feelingLucky
         ? "rabbitsfoot"
         : target?.type !== "monster"
         ? "jacko"
+        : feelingWise
+        ? "talkingskull"
         : "test_orb",
     gloves: "supermittens",
     amulet: isTanking ? "t2stramulet" : "intamulet",
@@ -620,7 +733,7 @@ async function warriorCleave(currentStrategy) {
   const mobsList = Object.values(parent.entities).filter(
     (mob) =>
       mob.type === "monster" &&
-      distance(mob, character) < G.skills["cleave"].range,
+      distance(mob, character) < G.skills["cleave"].range + character.xrange,
   );
 
   if (
@@ -629,7 +742,7 @@ async function warriorCleave(currentStrategy) {
     character.mp < G.skills["cleave"].mp + 280 ||
     is_on_cooldown("cleave") ||
     character.cc >= 100 ||
-    mobsList.some((mob) => mob.type === "porcupine") ||
+    mobsList.some((mob) => MELEE_IGNORE_LIST.includes(mob.mtype)) ||
     mobsList.length === 0 ||
     isCleaving ||
     isEquipingItems
@@ -715,6 +828,7 @@ async function warriorCleave(currentStrategy) {
     !isEquipingItems
   ) {
     isEquipingItems = true;
+    isCleaving = true;
     const warriorItems = calculateWarriorItems();
     promises.push(
       // equipBatch({ mainhand: "bataxe" }),
@@ -732,7 +846,7 @@ async function warriorCleave(currentStrategy) {
     );
   }
 
-  return Promise.all(promises).finally(() => {
+  return Promise.allSettled(promises).finally(() => {
     isCleaving = false;
     isEquipingItems = false;
   });
@@ -755,6 +869,7 @@ async function warriorStomp() {
   isStomping = true;
   const promises = [];
 
+  const warriorItems = calculateWarriorItems();
   promises.push(
     equipBatch({ mainhand: "basher", offhand: undefined }, true),
     use_skill("stomp").then(async () => {
@@ -763,14 +878,14 @@ async function warriorStomp() {
     }),
   );
 
-  return Promise.all(promises).finally(() => {
+  return Promise.allSettled(promises).finally(() => {
     isStomping = false;
     isEquipingItems = false;
   });
 }
 
 function shouldAttack() {
-  const currentTarget = get_targeted_monster();
+  const currentTarget = get_target();
   const partyPriest = parent.party_list
     .map((id) => get_player(id))
     .filter((player) => player && player.ctype === "priest");

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -179,7 +179,11 @@ function calculatePriestItems(target) {
   const currentTarget = get_targeted_monster();
   return {
     mainhand:
-      target && target.type !== "monster"
+      target &&
+      target.type !== "monster" &&
+      !["firestaff", "oozingterror", "pmace", "lmace"].includes(
+        character.slots.mainhand?.name,
+      )
         ? "oozingterror"
         : ["pinkgoo", "snowman", "wabbit", "crab"].includes(
             get_targeted_monster()?.mtype,
@@ -534,7 +538,8 @@ async function warriorCleave(currentStrategy) {
     character.cc >= 100 ||
     mobsList.some((mob) => mob.type === "porcupine") ||
     mobsList.length === 0 ||
-    isCleaving
+    isCleaving ||
+    isEquipingItems
   )
     return;
 
@@ -620,16 +625,14 @@ async function warriorCleave(currentStrategy) {
       const warriorItems = calculateWarriorItems();
       isEquipingItems = true;
       promises.push(
-        Promise.all(
-          [
-            character.slots["offhand"] && unequip("offhand"),
-            equip(findMaxLevelItem("bataxe")),
-          ].filter((promise) => promise !== false),
-        ),
-        // equipBatch({ mainhand: "bataxe", offhand: undefined }, true),
-        use_skill("cleave").then(async () => {
+        // equipBatch({ mainhand: "bataxe" }),
+        Promise.all([unequip("offhand"), equip(findMaxLevelItem("bataxe"))]),
+        withTimeout(use_skill("cleave"), 2500).then(async () => {
           reduce_cooldown("cleave", 0.95 * character.ping);
-          await equipBatch(warriorItems, true);
+          await equipBatch(
+            { mainhand: warriorItems.mainhand, offhand: warriorItems.offhand },
+            true,
+          );
         }),
       );
     }

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -179,14 +179,14 @@ function calculatePriestItems(target) {
   const currentTarget = get_targeted_monster();
   return {
     mainhand:
-      target?.type !== "monster"
+      target && target.type !== "monster"
         ? "oozingterror"
         : ["pinkgoo", "snowman", "wabbit", "crab"].includes(
             get_targeted_monster()?.mtype,
           )
         ? "pinkie"
         : character.map === "crypt"
-        ? currentTarget.s["frozen"]
+        ? currentTarget && currentTarget.s["frozen"]
           ? "oozingterror"
           : "froststaff"
         : currentTarget &&
@@ -237,7 +237,7 @@ function calculateBestItems(characterClass = character.ctype) {
     case "cupid":
       return calculateCupidItems();
     case "priest":
-      return calculatePriestItems();
+      return calculatePriestItems(get_target());
     default:
       return {};
   }
@@ -300,22 +300,27 @@ async function equipBatch(suggestedItems, forced = false) {
   )
     promises.push(unequip("offhand"));
 
-  promises.push(
-    equip_batch(
-      Object.keys(suggestedItems)
-        .filter(
-          (slot) =>
-            suggestedItems[slot] &&
-            (suggestedItems[slot] !== character.slots[slot]?.name ||
-              character.items[findMaxLevelItem(suggestedItems[slot])]?.level >
-                character.slots[slot]?.level),
-        )
-        .map((slot) => ({
-          slot,
-          num: findMaxLevelItem(suggestedItems[slot]),
-        }))
-        .filter((equipInfo) => equipInfo.num >= 0),
+  const usedCounts = {};
+
+  const itemSlots = Object.keys(suggestedItems)
+    .filter(
+      (slot) =>
+        suggestedItems[slot] &&
+        (suggestedItems[slot] !== character.slots[slot]?.name ||
+          character.items[findMaxLevelItem(suggestedItems[slot])]?.level >
+            character.slots[slot]?.level),
     )
+    .map((slot) => {
+      const id = suggestedItems[slot];
+      const count = usedCounts[id] || 0;
+      const num = findMaxLevelItem(id, count); // pick nth item
+      usedCounts[id] = count + 1; // increment for next use
+      return { slot, num };
+    })
+    .filter((equipInfo) => equipInfo.num >= 0);
+
+  promises.push(
+    equip_batch(itemSlots)
       .then(() => {
         isEquipingItems = false;
       })
@@ -323,7 +328,7 @@ async function equipBatch(suggestedItems, forced = false) {
         isEquipingItems = false;
       }),
   );
-  return promises;
+  return Promise.all(promises);
 }
 
 // Utilities
@@ -484,7 +489,7 @@ function getMonstersToCBurst() {
         calculateDamage(mob, partyTanker) < MAX_MOB_DPS &&
         mob.range < character.range - 20 &&
         !WATCHOUT_ABILITIES.some((skill) =>
-          Object.keys(mob.abilities).includes(skill),
+          Object.keys(mob.abilities ?? {}).includes(skill),
         ),
     )
     .sort((lhs, rhs) => distance(character, rhs) - distance(character, lhs));
@@ -523,7 +528,7 @@ async function warriorCleave(currentStrategy) {
   if (
     character.mp < G.skills["cleave"].mp + 280 ||
     is_on_cooldown("cleave") ||
-    character.cc >= 95 ||
+    character.cc >= 120 ||
     Object.values(parent.entities).filter(
       (mob) =>
         mob.type === "monster" &&
@@ -605,7 +610,7 @@ async function warriorCleave(currentStrategy) {
         (mob) =>
           MELEE_IGNORE_LIST.includes(mob.mtype) ||
           WATCHOUT_ABILITIES.some((skill) =>
-            Object.keys(mob.abilities).includes(skill),
+            Object.keys(mob.abilities ?? {}).includes(skill),
           ),
       ) &&
       !listOfNoTargetMonsterInRange.some((mob) => mob.abilities.burn) &&
@@ -613,25 +618,15 @@ async function warriorCleave(currentStrategy) {
       !formidableMob &&
       !isEquipingItems
     ) {
-      await equipBatch({ mainhand: "bataxe", offhand: undefined });
-      promises.push();
-
       const warriorItems = calculateWarriorItems();
       isEquipingItems = true;
-
-      await use_skill("cleave").then(() => {
-        reduce_cooldown("cleave", 0.95 * character.ping);
-        equip_batch([
-          {
-            slot: "mainhand",
-            num: findMaxLevelItem(warriorItems.mainhand),
-          },
-          {
-            slot: "offhand",
-            num: findMaxLevelItem(warriorItems.offhand),
-          },
-        ]);
-      });
+      promises.push(
+        equipBatch({ mainhand: "bataxe", offhand: undefined }, true),
+        use_skill("cleave").then(() => {
+          reduce_cooldown("cleave", 0.95 * character.ping);
+          equipBatch(warriorItems, true);
+        }),
+      );
     }
   } catch (e) {
     isCleaving = false;
@@ -662,24 +657,11 @@ async function warriorStomp() {
   isStomping = true;
   const promises = [];
 
-  await equipBatch({ mainhand: "basher", offhand: undefined });
-
-  const warriorItems = calculateWarriorItems();
-  isEquipingItems = true;
-
   promises.push(
+    equipBatch({ mainhand: "basher", offhand: undefined }, true),
     use_skill("stomp").then(() => {
       reduce_cooldown("stomp", 0.95 * character.ping);
-      equip_batch([
-        {
-          slot: "mainhand",
-          num: findMaxLevelItem(warriorItems.mainhand),
-        },
-        {
-          slot: "offhand",
-          num: findMaxLevelItem(warriorItems.offhand),
-        },
-      ]);
+      equipBatch(warriorItems, true);
     }),
   );
 

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -516,10 +516,12 @@ function avgPartyDmgTaken(partyMems, dmgType = null) {
   );
 }
 
-function rotateLeader(mems, value) {
-  const idx = mems.indexOf(value);
-  if (idx === -1) return mems; // not found
-  return mems.slice(idx).concat(mems.slice(0, idx));
+function rotateLeader(partyList, newLeaderId) {
+  const newLeaderIndex = partyList.indexOf(newLeaderId);
+  if (newLeaderIndex === -1) return partyList; // not found
+  return partyList
+    .slice(newLeaderIndex)
+    .concat(partyList.slice(0, newLeaderIndex));
 }
 
 function assignRoles() {
@@ -527,13 +529,10 @@ function assignRoles() {
     const partyDmgTaken = avgPartyDmgTaken(partyMems);
     const partyMagicalDmgTaken = avgPartyDmgTaken(partyMems, "magical");
 
-    if (partyMagicalDmgTaken / partyDmgTaken >= 0.5) {
-      TANKER = HEALER;
-      partyMems = rotateLeader(partyMems, HEALER);
-    } else {
-      TANKER = WARRIOR;
-      partyMems = rotateLeader(partyMems, WARRIOR);
-    }
+    // If more than half of taken DMG is magical, set our HEALER to be TANKER
+    const magicDmgRatio = partyMagicalDmgTaken / partyDmgTaken;
+    TANKER = magicDmgRatio > 0.5 ? HEALER : WARRIOR;
+    partyMems = rotateLeader(partyMems, TANKER);
   }
 }
 
@@ -542,13 +541,27 @@ function isAssignedAsTanker() {
 }
 
 function getMonstersToCBurst() {
+  // 1. Party Data and Early Exit Preparation
   const partyHealer = get_entity(HEALER) ?? get_entity(RANGER);
   const partyTanker = get_entity(TANKER);
-  const healerPower = partyHealer?.heal || partyHealer?.attack || 0;
+  // Calculate the healer's effective power (Heal > Attack > 0)
+  const healerPower = partyHealer?.heal || partyHealer?.attack * 0.5 || 0;
 
-  if (!(partyHealer && partyTanker)) return [];
+  if (!partyHealer || !partyTanker) return [];
 
-  const mobsList = Object.values(parent.entities)
+  // Healer's effective healing output (with a 5% buffer)
+  const MAX_SAFE_DPS = healerPower * partyHealer.frequency * 0.95;
+  // The damage threshold for adding a new mob (with a 10% buffer)
+  const NEW_MOB_DMG_LIMIT = healerPower * partyHealer.frequency * 0.9;
+
+  // 2. Identify and Filter Eligible Monsters
+  // This section filters the world for mobs that are:
+  // - A 'monster'
+  // - Within 'cburst' range
+  // - Safe for the tank (DPS < MAX_MOB_DPS)
+  // - Out of the mage's range (mob.range < character.range - 20)
+  // - Does NOT have any abilities in the WATCHOUT_ABILITIES list
+  const eligibleMobs = Object.values(parent.entities)
     .filter(
       (mob) =>
         mob.type === "monster" &&
@@ -561,32 +574,45 @@ function getMonstersToCBurst() {
     )
     .sort((lhs, rhs) => distance(character, rhs) - distance(character, lhs));
 
-  const result = [];
+  // 3. Iterative Selection Logic
+  const selectedMobs = [];
 
-  let partyDmgRecieved = avgPartyDmgTaken(partyMems);
-  let tankerNumberOfAggroedMobs = listOfMonsterAttacking(partyHealer).length;
+  // Initial State Variables
+  let currentPartyDmgRecieved = avgPartyDmgTaken(partyMems);
+  let tankerCurrentAggroCount = listOfMonsterAttacking(partyTanker).length;
 
-  for (const mob of mobsList) {
-    if (partyDmgRecieved >= healerPower * partyHealer.frequency * 0.95) break;
+  for (const mob of eligibleMobs) {
+    // Stop adding mobs if the party is already taking too much damage
+    if (currentPartyDmgRecieved >= MAX_SAFE_DPS) break;
 
+    // Check if the mob can be safely added:
     if (
-      is_in_range(mob, "cburst") &&
-      !mob.target &&
-      partyDmgRecieved +
+      is_in_range(mob, "cburst") && // Check range again (safety/original code)
+      !mob.target && // Mob must be untargeted
+      currentPartyDmgRecieved +
         calculateDamage(mob, partyTanker) *
-          mobbingMultiplier(tankerNumberOfAggroedMobs + 1) <
-        healerPower * partyHealer.frequency * 0.9
+          mobbingMultiplier(tankerCurrentAggroCount + 1) <
+        NEW_MOB_DMG_LIMIT // Aggroing the mob must be within the safe limit
     ) {
-      result.push([mob, 2]);
-      tankerNumberOfAggroedMobs += 1;
-      partyDmgRecieved =
-        (partyDmgRecieved * mobbingMultiplier(tankerNumberOfAggroedMobs + 1)) /
-          mobbingMultiplier(tankerNumberOfAggroedMobs) +
-        calculateDamage(mob, partyTanker) *
-          mobbingMultiplier(tankerNumberOfAggroedMobs + 1);
+      // Select the mob
+      selectedMobs.push(mob);
+
+      // Update state variables for the next iteration
+      const oldAggroMult = mobbingMultiplier(tankerCurrentAggroCount);
+      tankerCurrentAggroCount += 1;
+      const newAggroMult = mobbingMultiplier(tankerCurrentAggroCount);
+
+      // Scale previous DPS to the new multiplier context and add the new mob's contribution
+      // This ensures the damage calculation correctly accounts for the change
+      // in the mobbing multiplier when aggro count increases.
+      currentPartyDmgRecieved =
+        (currentPartyDmgRecieved * newAggroMult) / oldAggroMult +
+        calculateDamage(mob, partyTanker) * newAggroMult;
     }
   }
-  return result;
+
+  // Return a ready to use list for mage to cburst, with 2 mp per target
+  return selectedMobs.map((mob) => [mob, 2]);
 }
 
 isCleaving = false;
@@ -596,6 +622,7 @@ async function warriorCleave(currentStrategy) {
       mob.type === "monster" &&
       distance(mob, character) < G.skills["cleave"].range,
   );
+
   if (
     character.s.sugarrush ||
     character.s.penalty_cd ||
@@ -611,102 +638,98 @@ async function warriorCleave(currentStrategy) {
 
   isCleaving = true;
   const promises = [];
-  try {
-    // List monsters attacking the character
-    const mobsTargetingSelf = listOfMonsterAttacking(character);
-    const magicalMobs = [],
-      physicalMobs = [],
-      pureMobs = [];
 
-    for (const mob of mobsTargetingSelf) {
-      if (mob.damage_type === "magical") magicalMobs.push(mob);
-      else if (mob.damage_type === "physical") physicalMobs.push(mob);
-      else if (mob.damage_type === "pure") pureMobs.push(mob);
-    }
+  // List monsters attacking the character
+  const mobsTargetingSelf = listOfMonsterAttacking(character);
+  const magicalMobs = [],
+    physicalMobs = [],
+    pureMobs = [];
 
-    // Get non-targeted monsters in cleave range
-    const listOfNoTargetMonsterInRange = Object.values(parent.entities).filter(
-      (mob) => {
-        return (
-          distance(mob, character) <
-            G.skills["cleave"].range + character.xrange &&
-          !mob.target &&
-          mob.type === "monster" &&
-          mob.hp >
-            character.attack *
-              dps_multiplier(mob.armor - character.apiercing) *
-              1.5 &&
-          mob.attack > 150
-        );
-      },
-    );
+  for (const mob of mobsTargetingSelf) {
+    if (mob.damage_type === "magical") magicalMobs.push(mob);
+    else if (mob.damage_type === "physical") physicalMobs.push(mob);
+    else if (mob.damage_type === "pure") pureMobs.push(mob);
+  }
 
-    // Categorize additional mobs that would be cleaved
-    for (const mob of listOfNoTargetMonsterInRange) {
-      if (mob.damage_type === "magical") magicalMobs.push(mob);
-      else if (mob.damage_type === "physical") physicalMobs.push(mob);
-      else if (mob.damage_type === "pure") pureMobs.push(mob);
-    }
-
-    // Check if cleaving would cause fear
-    const isFeared =
-      magicalMobs.length > character.mcourage ||
-      physicalMobs.length > character.courage ||
-      pureMobs.length > character.pcourage;
-
-    // Identify strong mobs that might be risky
-    const formidableMob = listOfNoTargetMonsterInRange.some(
-      (mob) => mob.attack * mob.frequency > MAX_MOB_DPS,
-    );
-
-    // Calculate DPS after cleaving
-    const allMobs = [...magicalMobs, ...physicalMobs, ...pureMobs];
-    const totalDpsTaken =
-      allMobs
-        .map((mob) => calculateDamage(mob, character) * mob.frequency)
-        .reduce((acc, dmg) => acc + dmg, 0) * mobbingMultiplier(allMobs.length);
-
-    // Check if cleaving is safe and beneficial
-    const healer = get_entity(HEALER) ?? get_entity(RANGER);
-    const healerPower = healer?.heal ?? healer?.attack ?? 0;
-    const healThreshold = currentStrategy === "pull" ? healerPower * 0.9 : 0;
-
-    if (
-      (currentStrategy === "pull"
-        ? totalDpsTaken <= healThreshold ||
-          listOfNoTargetMonsterInRange.length === 0
-        : listOfNoTargetMonsterInRange.length === 0) &&
-      !allMobs.some(
-        (mob) =>
-          MELEE_IGNORE_LIST.includes(mob.mtype) ||
-          WATCHOUT_ABILITIES.some((skill) =>
-            Object.keys(mob.abilities ?? {}).includes(skill),
-          ),
-      ) &&
-      !listOfNoTargetMonsterInRange.some((mob) => mob.abilities.burn) &&
-      !isFeared &&
-      !formidableMob &&
-      !isEquipingItems
-    ) {
-      isEquipingItems = true;
-      const warriorItems = calculateWarriorItems();
-      promises.push(
-        // equipBatch({ mainhand: "bataxe" }),
-        Promise.all([unequip("offhand"), equip(findMaxLevelItem("bataxe"))]),
-        withTimeout(use_skill("cleave"), 2500).then(async () => {
-          reduce_cooldown("cleave", 0.95 * character.ping);
-          await equipBatch(
-            {
-              mainhand: warriorItems.mainhand,
-              offhand: warriorItems.offhand,
-            },
-            true,
-          );
-        }),
+  // Get non-targeted monsters in cleave range
+  const listOfNoTargetMonsterInRange = Object.values(parent.entities).filter(
+    (mob) => {
+      return (
+        distance(mob, character) <
+          G.skills["cleave"].range + character.xrange &&
+        !mob.target &&
+        mob.type === "monster" &&
+        mob.hp >
+          character.attack *
+            dps_multiplier(mob.armor - character.apiercing) *
+            1.5 &&
+        mob.attack > 150
       );
-    }
-  } catch (e) {
-    isCleaving = false;
+    },
+  );
+
+  // Categorize additional mobs that would be cleaved
+  for (const mob of listOfNoTargetMonsterInRange) {
+    if (mob.damage_type === "magical") magicalMobs.push(mob);
+    else if (mob.damage_type === "physical") physicalMobs.push(mob);
+    else if (mob.damage_type === "pure") pureMobs.push(mob);
+  }
+
+  // Check if cleaving would cause fear
+  const isFeared =
+    magicalMobs.length > character.mcourage ||
+    physicalMobs.length > character.courage ||
+    pureMobs.length > character.pcourage;
+
+  // Identify strong mobs that might be risky
+  const formidableMob = listOfNoTargetMonsterInRange.some(
+    (mob) => mob.attack * mob.frequency > MAX_MOB_DPS,
+  );
+
+  // Calculate DPS after cleaving
+  const allMobs = [...magicalMobs, ...physicalMobs, ...pureMobs];
+  const totalDpsTaken =
+    allMobs
+      .map((mob) => calculateDamage(mob, character) * mob.frequency)
+      .reduce((acc, dmg) => acc + dmg, 0) * mobbingMultiplier(allMobs.length);
+
+  // Check if cleaving is safe and beneficial
+  const healer = get_entity(HEALER) ?? get_entity(RANGER);
+  const healerPower = healer?.heal ?? healer?.attack ?? 0;
+  const healThreshold = currentStrategy === "pull" ? healerPower * 0.9 : 0;
+  if (
+    (currentStrategy === "pull"
+      ? totalDpsTaken <= healThreshold ||
+        listOfNoTargetMonsterInRange.length === 0
+      : listOfNoTargetMonsterInRange.length === 0) &&
+    !allMobs.some(
+      (mob) =>
+        MELEE_IGNORE_LIST.includes(mob.mtype) ||
+        WATCHOUT_ABILITIES.some((skill) =>
+          Object.keys(mob.abilities ?? {}).includes(skill),
+        ),
+    ) &&
+    !listOfNoTargetMonsterInRange.some((mob) => mob.abilities?.burn) &&
+    !isFeared &&
+    !formidableMob &&
+    !isEquipingItems
+  ) {
+    isEquipingItems = true;
+    const warriorItems = calculateWarriorItems();
+    promises.push(
+      // equipBatch({ mainhand: "bataxe" }),
+      Promise.all([unequip("offhand"), equip(findMaxLevelItem("bataxe"))]),
+      withTimeout(use_skill("cleave"), 2500).then(async () => {
+        reduce_cooldown("cleave", 0.95 * character.ping);
+        await equipBatch(
+          {
+            mainhand: warriorItems.mainhand,
+            offhand: warriorItems.offhand,
+          },
+          true,
+        );
+      }),
+    );
   }
 
   return Promise.all(promises).finally(() => {

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -97,9 +97,9 @@ function calculateMageItems() {
 }
 
 function calculateWarriorItems() {
+  const currentTarget = get_targeted_monster();
   const shouldUseBlaster =
-    numberOfMonsterAroundTarget(get_targeted_monster()) >= 2 &&
-    !get_targeted_monster()["1hp"];
+    numberOfMonsterAroundTarget(currentTarget) >= 2 && !currentTarget["1hp"];
 
   const haveLowHpMobsNearby = Object.values(parent.entities).some(
     (mob) =>
@@ -107,7 +107,10 @@ function calculateWarriorItems() {
       mob.hp <= Math.min(mob.max_hp * 0.15, 30000),
   );
 
-  if (["pinkgoo", "snowman", "wabbit"].includes(get_targeted_monster()?.mtype))
+  if (
+    currentTarget &&
+    ["pinkgoo", "snowman", "wabbit"].includes(currentTarget.mtype)
+  )
     return {
       mainhand: "rapier",
       offhand: undefined,
@@ -122,7 +125,7 @@ function calculateWarriorItems() {
       ? "oxhelmet"
       : character.map === "crypt"
       ? "xhelmet"
-      : "helmet1",
+      : "fury",
     mainhand:
       currentStrategy === usePullStrategies && shouldUseBlaster
         ? "vhammer"
@@ -153,6 +156,8 @@ function calculateWarriorItems() {
       ? "xarmor"
       : "coat1",
     pants: character.map === "crypt" ? "frankypants" : "frankypants",
+    ring2:
+      currentTarget && currentTarget.armor > 125 ? "suckerpunch" : "strring",
   };
 }
 
@@ -174,7 +179,7 @@ function calculatePriestItems(target) {
   const haveLowHpMobsNearby = Object.values(parent.entities).some(
     (mob) =>
       (mob.target === character.name || mob.cooperative) &&
-      mob.hp <= Math.min(mob.max_hp * 0.15, 30000),
+      mob.hp <= Math.min(mob.max_hp * 0.15, 100000),
   );
   const currentTarget = get_targeted_monster();
   return {
@@ -193,13 +198,13 @@ function calculatePriestItems(target) {
         ? currentTarget && currentTarget.s["frozen"]
           ? "oozingterror"
           : "froststaff"
+        : haveLowHpMobsNearby
+        ? "lmace"
         : currentTarget &&
           (currentTarget.cooperative ||
             currentTarget["1hp"] ||
             currentTarget["avoidance"] > 90)
         ? "firestaff"
-        : haveLowHpMobsNearby
-        ? "lmace"
         : "oozingterror",
     offhand:
       character.map === "crypt"
@@ -227,6 +232,40 @@ function calculatePriestItems(target) {
         ? "jacko"
         : "test_orb",
     amulet: isAssignedAsTanker() ? "t2stramulet" : "intamulet",
+  };
+}
+
+function calculateRogueItems(target) {
+  const fieryWeapon = "firestars";
+  const targetStacks = target.s.stack?.s ?? 0;
+  const fieryWeaponSlot = locate_item(fieryWeapon);
+  const characterFireStars =
+    fieryWeaponSlot !== -1
+      ? character.items[fieryWeaponSlot]
+      : character.slots.offhand?.name === fieryWeapon
+      ? character.slots.offhand
+      : undefined;
+  const equipItemAttackOffset =
+    item_info(character.slots.offhand).attack ??
+    0 - item_info(characterFireStars).attack ??
+    0;
+  const rogueBurnDmg = characterFireStars
+    ? dps_multiplier(target.armor - character.apiercing) *
+      ((100 - (target.firesistance ?? 0)) / 100) *
+      1.5 *
+      (character.attack - equipItemAttackOffset + targetStacks) *
+      0.9
+    : 0;
+
+  const shouldEquipFireStar = rogueBurnDmg > target.s.burn?.intensity;
+
+  return {
+    mainhand: "daggerofthedead",
+    offhand: shouldEquipFireStar ? fieryWeapon : "daggerofthedead",
+    amulet: haveLowHpMobsNearby ? "spookyamulet" : "dexamulet",
+    orb: haveLowHpMobsNearby ? "rabbitsfoot" : "orbofdex",
+    chest: "wattire",
+    pants: "wbreeches",
   };
 }
 
@@ -423,10 +462,7 @@ function avgDmgTaken(characterEntity, dmgType = null) {
             (G.monsters[highestBurningMob.mtype].rpiercing ?? 0)
           : 1,
       ) *
-      ((100 -
-        (characterEntity.firesistance ??
-          (characterEntity.slots.orb?.name === "orba" ? 15 : 0))) /
-        100) *
+      ((100 - fireResist) / 100) *
       (highestBurningMob.abilities.burn.unlimited ? 3 : 1.5) *
       highestBurningMob.attack
     : 0;
@@ -623,22 +659,20 @@ async function warriorCleave(currentStrategy) {
       !isEquipingItems
     ) {
       const warriorItems = calculateWarriorItems();
-      isEquipingItems = true;
       promises.push(
         // equipBatch({ mainhand: "bataxe" }),
         Promise.all([unequip("offhand"), equip(findMaxLevelItem("bataxe"))]),
         withTimeout(use_skill("cleave"), 2500).then(async () => {
           reduce_cooldown("cleave", 0.95 * character.ping);
-          await equipBatch(
-            { mainhand: warriorItems.mainhand, offhand: warriorItems.offhand },
-            true,
-          );
+          await equipBatch({
+            mainhand: warriorItems.mainhand,
+            offhand: warriorItems.offhand,
+          });
         }),
       );
     }
   } catch (e) {
     isCleaving = false;
-    isEquipingItems = false;
   }
 
   return Promise.all(promises).finally(() => {

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -64,8 +64,8 @@ function calculateMageItems() {
 
   const haveLowHpMobsNearby = Object.values(parent.entities).some(
     (mob) =>
-      (partyMems.includes(mob.target) || mob.cooperative) &&
-      mob.hp <= mob.max_hp * 0.15,
+      (character.name === mob.target || mob.cooperative) &&
+      mob.hp <= Math.min(mob.max_hp * 0.15, 30000),
   );
 
   return {
@@ -87,7 +87,7 @@ function calculateMageItems() {
           ? undefined
           : "wbook1"
         : "wbook1",
-    helmet: "eears",
+    helmet: haveLowHpMobsNearby ? "eears" : "gphelmet",
     chest: "epyjamas",
     pants: "starkillers",
     shoes: "wingedboots",
@@ -102,9 +102,9 @@ function calculateWarriorItems() {
     !get_targeted_monster()["1hp"];
 
   const haveLowHpMobsNearby = Object.values(parent.entities).some(
-    (mobs) =>
-      (mobs.target === character.name || mobs.cooperative) &&
-      mobs.hp <= mobs.max_hp * 0.15,
+    (mob) =>
+      (mob.target === character.name || mob.cooperative) &&
+      mob.hp <= Math.min(mob.max_hp * 0.15, 30000),
   );
 
   if (["pinkgoo", "snowman", "wabbit"].includes(get_targeted_monster()?.mtype))
@@ -172,9 +172,9 @@ function calculateCupidItems() {
 
 function calculatePriestItems(target) {
   const haveLowHpMobsNearby = Object.values(parent.entities).some(
-    (mobs) =>
-      (mobs.target === character.name || mobs.cooperative) &&
-      mobs.hp <= mobs.max_hp * 0.15,
+    (mob) =>
+      (mob.target === character.name || mob.cooperative) &&
+      mob.hp <= Math.min(mob.max_hp * 0.15, 30000),
   );
   const currentTarget = get_targeted_monster();
   return {
@@ -271,7 +271,7 @@ function findMaxLevelItem(id, offset = 0) {
 
 var isEquipingItems = false;
 async function equipBatch(suggestedItems, forced = false) {
-  if ((character.cc > 100 || isEquipingItems) && !forced) return;
+  if ((character.cc > 130 || isEquipingItems) && !forced) return;
 
   isEquipingItems = true;
 
@@ -318,17 +318,13 @@ async function equipBatch(suggestedItems, forced = false) {
       return { slot, num };
     })
     .filter((equipInfo) => equipInfo.num >= 0);
-
-  promises.push(
-    equip_batch(itemSlots)
-      .then(() => {
-        isEquipingItems = false;
-      })
-      .catch(() => {
-        isEquipingItems = false;
-      }),
-  );
-  return Promise.all(promises);
+  if (itemSlots.length)
+    if (itemSlots.length <= 2 && !character.s.penalty_cd)
+      for (const item of itemSlots) promises.push(equip(item.num, item.slot));
+    else promises.push(equip_batch(itemSlots));
+  return Promise.all(promises).finally(() => {
+    isEquipingItems = false;
+  });
 }
 
 // Utilities
@@ -525,16 +521,19 @@ function getMonstersToCBurst() {
 
 isCleaving = false;
 async function warriorCleave(currentStrategy) {
+  const mobsList = Object.values(parent.entities).filter(
+    (mob) =>
+      mob.type === "monster" &&
+      distance(mob, character) < G.skills["cleave"].range,
+  );
   if (
+    character.s.sugarrush ||
+    character.s.penalty_cd ||
     character.mp < G.skills["cleave"].mp + 280 ||
     is_on_cooldown("cleave") ||
-    character.cc >= 120 ||
-    Object.values(parent.entities).filter(
-      (mob) =>
-        mob.type === "monster" &&
-        distance(mob, character) < G.skills["cleave"].range &&
-        mob.mtype !== "porcupine",
-    ).length === 0 ||
+    character.cc >= 100 ||
+    mobsList.some((mob) => mob.type === "porcupine") ||
+    mobsList.length === 0 ||
     isCleaving
   )
     return;
@@ -621,10 +620,16 @@ async function warriorCleave(currentStrategy) {
       const warriorItems = calculateWarriorItems();
       isEquipingItems = true;
       promises.push(
-        equipBatch({ mainhand: "bataxe", offhand: undefined }, true),
-        use_skill("cleave").then(() => {
+        Promise.all(
+          [
+            character.slots["offhand"] && unequip("offhand"),
+            equip(findMaxLevelItem("bataxe")),
+          ].filter((promise) => promise !== false),
+        ),
+        // equipBatch({ mainhand: "bataxe", offhand: undefined }, true),
+        use_skill("cleave").then(async () => {
           reduce_cooldown("cleave", 0.95 * character.ping);
-          equipBatch(warriorItems, true);
+          await equipBatch(warriorItems, true);
         }),
       );
     }


### PR DESCRIPTION
 - [x] Add a WATCHOUT_ABILITIES list to make Mage and Warrior more considerate about fireroamer, fmagex and dragoldx and other mobs to watchout in the future
 - [x] Add burning effect and its padding formula to overall damage deduction for a character (strategic_fn => avgDmgTaken())
 - [x] Refactor parent.entities to be used with Object.values() instead of Object.keys() for consistency and readability
 - [x] Move Priest equipment consideration to strategy for readability
 
-- Note
 - [x] This pull request will be merged after more testing in Halloween event
 