### PR TITLE
More optimizations and loots

### DIFF
--- a/advance_smart_move.20.js
+++ b/advance_smart_move.20.js
@@ -439,12 +439,30 @@ async function smartMove(
             throw new Error("Magiport unavailable, mage location unknown");
           }
 
-          if (mageEntity.map === segment.map && distance(segment, mageEntity) < 300) {
+          if (
+            mageEntity.map === segment.map &&
+            distance(segment, mageEntity) < 300
+          ) {
             send_cm(MAGE, "magiport");
             await sleep(character.ping * 6);
             if (distance(character, segment) < 300) continue;
           } else {
-            throw new Error(`Magiport unavailable, mage too far from blink destination: ${distance(segment, mageEntity)}`);
+            throw new Error(
+              `Magiport unavailable, mage too far from blink destination: ${distance(
+                segment,
+                mageEntity,
+              )}`,
+            );
+          }
+        } else {
+          if (
+            character.mp > G.skills["blink"].mp &&
+            !is_on_cooldown("blink") &&
+            character.map === segment.map
+          ) {
+            await use_skill("blink", [segment.x, segment.y]);
+            await sleep(character.ping * 0.7);
+            continue;
           }
         }
       }

--- a/advance_smart_move.20.js
+++ b/advance_smart_move.20.js
@@ -357,7 +357,7 @@ async function smartMoveAStar(
 
   if (!Array.isArray(pathFindingResult) || !pathFindingResult.length) {
     throw new Error(
-      `Unable to find path from ${character.map},${character.x},${character.y}`,
+      `Unable to find path from ${character.map},${character.x},${character.y} to ${toPosition.map},${toPosition.x},${toPosition.y}`,
     );
   }
   isAdvanceSmartMoving = true;
@@ -381,7 +381,7 @@ async function smartMoveAStar(
       }
 
       if (segment.method === "town") {
-        await smartMoveAStar({ map: segment.map }, { speed: 999999 });
+        await smartMoveAStar({ map: segment.map }, { speed: 999999999 });
       }
     }
   } catch (e) {

--- a/advance_smart_move.20.js
+++ b/advance_smart_move.20.js
@@ -476,6 +476,7 @@ async function advanceSmartMove(
   let scareInterval = undefined;
 
   if (options.useScare) {
+    await scareAwayMobs();
     scareInterval = setInterval(() => {
       scareAwayMobs();
     }, 1000);
@@ -484,7 +485,6 @@ async function advanceSmartMove(
 
   try {
     // useNearbySmartMove();
-    await scareAwayMobs();
 
     if (isAdvanceSmartMoving) {
       resetSmartMove();

--- a/advance_smart_move.20.js
+++ b/advance_smart_move.20.js
@@ -250,6 +250,33 @@ function pathfinderGetPath(toPosition, speed = character.speed) {
   );
 }
 
+async function useTownWithRetry({ maxRetries = 5, retryDelay = 300 } = {}) {
+  let attempts = 0;
+
+  while (attempts < maxRetries) {
+    try {
+      await use_skill("use_town");
+      await sleep(500);
+      return true;
+    } catch (e) {
+      attempts++;
+      await sleep(retryDelay);
+    }
+  }
+
+  let mapData = parent.G.maps[character.map];
+
+  if (mapData.spawns?.length) {
+    await smart_move({
+      map: character.map,
+      x: mapData.spawns[0][0],
+      y: mapData.spawns[0][1],
+    });
+  }
+
+  return false;
+}
+
 /**
  * A smart move helper using earth's ALPathfinder
  * @param {Object} toPosition
@@ -262,7 +289,7 @@ async function smartMove(
     useMagiport: true,
     useScare: true,
     stopCondition: undefined,
-    speed: 999999999,
+    speed: 100,
   },
 ) {
   if (!toPosition) return;
@@ -391,8 +418,8 @@ async function smartMove(
       }
 
       if (segment.method === "town") {
-        await use_skill("use_town");
-        await sleep(500);
+        await useTownWithRetry();
+        continue;
       }
     }
   } catch (e) {

--- a/advance_smart_move.20.js
+++ b/advance_smart_move.20.js
@@ -252,19 +252,24 @@ function pathfinderGetPath(toPosition, speed = character.speed) {
 
 async function useTownWithRetry({ maxRetries = 5, retryDelay = 300 } = {}) {
   let attempts = 0;
+  let mapData = parent.G.maps[character.map];
 
   while (attempts < maxRetries) {
-    try {
-      await use_skill("use_town");
-      await sleep(500);
+    await town();
+
+    if (mapData.spawns?.length) {
+      if (
+        distance(character, {
+          map: character.map,
+          x: mapData.spawns[0][0],
+          y: mapData.spawns[0][1],
+        }) > 100
+      ) {
+        continue;
+      }
       return true;
-    } catch (e) {
-      attempts++;
-      await sleep(retryDelay);
     }
   }
-
-  let mapData = parent.G.maps[character.map];
 
   if (mapData.spawns?.length) {
     await smart_move({
@@ -289,7 +294,7 @@ async function smartMove(
     useMagiport: true,
     useScare: true,
     stopCondition: undefined,
-    speed: 100,
+    speed: 50,
   },
 ) {
   if (!toPosition) return;

--- a/advance_smart_move.20.js
+++ b/advance_smart_move.20.js
@@ -357,6 +357,7 @@ async function smartMove(
   }
 
   if (!Array.isArray(pathFindingResult) || !pathFindingResult.length) {
+    await use_skill("use_town");
     throw new Error(
       `Unable to find path from ${character.map},${character.x},${character.y} to ${toPosition.map},${toPosition.x},${toPosition.y}`,
     );

--- a/advance_smart_move.20.js
+++ b/advance_smart_move.20.js
@@ -495,6 +495,14 @@ function resetSmartMove() {
   smart.try_exact_spot = true;
 }
 
+async function smartMoveWrapper(args, options = undefined) {
+  if (parent.caracAL && parent.caracAL.ALPathfinder) {
+    return smartMove(args, options);
+  } else {
+    return smart_move(args);
+  }
+}
+
 async function advanceSmartMove(
   props,
   options = {
@@ -538,7 +546,7 @@ async function advanceSmartMove(
       get("cryptInstance")
     ) {
       if (distance(character, CRYPT_DOOR) > 100)
-        await smart_move(CRYPT_DOOR).catch((e) => e);
+        await smartMoveWrapper(CRYPT_DOOR).catch((e) => e);
 
       await enter("crypt", get("cryptInstance"));
       await sleep(character.ping * 3 + 3000);
@@ -557,12 +565,11 @@ async function advanceSmartMove(
         await mageBlink(character.map, [props.x, props.y]);
         log("Blinked!");
         await sleep(character.ping);
-        isAdvanceSmartMoving = false;
         log("Done!");
-        await smart_move(props);
+        await smartMoveWrapper(props);
         resetSmartMove();
         clearInterval(scareInterval);
-
+        isAdvanceSmartMoving = false;
         return;
       }
 
@@ -582,7 +589,7 @@ async function advanceSmartMove(
         // Blink to location if enough mana
         await mageBlink(aliaTo.map, [props.x, props.y]);
         await sleep(character.ping + 800);
-        await smart_move(props);
+        await smartMoveWrapper(props);
         isAdvanceSmartMoving = false;
         resetSmartMove();
         clearInterval(scareInterval);
@@ -594,17 +601,18 @@ async function advanceSmartMove(
         const checkingMapInterval = setInterval(() => {
           if (character.map === props.map) {
             stop("smart");
+            stop("moving");
             clearInterval(checkingMapInterval);
           }
         }, 1000);
 
-        await smart_move({ map: props.map }).catch((e) => e);
+        await smartMoveWrapper({ map: props.map }).catch((e) => e);
 
         await mageBlink(props.map, [props.x, props.y]);
 
         await sleep(character.ping);
         isAdvanceSmartMoving = false;
-        await smart_move(props);
+        await smartMoveWrapper(props);
         clearInterval(scareInterval);
         resetSmartMove();
         return;
@@ -652,7 +660,7 @@ async function advanceSmartMove(
             send_cm(MAGE, "magiport");
             log("Whoosh!");
             await sleep(character.ping * 2);
-            if (distance(character, props) < 300) stop("smart");
+            if (distance(character, props) < 300) stop();
             clearInterval(checkingMageMagiportInterval);
           }
         }, 1000);
@@ -667,7 +675,7 @@ async function advanceSmartMove(
           })
         ) {
           await move(props.x, props.y);
-        } else await smart_move(props);
+        } else await smartMoveWrapper(props);
         clearInterval(checkingMageMagiportInterval);
         isAdvanceSmartMoving = false;
         clearInterval(scareInterval);

--- a/advance_smart_move.20.js
+++ b/advance_smart_move.20.js
@@ -1,3 +1,4 @@
+// Global vars and Constants
 var isAdvanceSmartMoving = false;
 
 const CRYPT_DOOR = {
@@ -33,12 +34,361 @@ const ALIA_FROM_POSITION = {
   },
 };
 
+const CELL = Object.freeze({
+  unknown: 0,
+  unstandable: -1,
+  standable: 1,
+});
+const GRID_CACHE = {};
+
+// Utils
+
+/**
+ * @author earthiverse
+ *
+ * Only use within DOM environment to search for character's ifram
+ * @param {string} name Character's ID
+ * @returns
+ */
 function getCharacter(name) {
   for (const iframe of top.$("iframe")) {
     const char = iframe.contentWindow.character;
     if (!char) continue; // Character isn't loaded yet
     if (char.name == name) return char;
   }
+}
+
+if (parent.caracAL && parent.caracAL.ALPathfinder) {
+  parent.caracAL.ALPathfinder.prepare(parent.G);
+}
+
+/**
+ * Generates and caches a grid object for the target map on cache miss.
+ * TODO: Account for mob spawn points as additional standable seeds.
+ *
+ * @version 20251227vCow
+ * @param {string} mapString - The target map ID
+ * @returns {Object} Grid data including standability map and map boundaries
+ */
+function getGrid(mapString) {
+  if (GRID_CACHE[mapString]) return GRID_CACHE[mapString];
+  const data = parent.G.geometry[mapString];
+  const { min_x, min_y, max_x, max_y, x_lines, y_lines, points } = data;
+  const mapMobs = parent.G.maps[mapString].monsters;
+  const mapSpawns = mapMobs
+    .filter((p) => !p.boundaries && p.boundary)
+    .reduce((acc, current) => {
+      acc.push([
+        (current.boundary[0] + current.boundary[2]) / 2,
+        (current.boundary[1] + current.boundary[3]) / 2,
+      ]);
+      return acc;
+    }, []);
+
+  // Init Array for Grid coloring
+  const gridWidth = Math.ceil(max_x - min_x);
+  const gridHeight = Math.ceil(max_y - min_y);
+  const mapGrid = new Int8Array(gridWidth * gridHeight);
+  mapGrid.fill(CELL.unknown);
+
+  // Color Boundaries with CELL.unstandable
+  for (const yLine of y_lines) {
+    const y = Math.round(yLine[0] - min_y);
+    const fromX = Math.max(0, Math.round(yLine[1] - min_x));
+    const toX = Math.min(gridWidth - 1, Math.round(yLine[2] - min_x));
+    for (let x = fromX; x <= toX; x++) {
+      if (y >= 0 && y < gridHeight)
+        mapGrid[y * gridWidth + x] = CELL.unstandable;
+    }
+  }
+
+  for (const xLine of x_lines) {
+    const x = Math.round(xLine[0] - min_x);
+    const fromY = Math.max(0, Math.round(xLine[1] - min_y));
+    const toY = Math.min(gridHeight - 1, Math.round(xLine[2] - min_y));
+    for (let y = fromY; y <= toY; y++) {
+      if (x >= 0 && x < gridWidth)
+        mapGrid[y * gridWidth + x] = CELL.unstandable;
+    }
+  }
+
+  // Prepare Seeds (The points where we KNOW we can stand)
+  const queue = [];
+  for (let key in points) {
+    const p = points[key];
+    const px = Math.round(p[0] - min_x);
+    const py = Math.round(p[1] - min_y);
+    const idx = py * gridWidth + px;
+    if (mapGrid[idx] === CELL.unknown) {
+      mapGrid[idx] = CELL.standable;
+      queue.push(idx);
+    }
+  }
+
+  // Seed from monster spawn centers
+  for (const [x, y] of mapSpawns) {
+    const px = Math.round(x - min_x);
+    const py = Math.round(y - min_y);
+    const idx = py * gridWidth + px;
+
+    if (mapGrid[idx] === CELL.unknown) {
+      mapGrid[idx] = CELL.standable;
+      queue.push(idx);
+    }
+  }
+
+  // Flood Fill (BFS)
+  let head = 0;
+  while (head < queue.length) {
+    const currIdx = queue[head++];
+    const x = currIdx % gridWidth;
+    const y = (currIdx / gridWidth) | 0;
+
+    // Standard 4-direction check (1 pixel at a time)
+    const neighbors = [
+      [x + 1, y],
+      [x - 1, y],
+      [x, y + 1],
+      [x, y - 1],
+    ];
+
+    for (const [nx, ny] of neighbors) {
+      if (nx >= 0 && nx < gridWidth && ny >= 0 && ny < gridHeight) {
+        const nextIdx = ny * gridWidth + nx;
+        if (mapGrid[nextIdx] === 0) {
+          // If CELL.unknown and not a wall
+          mapGrid[nextIdx] = 1;
+          queue.push(nextIdx);
+        }
+      }
+    }
+  }
+
+  GRID_CACHE[mapString] = {
+    gridWidth,
+    gridHeight,
+    mapGrid,
+    maxX: max_x,
+    maxY: max_y,
+    minX: min_x,
+    minY: min_y,
+  };
+
+  return GRID_CACHE[mapString];
+}
+
+/**
+ * Helper to check against the grid
+ * @param {Object} position a position object with `x`, `y`, and `map` id
+ * @returns
+ */
+function isStandablePoint(position) {
+  const { x, y, map } = position;
+  const { gridWidth, gridHeight, mapGrid, minX, minY } = getGrid(map);
+
+  // Convert world → grid coordinates
+  const gx = Math.round(x - minX);
+  const gy = Math.round(y - minY);
+
+  // Out of bounds = not standable
+  if (gx < 0 || gx >= gridWidth || gy < 0 || gy >= gridHeight) {
+    return false;
+  }
+
+  const idx = gy * gridWidth + gx;
+  return mapGrid[idx] === CELL.standable;
+}
+
+/**
+ * Returns spawns data for the given monster
+ *
+ * @param {string} monster
+ * @param {Object} g
+ * @returns {Array<{ map: string, x: number, y: number }>}
+ */
+function getMonsterSpawns(monster, g = parent.G) {
+  const spawns = [];
+
+  for (const [mapKey, gMap] of Object.entries(g.maps)) {
+    if (gMap.ignore) continue; // Ignore map
+    if (!gMap.monsters) continue; // No monsters on map
+
+    for (const mapMonster of gMap.monsters) {
+      if (mapMonster.type !== monster) continue; // Different monster
+
+      const boundaries = mapMonster.boundaries ?? [
+        [mapKey, ...mapMonster.boundary],
+      ];
+
+      for (const [map, x1, y1, x2, y2] of boundaries) {
+        spawns.push({
+          map,
+          x: (x1 + x2) / 2,
+          y: (y1 + y2) / 2,
+        });
+      }
+    }
+  }
+
+  return spawns;
+}
+
+/**
+ * Pathfinding using earth's ALPathfinder
+ * @param {Object} toPosition includes `x`, `y` and `map`
+ * @param {number} speed set the speed to a very big number to disable use_town, default: character's speed
+ */
+function pathfinderGetPath(toPosition, speed = character.speed) {
+  return parent.caracAL.ALPathfinder.getPath(
+    character.map,
+    character.x,
+    character.y,
+    toPosition.map,
+    toPosition.x,
+    toPosition.y,
+    speed,
+  );
+}
+
+/**
+ * A smart move helper using earth's ALPathfinder
+ * @param {Object} toPosition
+ * @param {Object} options
+ */
+async function smartMoveAStar(
+  toPosition,
+  options = {
+    useBlink: true,
+    useMagiport: true,
+    stopCondition: undefined,
+    speed: character.speed,
+  },
+) {
+  if (!toPosition) return;
+
+  let pathFindingResult;
+
+  // If position is a mob's name id
+  if (typeof toPosition === "string") {
+    if (!parent.G.monsters[toPosition]) {
+      throw new Error("Unknown monster");
+    }
+
+    const monsterSpawns = getMonsterSpawns(toPosition);
+    if (!monsterSpawns.length) {
+      throw new Error("Monster has no spawns");
+    }
+
+    let shortest = Infinity;
+
+    for (const spawn of monsterSpawns) {
+      const result = pathfinderGetPath(spawn, options.speed);
+
+      if (Array.isArray(result) && result.length < shortest) {
+        shortest = result.length;
+        pathFindingResult = result;
+
+        // prefer same-map immediately
+        if (spawn.map === character.map) break;
+      }
+    }
+  } else {
+    /* Position filler */
+
+    // Fill map first
+    if (
+      toPosition.map === undefined &&
+      toPosition.x !== undefined &&
+      toPosition.y !== undefined
+    ) {
+      toPosition.map = character.map;
+    }
+
+    let mapData = parent.G.maps[toPosition.map];
+
+    // Fill x/y from spawn
+    if (
+      mapData.spawns?.length &&
+      (toPosition.x === undefined || toPosition.y === undefined)
+    ) {
+      toPosition.x = mapData.spawns[0][0];
+      toPosition.y = mapData.spawns[0][1];
+    }
+
+    // Final validation
+    if (
+      toPosition.map === undefined ||
+      toPosition.x === undefined ||
+      toPosition.y === undefined
+    ) {
+      throw new Error(
+        `Unable to find path from ${character.map},${character.x},${character.y} ` +
+          `to ${toPosition.map},${toPosition.x},${toPosition.y}`,
+      );
+    }
+
+    pathFindingResult = pathfinderGetPath(toPosition, options.speed);
+
+    // Standable fallback (for example: icegolem spawn)
+    if (
+      (!pathFindingResult || !pathFindingResult.length) &&
+      mapData?.spawns?.length &&
+      isStandablePoint(toPosition)
+    ) {
+      pathFindingResult = pathfinderGetPath(
+        {
+          ...toPosition,
+          x: mapData.spawns[0][0],
+          y: mapData.spawns[0][1],
+        },
+        options.speed,
+      );
+
+      if (Array.isArray(pathFindingResult)) {
+        pathFindingResult.push({
+          map: toPosition.map,
+          x: toPosition.x,
+          y: toPosition.y,
+          method: "move",
+        });
+      }
+    }
+  }
+
+  if (!Array.isArray(pathFindingResult) || !pathFindingResult.length) {
+    throw new Error(
+      `Unable to find path from ${character.map},${character.x},${character.y}`,
+    );
+  }
+  isAdvanceSmartMoving = true;
+
+  try {
+    // Moving
+    for (const segment of pathFindingResult) {
+      if (segment.method === "move") {
+        if (segment.map !== character.map) {
+          throw new Error(
+            `Expected map ${segment.map}, currently on ${character.map}`,
+          );
+        }
+        console.log(await move(segment.x, segment.y));
+        continue;
+      }
+
+      if (segment.method === "door" || segment.method === "transport") {
+        await transport(segment.map, segment.spawn);
+        continue;
+      }
+
+      if (segment.method === "town") {
+        await smartMoveAStar({ map: segment.map }, { speed: 999999 });
+      }
+    }
+  } catch (e) {
+    isAdvanceSmartMoving = false;
+  }
+
+  isAdvanceSmartMoving = false;
 }
 
 async function scareAwayMobs() {
@@ -51,9 +401,12 @@ async function scareAwayMobs() {
     character.mp > 100
   ) {
     return Promise.all([
-      equipBatch({
-        orb: "jacko",
-      }),
+      equipBatch(
+        {
+          orb: "jacko",
+        },
+        true,
+      ),
       use_skill("scare"),
     ]);
   }

--- a/advance_smart_move.20.js
+++ b/advance_smart_move.20.js
@@ -59,7 +59,7 @@ function getCharacter(name) {
 }
 
 if (parent.caracAL && parent.caracAL.ALPathfinder) {
-  parent.caracAL.ALPathfinder.prepare(parent.G);
+  parent.caracAL.ALPathfinder.prepare(parent.G, ['bank_u']); // Ignore bank_u for pathfinding
 }
 
 /**

--- a/advance_smart_move.20.js
+++ b/advance_smart_move.20.js
@@ -371,7 +371,7 @@ async function smartMove(
             `Expected map ${segment.map}, currently on ${character.map}`,
           );
         }
-        console.log(await move(segment.x, segment.y));
+        await move(segment.x, segment.y);
         continue;
       }
 

--- a/advance_smart_move.20.js
+++ b/advance_smart_move.20.js
@@ -255,7 +255,7 @@ function pathfinderGetPath(toPosition, speed = character.speed) {
  * @param {Object} toPosition
  * @param {Object} options
  */
-async function smartMoveAStar(
+async function smartMove(
   toPosition,
   options = {
     useBlink: true,
@@ -381,7 +381,7 @@ async function smartMoveAStar(
       }
 
       if (segment.method === "town") {
-        await smartMoveAStar({ map: segment.map }, { speed: 999999999 });
+        await smartMove({ map: segment.map }, { speed: 999999999 });
       }
     }
   } catch (e) {

--- a/advance_smart_move.20.js
+++ b/advance_smart_move.20.js
@@ -261,7 +261,7 @@ async function smartMove(
     useBlink: true,
     useMagiport: true,
     stopCondition: undefined,
-    speed: character.speed,
+    speed: 999999999,
   },
 ) {
   if (!toPosition) return;
@@ -381,7 +381,8 @@ async function smartMove(
       }
 
       if (segment.method === "town") {
-        await smartMove({ map: segment.map }, { speed: 999999999 });
+        await use_skill("use_town");
+        await sleep(500);
       }
     }
   } catch (e) {

--- a/advance_smart_move.20.js
+++ b/advance_smart_move.20.js
@@ -382,7 +382,7 @@ async function smartMove(
           map: toPosition.map,
           x: toPosition.x,
           y: toPosition.y,
-          method: "move",
+          method: "blink",
         });
       }
     }
@@ -425,6 +425,28 @@ async function smartMove(
       if (segment.method === "town") {
         await useTownWithRetry();
         continue;
+      }
+
+      if (segment.method === "blink") {
+        if (character.ctype !== "mage") {
+          const mageEntity = parent.caracAL
+            ? parent.caracAL.siblings.includes(MAGE)
+              ? get("mageLocation")
+              : undefined
+            : getCharacter(MAGE);
+
+          if (!mageEntity || mageEntity.Date.now() - mageInfo.time > 15_000) {
+            throw new Error("Magiport unavailable, mage location unknown");
+          }
+
+          if (mageEntity.map === segment.map && distance(segment, mageEntity) < 300) {
+            send_cm(MAGE, "magiport");
+            await sleep(character.ping * 6);
+            if (distance(character, segment) < 300) continue;
+          } else {
+            throw new Error(`Magiport unavailable, mage too far from blink destination: ${distance(segment, mageEntity)}`);
+          }
+        }
       }
     }
   } catch (e) {

--- a/advance_smart_move.20.js
+++ b/advance_smart_move.20.js
@@ -260,6 +260,7 @@ async function smartMove(
   options = {
     useBlink: true,
     useMagiport: true,
+    useScare: true,
     stopCondition: undefined,
     speed: 999999999,
   },
@@ -362,6 +363,14 @@ async function smartMove(
   }
   isAdvanceSmartMoving = true;
 
+  if (options.useScare) {
+    await scareAwayMobs();
+    scareInterval = setInterval(() => {
+      scareAwayMobs();
+    }, 1000);
+    setTimeout(() => clearInterval(scareInterval), 300000);
+  }
+
   try {
     // Moving
     for (const segment of pathFindingResult) {
@@ -386,10 +395,11 @@ async function smartMove(
       }
     }
   } catch (e) {
+    console.log("smartMove error:", e);
+  } finally {
+    clearInterval(scareInterval);
     isAdvanceSmartMoving = false;
   }
-
-  isAdvanceSmartMoving = false;
 }
 
 async function scareAwayMobs() {

--- a/advance_smart_move.20.js
+++ b/advance_smart_move.20.js
@@ -457,7 +457,12 @@ function resetSmartMove() {
   smart.try_exact_spot = true;
 }
 
-async function advanceSmartMove(props) {
+async function advanceSmartMove(
+  props,
+  options = {
+    useScare: true,
+  },
+) {
   if (
     !smart.moving &&
     !character.c &&
@@ -468,11 +473,14 @@ async function advanceSmartMove(props) {
     equip(findMaxLevelItem("broom"));
   }
 
-  const scareInterval = setInterval(() => {
-    scareAwayMobs();
-  }, 1000);
+  let scareInterval = undefined;
 
-  setTimeout(() => clearInterval(scareInterval), 300000);
+  if (options.useScare) {
+    scareInterval = setInterval(() => {
+      scareAwayMobs();
+    }, 1000);
+    setTimeout(() => clearInterval(scareInterval), 300000);
+  }
 
   try {
     // useNearbySmartMove();

--- a/advance_smart_move.20.js
+++ b/advance_smart_move.20.js
@@ -59,7 +59,7 @@ function getCharacter(name) {
 }
 
 if (parent.caracAL && parent.caracAL.ALPathfinder) {
-  parent.caracAL.ALPathfinder.prepare(parent.G, ['bank_u']); // Ignore bank_u for pathfinding
+  parent.caracAL.ALPathfinder.prepare(parent.G, ["bank_u"]); // Ignore bank_u for pathfinding
 }
 
 /**
@@ -254,9 +254,9 @@ async function useTownWithRetry({ maxRetries = 5, retryDelay = 300 } = {}) {
   let attempts = 0;
   let mapData = parent.G.maps[character.map];
 
-  while (attempts < maxRetries) {
+  while (attempts++ < maxRetries) {
     await town();
-
+    await sleep(retryDelay);
     if (mapData.spawns?.length) {
       if (
         distance(character, {

--- a/advance_smart_move.20.js
+++ b/advance_smart_move.20.js
@@ -256,7 +256,18 @@ async function advanceSmartMove(props) {
             clearInterval(checkingMageMagiportInterval);
           }
         }, 1000);
-        await smart_move(props);
+        if (
+          can_move({
+            map: props.map,
+            x: character.real_x,
+            y: character.real_y,
+            going_x: props.x,
+            going_y: props.y,
+            base: character.base,
+          })
+        ) {
+          await move(props.x, props.y);
+        } else await smart_move(props);
         clearInterval(checkingMageMagiportInterval);
         isAdvanceSmartMoving = false;
         clearInterval(scareInterval);

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -1038,10 +1038,17 @@ function getPlayersToHeal() {
 }
 
 function getLowestMana() {
-  const allies = parent.party_list.map((name) => get_entity(name));
-  allies.filter((entity) => entity);
-  allies.sort((lhs, rhs) => lhs.mp / lhs.max_mp - rhs.mp / rhs.max_mp);
-  return allies[0] || character;
+  const allies = parent.party_list
+    .filter((name) => name !== character.name)
+    .map((name) => get_player(name))
+    .filter(
+      (entity) =>
+        entity &&
+        partyMems.includes(entity.name) &&
+        !["mage", "priest"].includes(entity.ctype),
+    )
+    .sort((lhs, rhs) => lhs.mp / lhs.max_mp - rhs.mp / rhs.max_mp);
+  return allies.shift();
 }
 
 //// RESPAWN
@@ -1932,10 +1939,7 @@ function on_magiport(name) {
 function attackErrorHandler(error) {
   if (error.failed) {
     if (error.response === "cooldown" && error.place) {
-      reduce_cooldown(
-        error.place,
-        -error.ms + Math.min(...parent.pings) / 2 ,
-      );
+      reduce_cooldown(error.place, -error.ms + Math.min(...parent.pings) / 2);
     } else if (
       error.reason === "too_far" &&
       character.cc < 125 &&

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -832,7 +832,7 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
   if (
     character.ctype === "warrior" &&
     distance(character, target) > character.range * 0.35 &&
-    distance(character, target) < rangeRadius + extendedRadius
+    distance(character, target) < rangeRadius + extendedRadius * 0.9
   ) {
     const allEntities = Object.values(parent.entities);
     const noAggro = allEntities
@@ -1559,14 +1559,18 @@ const DYNAMIC_PARTY_PRESETS = {
     EUII: () => {
       RANGER = RANGER2;
       HEALER = RANGER;
-      return [ROGUE, RANGER, MAGE];
+      return [WARRIOR, RANGER, MAGE];
     },
     USII: () => {
       RANGER = RANGER1;
       HEALER = PRIEST;
       return [MAGE, RANGER, PRIEST];
     },
-    default: [WARRIOR, RANGER, MAGE],
+    default: () => {
+      RANGER = RANGER1;
+      HEALER = RANGER;
+      return [WARRIOR, RANGER, MAGE];
+    },
   },
   crabxx: () => {
     const isAggroed = !!parent.S.crabxx?.target;

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -147,9 +147,13 @@ const MELEE_IGNORE_LIST = ["porcupine"];
 // var mapX = 255;
 // var mapY = -1160;
 
-var map = "spookytown";
-var mapX = 412;
-var mapY = -694;
+// var map = "spookytown";
+// var mapX = 412;
+// var mapY = -694;
+
+var map = "mforest";
+var mapX = -172;
+var mapY = 708;
 
 // var mobsToFarm = ["grinch", "phoenix", "spider", "bigbird", "scorpion"];
 // var mobsToFarm = ["goldenbot", "sparkbot", "sparkbot"];
@@ -173,7 +177,8 @@ var mapY = -694;
 // var mobsToFarm = ["plantoid"];
 // var mobsToFarm = ["prat"];
 // var mobsToFarm = ["mummy"];
-var mobsToFarm = ["jr", "booboo"];
+// var mobsToFarm = ["jr", "booboo"];
+var mobsToFarm = ["odino"];
 
 // desired elixir named
 var desiredElixir = "elixirluck";
@@ -1865,7 +1870,7 @@ async function changeToDailyEventTargets() {
     let targetCrab;
 
     if (character.ctype === "warrior") {
-      targetCrab = bestClusteredCrabx|| bestCrabx || crabxxInstance;
+      targetCrab = bestClusteredCrabx || bestCrabx || crabxxInstance;
     } else {
       targetCrab =
         bestCrabx || (crabxxInstance?.target ? crabxxInstance : undefined);

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -1940,26 +1940,28 @@ function attackErrorHandler(error) {
   if (error.failed) {
     if (error.response === "cooldown" && error.place) {
       reduce_cooldown(error.place, -error.ms + Math.min(...parent.pings) / 2);
-    } else if (
-      error.reason === "too_far" &&
-      character.cc < 125 &&
-      !character.moving
-    ) {
-      const currentX = character.x;
-      const currentY = character.y;
+    } else if (error.reason === "too_far" && error.place) {
+      if (character.cc < 125 && !character.moving && error.place === "attack") {
+        const currentX = character.x;
+        const currentY = character.y;
 
-      const target = get_target();
-      const targetX = target.real_x ?? target.x;
-      const targetY = target.real_y ?? target.y;
+        const target = get_target();
+        const targetX = target.real_x ?? target.x;
+        const targetY = target.real_y ?? target.y;
 
-      const newX = currentX + 0.4 * (targetX - currentX);
-      const newY = currentY + 0.4 * (targetY - currentY);
+        const newX = currentX + 0.4 * (targetX - currentX);
+        const newY = currentY + 0.4 * (targetY - currentY);
+        move(newX, newY);
+      }
+
       console.warn(
-        `Too far, ${Math.round(error.distance)} distance / ${
-          character.range + character.xrange
-        } range`,
+        `Too far to use '${error.place}'` +
+          (error.place === "attack"
+            ? `, ${Math.round(error.distance)} distance / ${
+                character.range + character.xrange
+              } range`
+            : ""),
       );
-      move(newX, newY);
     }
   } else console.warn("Error while attacking:", error);
 }

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -798,6 +798,12 @@ function extraDistanceWithinHitbox(target) {
 
 var lastKitingTargetId = undefined;
 async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
+  // Debug: Fixed width and height of target
+  if (target) {
+    target.awidth = 24;
+    target.aheight = 24;
+  }
+
   const loopInterval = Math.max(200, getLoopInterval());
 
   // --- 1. Early exits and sanity checks ---
@@ -1201,17 +1207,13 @@ setInterval(async function () {
 
   // Fix a bug where character is stuck to corner
   const currentTarget =
-    get_targeted_monster() ??
-    getTarget() ??
-    get_nearest_monster({ target: TANKER });
+    get_target() ?? getTarget() ?? get_nearest_monster({ target: TANKER });
 
   if (
     currentTarget &&
+    currentTarget.type === "monster" &&
     distance(currentTarget, character) >
-      character.range +
-        character.xrange * 0.9 +
-        extraDistanceWithinHitbox(currentTarget) +
-        extraDistanceWithinHitbox(character) &&
+      character.range + character.xrange * 0.9 &&
     !smart.moving &&
     !isAdvanceSmartMoving
   ) {
@@ -1220,8 +1222,8 @@ setInterval(async function () {
     if (parent.caracAL) {
       await smartMove({
         map: character.map,
-        x: currentTarget.x,
-        y: currentTarget.y,
+        x: currentTarget.going_x,
+        y: currentTarget.going_y,
       });
     } else {
       if (can_move_to(currentTarget.x, currentTarget.y))

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -821,15 +821,14 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
 
   if (
     character.ctype === "warrior" &&
-    ((distance(character, target) > character.range * 0.5 &&
-      distance(character, target) <
-        character.range * rangeRate + character.xrange * 0.25) ||
-      target["1hp"])
+    distance(character, target) > character.range * 0.5 &&
+    distance(character, target) <
+      character.range * rangeRate + character.xrange * 0.25
   ) {
     const allEntities = Object.values(parent.entities);
     const noAggro = allEntities
       .filter((entity) => entity.type === "monster")
-      .every((mob) => mob.target !== character.name);
+      .every((mob) => mob.target !== character.name || mob.);
     const noNearbyPlayers = allEntities
       .filter((entity) => entity.type === "character" && !entity.moving)
       .every((char) => distance(character, char) >= 8);

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -175,7 +175,7 @@ function item_info(item) {
   const baseInfo = parent.G.items[item.name];
   if (!baseInfo) return undefined;
   const itemProperties = calculate_item_properties(item);
-  return [...baseInfo, ...itemProperties];
+  return {...baseInfo, ...itemProperties};
 }
 
 function isInvFull(slots = 1) {

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -821,7 +821,7 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
   if (
     character.ctype === "warrior" &&
     distance(character, target) > character.range * 0.35 &&
-    distance(character, target) <
+    distance(character, target) 
       character.range * rangeRate + character.xrange * 0.25
   ) {
     const allEntities = Object.values(parent.entities);
@@ -859,9 +859,6 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
     angle = Math.atan2(dy, dx);
   }
 
-  const cosAngle = Math.cos(angle);
-  const sinAngle = Math.sin(angle);
-
   // Track recent movement to detect being stuck
   movementHistory.push({ x: character.real_x, y: character.real_y });
   if (movementHistory.length > 5) movementHistory.shift();
@@ -887,6 +884,20 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
   const extendedRadius = character.xrange;
   const radiusTotal = rangeRadius + extendedRadius;
 
+  // Calculate rotation step - use actual distance that will be moved
+  const maxStep = ((character.speed * loopInterval) / 1000) * 0.9;
+  
+  // Better rotation calculation: arc_length / radius, with minimum step
+  // This ensures smooth rotation even at large radii
+  const baseRotationStep = maxStep / radiusTotal;
+  const minRotationStep = Math.PI / 32; // Minimum ~5.6 degrees per step
+  const rotationStep = flipRotation * Math.max(baseRotationStep, minRotationStep);
+  
+  angle += rotationStep;
+
+  const cosAngle = Math.cos(angle);
+  const sinAngle = Math.sin(angle);
+
   // Desired destination based on current orbit angle
   let newX = target.x + radiusTotal * cosAngle;
   let newY = target.y + radiusTotal * sinAngle;
@@ -894,8 +905,7 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
   // Smooth micro-rotation when close to target
   if (flipCooldown > 9) {
     const closeToTarget =
-      distance(character, target) <=
-      (character.range + character.xrange) * 0.1 * rangeRateFn;
+      distance(character, target) <= (character.range + character.xrange) * 0.1 * rangeRateFn;
 
     if (closeToTarget) {
       angle += (flipRotation * Math.PI) / 16;
@@ -937,8 +947,6 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
 
   // Trim & execute movement
   if (destinationX && destinationY) {
-    const maxStep = ((character.speed * loopInterval) / 1000) * 0.9;
-
     const dx = destinationX - character.real_x;
     const dy = destinationY - character.real_y;
     const distanceToMove = Math.sqrt(dx * dx + dy * dy);
@@ -950,22 +958,6 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
     }
 
     move(destinationX, destinationY);
-
-    // Calculate angle increment based on ACTUAL movement distance
-    const actualDx = destinationX - character.real_x;
-    const actualDy = destinationY - character.real_y;
-    const actualDistanceMoved = Math.sqrt(
-      actualDx * actualDx + actualDy * actualDy,
-    );
-
-    // Arc length formula: angle = arcLength / radius
-    // We use asin for small angles: angle ≈ 2 * asin(chord/2 / radius)
-    const rotationStep =
-      flipRotation *
-      Math.asin(Math.min(1, actualDistanceMoved / 2 / radiusTotal)) *
-      2;
-
-    angle += rotationStep;
   } else {
     return setTimeout(hitAndRun, loopInterval);
   }

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -15,14 +15,15 @@ const WARRIOR = "MooohMoooh";
 const ROGUE = "MooohSteak";
 const RANGER1 = "MoohThatCow";
 const RANGER2 = "CupidCow";
-var HEALER = "CowTheMooh";
+const PRIEST = "CowTheMooh";
+var HEALER = PRIEST;
 var RANGER = RANGER1;
 
 var TANKER =
   partyMems.find((id) => [HEALER, WARRIOR].includes(id)) ?? partyMems[0];
 // var TANKER = "CowTheMooh";
 
-const MIDAS_CHARACTER = [MAGE];
+const MIDAS_CHARACTER = [MAGE, "CrownPriest"];
 
 // var partyCodeSlot = [4, 15, 3, 5];
 const CODE_SLOTS = {
@@ -106,9 +107,9 @@ const MELEE_IGNORE_LIST = ["porcupine"];
 // var mapX = -289;
 // var mapY = -188;
 
-// var map = "winterland";
-// var mapX = 423;
-// var mapY = -2614;
+var map = "winterland";
+var mapX = 423;
+var mapY = -2614;
 
 // var map = "desertland";
 // var mapX = 223;
@@ -134,13 +135,13 @@ const MELEE_IGNORE_LIST = ["porcupine"];
 // var mapX = -1111;
 // var mapY = 132;
 
-var map = "desertland";
-var mapX = -800;
-var mapY = -354;
+// var map = "desertland";
+// var mapX = -800;
+// var mapY = -354;
 
 // var mobsToFarm = ["grinch", "phoenix", "spider", "bigbird", "scorpion"];
 // var mobsToFarm = ["goldenbot", "sparkbot", "sparkbot"];
-// var mobsToFarm = ["phoenix", "stompy", "wolf"];
+var mobsToFarm = ["phoenix", "stompy", "wolf"];
 // var mobsToFarm = ["fireroamer"];
 // var mobsToFarm = ["grinch", "phoenix", "mole"];
 
@@ -157,7 +158,7 @@ var mapY = -354;
 //   "turtle",
 //   "crabx",
 // ];
-var mobsToFarm = ["plantoid"];
+// var mobsToFarm = ["plantoid"];
 
 // desired elixir named
 var desiredElixir = "elixirluck";
@@ -279,16 +280,7 @@ const BUYABLE = [
 ];
 
 var IGNORE = [
-  "x0",
   "staff",
-  "x1",
-  "x2",
-  "x3",
-  "x4",
-  "x5",
-  "x6",
-  "x7",
-  "x8",
   "hpot0",
   "mpot0",
   "cscroll0",
@@ -323,6 +315,16 @@ var IGNORE = [
 ];
 
 const STORE_ABLE = [
+  "x0",
+  "x1",
+  "x2",
+  "x3",
+  "x4",
+  "x5",
+  "x6",
+  "x7",
+  "x8",
+  "xbox",
   "essenceofether",
   "spidersilk",
   "feather0",
@@ -411,6 +413,7 @@ const SALE_ABLE = [
   "fieldgen0",
   "snowball",
   "carrotsword",
+  "shield",
   // "wcap",
   // "wshoes",
   "wgloves",
@@ -454,10 +457,10 @@ const SALE_ABLE = [
   // Sell and replace by crypts's drops
   "intearring",
   "strearring",
-  "dexring",
-  "intring",
-  "dexamulet",
-  "stramulet",
+  // "dexring",
+  // "intring",
+  // "dexamulet",
+  // "stramulet",
   "dexbelt",
   "intbelt",
   // Halloween temp for gold
@@ -574,9 +577,15 @@ function arrayShuffle(array) {
 
 function getMonstersOnDeclares() {
   // if (character.name === partyMems[0]) arrayShuffle(mobsToFarm);
+  for (monster of ["grinch"]) {
+    if (get_nearest_monster({ type: monster })) {
+      return get_nearest_monster({ type: monster });
+    }
+  }
+
   for (monster of mobsToFarm) {
-    if (get_nearest_monster({ min_xp, type: monster })) {
-      return get_nearest_monster({ min_xp, type: monster });
+    if (get_nearest_monster({ type: monster })) {
+      return get_nearest_monster({ type: monster });
     }
   }
 }
@@ -593,6 +602,9 @@ async function withTimeout(
 
 async function buff() {
   try {
+    if (Object.keys(character.c).length) {
+      throw new Error("Wait for channeling before using potions");
+    }
     const minPing = Math.min(...parent.pings);
     const adjustPotionsCooldown = () => {
       reduce_cooldown("use_mp", minPing);
@@ -629,98 +641,95 @@ async function buff() {
         adjustPotionsCooldown();
       }
     }
-  } catch (e) {
-    console.error(e);
-  }
+  } catch (e) {}
   setTimeout(async () => buff(), Math.max(ms_to_next_skill("use_mp"), 5));
 }
-
 buff();
 
 function getTarget() {
-  const leader = get_entity(partyMems[0]);
-  let target = get_targeted_monster();
+  const leader = get_entity(TANKER) ?? get_entity(partyMems[0]);
+  const declared = getMonstersOnDeclares();
+  const party = new Set([...partyMems, partyMerchant, ...parent.party_list]);
 
-  if (target && !get_nearest_monster({ type: target.mtype }))
-    target = undefined;
+  let target =
+    declared && declared.cooperative ? declared : get_targeted_monster();
+  if (target && !get_entity(target.id)) target = undefined;
 
   if (!target) {
-    if (character.name === partyMems[0]) {
-      target = getMonstersOnDeclares();
+    const isLeader = character.name === (leader?.name ?? partyMems[0]);
 
-      const mobsTargetingNonTanker = Object.values(parent.entities)
+    if (isLeader) {
+      target = declared ?? undefined;
+
+      const mobsHittingParty = Object.values(parent.entities)
         .filter(
           (entity) =>
             entity.type === "monster" &&
-            (entity.target === HEALER || entity.target === MAGE),
+            entity.target &&
+            party.has(entity.target) &&
+            entity.target !== character.name,
         )
         .sort(
           (lhs, rhs) => distance(rhs, character) - distance(lhs, character),
         );
       if (
-        mobsTargetingNonTanker.length &&
-        (!target ||
-          (target &&
-            target.target !== character.name &&
-            partyMems.includes(target.target)))
+        mobsHittingParty.length &&
+        (!target || target.target === character.name || !target.cooperative)
       ) {
-        target = mobsTargetingNonTanker.shift();
+        target = mobsHittingParty[0];
       }
     } else {
-      const mob = getMonstersOnDeclares();
-      const aggroedMobs = Object.values(parent.entities).filter(
-        (mob) =>
-          mob.type === "monster" &&
-          [...partyMems, partyMerchant].includes(mob.target) &&
-          distance(mob, character) < character.range + character.xrange,
-      );
-      if (leader) {
-        let tempTarget =
-          get_target_of(leader) ||
-          get_nearest_monster({ target: partyMems[0] });
-        const tempTargetIsPartyMember =
-          tempTarget &&
-          tempTarget.name &&
-          [...partyMems, ...parent.party_list].includes(tempTarget.name);
+      const declaredMob = declared;
+      const aggroed = Object.values(parent.entities)
+        .filter(
+          (entity) =>
+            entity.type === "monster" &&
+            entity.target &&
+            party.has(entity.target),
+        )
+        .sort(
+          (lhs, rhs) => distance(rhs, character) - distance(lhs, character),
+        );
 
-        if (tempTarget && tempTargetIsPartyMember) {
-          tempTarget = undefined;
-        }
+      if (leader) {
+        let leaderTarget =
+          get_target_of(leader) ?? get_nearest_monster({ target: leader.name });
+        if (leaderTarget && party.has(leaderTarget.name))
+          leaderTarget = undefined;
 
         target =
-          tempTarget ?? aggroedMobs.length > 0
-            ? aggroedMobs[0]
-            : mob && mob.attack < 200
-            ? mob
-            : undefined;
-      } else target = mob;
+          leaderTarget ??
+          aggroed[0] ??
+          (declaredMob && declaredMob.attack < 200 ? declaredMob : undefined);
+      } else {
+        target = aggroed[0] ?? declaredMob;
+      }
     }
 
-    if (target) change_target(target);
-    else {
-      set_message("No Monsters");
-      if (
-        !character.moving &&
-        character.map !== "crypt" &&
-        leader &&
-        !smart.moving &&
-        !isAdvanceSmartMoving &&
-        character.cc < 125 &&
-        Math.sqrt(
-          (character.x - leader.x) * (character.x - leader.x) +
-            (character.y - leader.y) * (character.y - leader.y),
-        ) > spacial &&
-        can_move_to(
-          character.x + (leader.x - character.x) / 2,
-          character.y + (leader.y - character.y) / 2,
-        )
-      )
-        move(
-          character.x + (leader.x - character.x) / 2,
-          character.y + (leader.y - character.y) / 2,
-        );
-      return;
+    if (target) {
+      change_target(target);
+      return target;
     }
+
+    set_message("No Monsters");
+
+    if (
+      !character.moving &&
+      character.map !== "crypt" &&
+      leader &&
+      !smart.moving &&
+      !isAdvanceSmartMoving &&
+      character.cc < 125
+    ) {
+      const dist = distance(character, leader);
+      if (dist > spacial) {
+        const midX = character.x + (leader.x - character.x) / 2;
+        const midY = character.y + (leader.y - character.y) / 2;
+        if (can_move_to(midX, midY)) move(midX, midY);
+      }
+    }
+
+    return;
   }
 
   return target;
@@ -752,7 +761,7 @@ function ms_to_next_skill(skill) {
 async function leaveJail() {
   if (character.map === "jail" && !smart.moving && !isAdvanceSmartMoving) {
     log("Jail escape plan!");
-    smart_move(find_npc("jailer")).then(() => {
+    return smart_move(find_npc("jailer")).then(() => {
       parent.socket.emit("leave");
     });
   }
@@ -794,7 +803,8 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
   if (
     character.ctype === "warrior" &&
     distance(character, target) > character.range * 0.5 &&
-    distance(character, target) < character.range * rangeRate + character.xrange
+    distance(character, target) <
+      character.range * rangeRate + character.xrange * 0.25
   ) {
     const allEntities = Object.values(parent.entities);
     const noAggro = allEntities
@@ -929,7 +939,7 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
 }
 hitAndRun();
 
-const HEAL_IGNORE = ["Geoffriel", "CrownPriest"];
+const HEAL_IGNORE = ["Geoffriel"];
 
 function prioritizedNames() {
   return [...new Set([...partyMems, partyMerchant, ...parent.party_list])];
@@ -1047,78 +1057,89 @@ function goToBoss() {
   return false;
 }
 
-const LOOTING_LIMIT = 10;
+const LOOTING_LIMIT = 15;
 var isLooting = false;
 async function midasLooting(forced = false) {
   const chests = Object.values(parent.chests);
+
+  // Early exit: do NOT touch isLooting here
   if ((isLooting && !forced) || !chests.length || character.s.penalty_cd)
     return;
 
+  let shouldReset = false;
   const promises = [];
-  const partyMidasUsers = Object.keys(parent.party)
+
+  const bestLooterCharacter = bestLooter();
+  const partyMidasUsers = [...parent.party_list, character.name]
     .map((id) => get_player(id))
     .filter((player) => player && MIDAS_CHARACTER.includes(player.name));
 
-  if (
-    MIDAS_CHARACTER.includes(character.name) &&
-    (chests.length >= LOOTING_LIMIT ||
-      smart.moving ||
-      isAdvanceSmartMoving ||
-      forced)
-  ) {
-    isLooting = true;
-
-    const currentBooster = findInvBooster();
-    if (currentBooster && currentBooster !== "goldbooster") {
-      await shift(locate_item(currentBooster), "goldbooster");
-    }
-
-    if ((!smart.moving && !isAdvanceSmartMoving) || forced)
-      await equipBatch({
-        helmet: "wcap",
-        chest: "wattire",
-        pants: "wbreeches",
-        shoes: "wshoes",
-        gloves: "handofmidas",
-        amulet: "spookyamulet",
-      });
-    // Prevent overflooding code cost
-    let breakFlag = LOOTING_LIMIT * 2;
-    for (const chest of chests) {
-      if (breakFlag <= 0) break;
-      if (distance(chest, character) <= 800) {
-        promises.push(loot(chest.id));
-        breakFlag--;
-      }
-    }
-    await Promise.all(promises);
-    await equipBatch(calculateBestItems(), true);
-  } else if (partyMidasUsers.length) {
-    if (chests.length && (smart.moving || isAdvanceSmartMoving || forced)) {
+  try {
+    if (
+      MIDAS_CHARACTER.includes(character.name) &&
+      (chests.length >= LOOTING_LIMIT ||
+        ((smart.moving || isAdvanceSmartMoving) && !smartmoveDebug) ||
+        forced)
+    ) {
       isLooting = true;
-      let breakFlag = LOOTING_LIMIT * 1.5;
+      shouldReset = true;
+
+      if ((!smart.moving && !isAdvanceSmartMoving) || forced)
+        await withTimeout(
+          equipBatch(
+            {
+              helmet: "wcap",
+              chest: "wattire",
+              pants: "wbreeches",
+              shoes: "wshoes",
+              gloves: "handofmidas",
+              amulet: "spookyamulet",
+              booster: "goldbooster",
+            },
+            true,
+          ),
+          500,
+        );
+
+      let breakFlag = LOOTING_LIMIT * 2;
       for (const chest of chests) {
-        if (breakFlag <= 0) break;
-        if (
-          partyMidasUsers.every((player) => distance(chest, player) > 800) ||
-          10000 > mssince(chest.last_loot)
-        ) {
+        if (breakFlag-- <= 0) break;
+        if (distance(chest, character) <= 800) {
           promises.push(loot(chest.id));
-          breakFlag--;
         }
       }
-    }
-  } else if (
-    (bestLooter().name === character.name || !bestLooter()) &&
-    Object.keys(get_chests()).length
-  ) {
-    isLooting = true;
-    promises.push(loot());
-  }
+    } else if (!MIDAS_CHARACTER.includes(character.name) && partyMidasUsers.length) {
+      if (chests.length >= LOOTING_LIMIT && (smart.moving || isAdvanceSmartMoving || forced)) {
+        isLooting = true;
+        shouldReset = true;
 
-  return Promise.all(promises).finally(() => {
-    isLooting = false;
-  });
+        let breakFlag = LOOTING_LIMIT * 1.5;
+        for (const chest of chests) {
+          if (breakFlag-- <= 0) break;
+
+          if (
+            partyMidasUsers.every((player) => distance(chest, player) > 800) ||
+            300000 > mssince(chest.last_loot)
+          ) {
+            promises.push(loot(chest.id));
+          }
+        }
+      }
+    } else if (
+      (bestLooterCharacter?.name === character.name || !bestLooterCharacter) &&
+      Object.keys(get_chests()).length
+    ) {
+      isLooting = true;
+      shouldReset = true;
+      promises.push(loot());
+    }
+
+    if (!shouldReset) return;
+
+    await withTimeout(Promise.allSettled(promises), 2500);
+  } finally {
+    if (shouldReset) isLooting = false;
+  }
 }
 
 function suicide() {
@@ -1217,7 +1238,8 @@ setInterval(async function () {
             "mpot1",
             "cdragon",
             "oxhelmet",
-            "snowball",
+            // Remove for christmas snowman server hopping
+            // "snowball",
             "spookyamulet",
             "xptome",
             "xpbooster",
@@ -1334,10 +1356,14 @@ setInterval(async () => {
 
   if (
     whitelistPartyMembers.length &&
-    whitelistPartyMembers.length <= 6 &&
+    whitelistPartyMembers.length <= 9 &&
     (!parent.party_list.length || !hasWhitelistedMember)
   ) {
-    send_party_request(whitelistPartyMembers[0].name);
+    send_party_request(
+      whitelistPartyMembers.find((member) =>
+        partyWhitelistRegex.some((regex) => regex.test(member.name)),
+      ).name,
+    );
   }
 
   if (character.ping > 5000) disconnect();
@@ -1359,37 +1385,115 @@ function on_party_invite(name) {
   if (name === partyMems[0]) accept_party_invite(name);
 }
 
+setInterval(() => {
+  if (!isMerchant() && parent.party_list)
+    set("currentParty", parent.party_list);
+}, 5000);
+
+const PARTICIPATABLE_EVENTS = [
+  "icegolem",
+  "franky",
+  "mrpumpkin",
+  "mrgreen",
+  "crabxx",
+  "dragold",
+  "wabbit",
+  "snowman",
+  "pinkgoo",
+  "goobrawl",
+  "abtesting",
+];
+
+function serverCurrentlyHasLiveEvent() {
+  return PARTICIPATABLE_EVENTS.some((eventName) => parent.S[eventName]?.live);
+}
+
+const RSPEED_DURATION = G.conditions["rspeed"].duration;
+const RSPEED_MARGIN = 5 * 60 * 1000; // 5 minutes
+
+const setRogueSpeedLastDeployment = () => {
+  const last = get("rogueLastDeployed");
+  const lastDate = last ? new Date(last) : null;
+
+  // If we recently deployed (still inside rspeed - 5m), DO NOT overwrite
+  if (lastDate && mssince(lastDate) < RSPEED_DURATION - RSPEED_MARGIN) {
+    return; // Too early to overwrite
+  }
+
+  // Otherwise update the timestamp
+  set("rogueLastDeployed", new Date());
+};
+
+const shouldDeployRogue = () => {
+  const last = get("rogueLastDeployed");
+  const lastDate = last ? new Date(last) : null;
+
+  // If never deployed before → SHOULD deploy
+  if (!lastDate) return true;
+
+  // Deploy if enough time has passed
+  return (
+    mssince(lastDate) > RSPEED_DURATION - RSPEED_MARGIN ||
+    mssince(lastDate) < RSPEED_MARGIN
+  );
+};
+
 const DYNAMIC_PARTY_PRESETS = {
   snowman: () => {
-    RANGER = RANGER2;
-    return [WARRIOR, RANGER2, MAGE];
+    RANGER = RANGER1;
+    HEALER = RANGER;
+    return [WARRIOR, RANGER, MAGE];
   },
   mrgreen: {
-    USI: [WARRIOR, HEALER, ROGUE],
+    USI: [WARRIOR, PRIEST, ROGUE],
     EUII: () => {
       RANGER = RANGER1;
-      return [WARRIOR, RANGER1, MAGE];
+      HEALER = RANGER;
+      return [WARRIOR, RANGER, MAGE];
     },
     USII: () => {
       RANGER = RANGER2;
-      return [WARRIOR, RANGER2, MAGE];
+      HEALER = RANGER;
+      return [WARRIOR, RANGER, MAGE];
     },
-    default: [WARRIOR, HEALER, MAGE],
+    default: [WARRIOR, PRIEST, MAGE],
   },
   mrpumpkin: "mrgreen", // share config
   franky: () => {
     const isAggroed = !!parent.S.franky?.target;
-    return [WARRIOR, HEALER, isAggroed ? ROGUE : MAGE];
+    HEALER = PRIEST;
+    return [WARRIOR, PRIEST, isAggroed ? ROGUE : MAGE];
   },
   icegolem: () => {
-    return [HEALER, ROGUE, MAGE];
+    HEALER = PRIEST;
+    return [PRIEST, ROGUE, MAGE];
   },
 
   crabxx: () => {
     const isAggroed = !!parent.S.crabxx?.target;
-    return [WARRIOR, isAggroed ? RANGER1 : HEALER, isAggroed ? RANGER2 : MAGE];
+    return [WARRIOR, isAggroed ? RANGER1 : PRIEST, isAggroed ? RANGER2 : MAGE];
   },
-  default: [WARRIOR, HEALER, MAGE],
+  default: () => {
+    const globalParty = get("currentParty");
+
+    if (
+      globalParty &&
+      globalParty.includes("CrownPriest") &&
+      !serverCurrentlyHasLiveEvent()
+    ) {
+      setRogueSpeedLastDeployment();
+      if (shouldDeployRogue()) {
+        return [WARRIOR, ROGUE, MAGE];
+      } else {
+        RANGER = RANGER1;
+        HEALER = RANGER;
+        return [WARRIOR, RANGER, MAGE];
+      }
+    }
+
+    HEALER = PRIEST;
+    return [WARRIOR, PRIEST, MAGE];
+  },
 };
 
 function getPresetMembers(preset, currentServer) {
@@ -1398,7 +1502,7 @@ function getPresetMembers(preset, currentServer) {
   if (typeof preset === "string")
     return getPresetMembers(DYNAMIC_PARTY_PRESETS[preset], currentServer);
 
-  const value = preset[currentServer] ?? DYNAMIC_PARTY_PRESETS.default;
+  const value = preset[currentServer] ?? DYNAMIC_PARTY_PRESETS.default();
   return typeof value === "function" ? value() : value;
 }
 
@@ -1478,17 +1582,25 @@ async function changeToDailyEventTargets() {
   }
 
   if (parent.S.snowman?.live) {
-    changeToNormalStrategies();
+    if (!["mage"].includes(character.ctype)) changeToPullStrategies();
+    else changeToNormalStrategies();
 
+    const currentTarget = get_target();
     const snowmanInstance = get_nearest_monster({ type: "snowman" });
+    const grinchInstance = get_nearest_monster({ type: "grinch" });
+    const beeToAttack =
+      currentTarget && currentTarget.mtype === "arcticbee"
+        ? currentTarget
+        : get_nearest_monster({ type: "arcticbee" });
+
     if (!snowmanInstance) advanceSmartMove(parent.S.snowman);
     else {
-      if (snowmanInstance.s?.fullguardx)
-        change_target(get_nearest_monster({ type: "arcticbee" }));
+      if (grinchInstance) change_target(grinchInstance);
+      else if (snowmanInstance.s?.fullguardx) change_target(beeToAttack);
       else change_target(snowmanInstance);
 
-      return snowmanInstance.s?.fullguardx
-        ? get_nearest_monster({ type: "arcticbee" })
+      return grinchInstance ?? snowmanInstance.s?.fullguardx
+        ? beeToAttack
         : snowmanInstance;
     }
   }
@@ -1725,7 +1837,14 @@ async function changeToDailyEventTargets() {
     }
   }
 
-  const partyHealer = get_entity(HEALER);
+  const thirdPartyHealerId = parent.party_list.find((id) => {
+    const player = get_player(id);
+    return !partyMems.includes(id) && player?.ctype === "priest";
+  });
+  const partyHealer =
+    get_entity(HEALER) ||
+    (thirdPartyHealerId && get_player(thirdPartyHealerId)) ||
+    undefined;
   const partyTanker = get_entity(TANKER);
 
   if (

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -938,16 +938,13 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
     const dy = destinationY - character.real_y;
     const dist = Math.sqrt(dx * dx + dy * dy);
 
-    let moveX = destinationX;
-    let moveY = destinationY;
-
     if (dist > maxStep) {
       const scale = maxStep / dist;
-      moveX = character.real_x + dx * scale;
-      moveY = character.real_y + dy * scale;
+      destinationX = character.real_x + dx * scale;
+      destinationY = character.real_y + dy * scale;
     }
 
-    move(moveX, moveY);
+    move(destinationX, destinationY);
   } else {
     return setTimeout(hitAndRun, loopInterval);
   }

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -107,13 +107,13 @@ const MELEE_IGNORE_LIST = ["porcupine"];
 // var mapX = -289;
 // var mapY = -188;
 
-var map = "winterland";
-var mapX = 423;
-var mapY = -2614;
+// var map = "winterland";
+// var mapX = 423;
+// var mapY = -2614;
 
-// var map = "desertland";
-// var mapX = 223;
-// var mapY = -708;
+var map = "desertland";
+var mapX = 223;
+var mapY = -708;
 
 // var map = "tunnel";
 // var mapX = 0;
@@ -145,8 +145,8 @@ var mapY = -2614;
 
 // var mobsToFarm = ["grinch", "phoenix", "spider", "bigbird", "scorpion"];
 // var mobsToFarm = ["goldenbot", "sparkbot", "sparkbot"];
-var mobsToFarm = ["phoenix", "stompy", "wolf"];
-// var mobsToFarm = ["fireroamer"];
+// var mobsToFarm = ["phoenix", "stompy", "wolf"];
+var mobsToFarm = ["fireroamer"];
 // var mobsToFarm = ["grinch", "phoenix", "mole"];
 
 // var mobsToFarm = ["phoenix", "xscorpion", "minimush"];

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -1236,7 +1236,7 @@ setInterval(async function () {
     currentTarget.type === "monster" &&
     distance(currentTarget, character) >
       character.range + character.xrange * 0.9 &&
-    !smart.moving &&
+    !smart.moving && !character.moving &&
     !isAdvanceSmartMoving
   ) {
     smartmoveDebug = true;
@@ -1245,14 +1245,14 @@ setInterval(async function () {
       if (can_move_to(currentTarget.x, currentTarget.y))
         await smartMove({
           map: character.map,
-          x: (character.x + currentTarget.x) / 2,
-          y: (character.y + currentTarget.y) / 2,
+          x: (character.x + currentTarget.real_x) / 2,
+          y: (character.y + currentTarget.real_y) / 2,
         });
       else
         await smartMove({
           map: character.map,
-          x: currentTarget.x,
-          y: currentTarget.y,
+          x: currentTarget.real_x,
+          y: currentTarget.real_y,
         });
     } else {
       if (can_move_to(currentTarget.x, currentTarget.y))
@@ -1260,8 +1260,8 @@ setInterval(async function () {
       else
         await advanceSmartMove({
           map: character.map,
-          x: currentTarget.x,
-          y: currentTarget.y,
+          x: currentTarget.real_x,
+          y: currentTarget.real_y,
         });
     }
 

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -1383,7 +1383,7 @@ setInterval(async () => {
     );
   }
 
-  if (character.ping > 1000) {
+  if (Math.min(...parent.pings) > 1000) {
     if (character.ctype === "merchant") disconnect();
     else {
       if (parent.caracAL) parent.caracAL.shutdown();

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -107,13 +107,13 @@ const MELEE_IGNORE_LIST = ["porcupine"];
 // var mapX = -289;
 // var mapY = -188;
 
-var map = "winterland";
-var mapX = 423;
-var mapY = -2614;
+// var map = "winterland";
+// var mapX = 423;
+// var mapY = -2614;
 
-// var map = "desertland";
-// var mapX = 223;
-// var mapY = -708;
+var map = "desertland";
+var mapX = 223;
+var mapY = -708;
 
 // var map = "tunnel";
 // var mapX = 0;
@@ -145,8 +145,8 @@ var mapY = -2614;
 
 // var mobsToFarm = ["grinch", "phoenix", "spider", "bigbird", "scorpion"];
 // var mobsToFarm = ["goldenbot", "sparkbot", "sparkbot"];
-var mobsToFarm = ["phoenix", "stompy", "wolf"];
-// var mobsToFarm = ["fireroamer"];
+// var mobsToFarm = ["phoenix", "stompy", "wolf"];
+var mobsToFarm = ["fireroamer"];
 // var mobsToFarm = ["grinch", "phoenix", "mole"];
 
 // var mobsToFarm = ["phoenix", "xscorpion", "minimush"];
@@ -1137,6 +1137,7 @@ async function midasLooting(forced = false) {
                 gloves: "handofmidas",
                 amulet: "spookyamulet",
                 booster: "goldbooster",
+                cape: "horsecapeg",
               },
               true,
             ),
@@ -1554,23 +1555,23 @@ const DYNAMIC_PARTY_PRESETS = {
       return [ROGUE, RANGER, PRIEST];
     },
     USII: () => {
-      RANGER = RANGER1;
       HEALER = PRIEST;
-      return [WARRIOR, RANGER, PRIEST];
+      return [WARRIOR, MAGE, PRIEST];
     },
     default: [WARRIOR, PRIEST, ROGUE],
   },
   pinkgoo: {
-    USI: [WARRIOR, MAGE, ROGUE],
+    USI: [WARRIOR, PRIEST, ROGUE],
+    USII: [WARRIOR, MAGE, PRIEST],
+    EUI: () => {
+      RANGER = RANGER1;
+      HEALER = RANGER;
+      return [WARRIOR, RANGER, MAGE];
+    },
     EUII: () => {
       RANGER = RANGER2;
       HEALER = RANGER;
       return [WARRIOR, RANGER, MAGE];
-    },
-    USII: () => {
-      RANGER = RANGER1;
-      HEALER = PRIEST;
-      return [MAGE, RANGER, PRIEST];
     },
     default: () => {
       RANGER = RANGER1;
@@ -1587,7 +1588,7 @@ const DYNAMIC_PARTY_PRESETS = {
 
   default: () => {
     const globalParty = get("currentParty");
-    const knownTankers = ["CrownPriest", "earthPri", "earthWar"];
+    const knownTankers = ["CrownPriest"];
 
     if (
       globalParty &&

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -1805,6 +1805,9 @@ async function changeToDailyEventTargets() {
         .sort((a, b) => a.hp - b.hp)[0]; // lowest hp first
     };
 
+    const crabxList = Object.values(parent.entities).filter(
+      (e) => e?.mtype === "crabx",
+    );
     let crabxxInstance = get_nearest_monster({ type: "crabxx" });
     let crabxInstance = findBestCrabx();
 
@@ -1824,8 +1827,7 @@ async function changeToDailyEventTargets() {
       character.ctype === "warrior" &&
       crabxxInstance &&
       !crabxxInstance.s.stunned &&
-      Object.values(parent.entities).filter((e) => e?.mtype === "crabx")
-        .length <= 1
+      (crabxList.length <= 1 || crabxList.length >= 6)
     ) {
       await warriorStomp();
     }

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -1519,12 +1519,12 @@ const DYNAMIC_PARTY_PRESETS = {
   mrgreen: {
     USI: [WARRIOR, PRIEST, ROGUE],
     EUII: () => {
-      RANGER = RANGER1;
+      RANGER = RANGER2;
       HEALER = RANGER;
       return [WARRIOR, RANGER, MAGE];
     },
     USII: () => {
-      RANGER = RANGER2;
+      RANGER = RANGER1;
       HEALER = RANGER;
       return [WARRIOR, RANGER, MAGE];
     },
@@ -1540,12 +1540,28 @@ const DYNAMIC_PARTY_PRESETS = {
     HEALER = PRIEST;
     return [PRIEST, ROGUE, MAGE];
   },
+  dragold: {
+    USI: [WARRIOR, PRIEST, ROGUE],
+    EUII: () => {
+      RANGER = RANGER1;
+      HEALER = PRIEST;
+      return [ROGUE, RANGER, PRIEST];
+    },
+    USII: () => {
+      RANGER = RANGER2;
+      HEALER = PRIEST;
+      return [WARRIOR, RANGER, PRIEST];
+    },
+    default: [WARRIOR, PRIEST, ROGUE],
+  },
+  pinkgoo: "snowman",
   crabxx: () => {
     const isAggroed = !!parent.S.crabxx?.target;
     if (isAggroed) RANGER = RANGER1;
     HEALER = isAggroed ? RANGER1 : PRIEST;
     return [WARRIOR, isAggroed ? RANGER1 : PRIEST, isAggroed ? RANGER2 : MAGE];
   },
+
   default: () => {
     const globalParty = get("currentParty");
     const knownTankers = ["CrownPriest", "earthPri", "earthWar"];

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -818,7 +818,7 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
   const loopInterval = Math.max(200, getLoopInterval());
   // const totalExtraRange = extraRangeTarget + extraRangeSelf;
   const rangeRadius = character.range * rangeRateFn;
-  const extendedRadius = character.xrange;
+  const extendedRadius = character.xrange * 0.9;
   // + totalExtraRange;
 
   // --- 1. Early exits and sanity checks ---
@@ -832,7 +832,7 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
   if (
     character.ctype === "warrior" &&
     distance(character, target) > character.range * 0.35 &&
-    distance(character, target) < rangeRadius + extendedRadius * 0.9
+    distance(character, target) < rangeRadius + extendedRadius
   ) {
     const allEntities = Object.values(parent.entities);
     const noAggro = allEntities
@@ -851,10 +851,11 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
   }
 
   // Reset angle when switching or losing target
+  const lastTarget = parent.entities[lastKitingTargetId];
   const targetChanged =
-    !lastKitingTargetId ||
-    (lastKitingTargetId !== target.id &&
-      distance(parent.entities[lastKitingTargetId], target) > 30);
+    !lastTarget ||
+    lastKitingTargetId !== target.id ||
+    distance(lastTarget, target) > 30;
   if (targetChanged) angle = undefined;
 
   lastKitingTargetId = target.id;
@@ -938,7 +939,7 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
   }
 
   // --- 8. Execute movement or retry later ---
-  if (destinationX && destinationY) {
+  if (destinationX !== undefined && destinationY !== undefined) {
     const maxStep = (character.speed * 500) / 1000;
 
     const dx = destinationX - character.real_x;
@@ -1969,16 +1970,15 @@ function on_magiport(name) {
   }
 }
 
-function attackErrorHandler(error) {
+function attackErrorHandler(error, target = get_target()) {
   if (error.failed) {
     if (error.response === "cooldown" && error.place) {
       reduce_cooldown(error.place, -error.ms + Math.min(...parent.pings) / 2);
     } else if (error.reason === "too_far") {
-      if (character.cc < 125) {
+      if (character.cc < 125 && target) {
         const currentX = character.x;
         const currentY = character.y;
 
-        const target = get_target();
         const targetX = target.real_x ?? target.x;
         const targetY = target.real_y ?? target.y;
 

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -820,8 +820,8 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
 
   if (
     character.ctype === "warrior" &&
-    distance(character, target) < character.range * 0.35 &&
-    distance(character, target) >
+    distance(character, target) > character.range * 0.35 &&
+    distance(character, target) <
       character.range * rangeRate + character.xrange * 0.25
   ) {
     const allEntities = Object.values(parent.entities);

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -1241,14 +1241,23 @@ setInterval(async function () {
     smartmoveDebug = true;
     log("Debug being stuck while kiting");
     if (parent.caracAL) {
-      await smartMove({
-        map: character.map,
-        x: currentTarget.real_x,
-        y: currentTarget.real_y,
-      });
+      if (can_move_to(currentTarget.x, currentTarget.y))
+        await move(
+          (currentTarget.real_x + character.real_x) / 2,
+          (currentTarget.real_y + character.real_y) / 2,
+        );
+      else
+        await smartMove({
+          map: character.map,
+          x: currentTarget.real_x,
+          y: currentTarget.real_y,
+        });
     } else {
       if (can_move_to(currentTarget.x, currentTarget.y))
-        await move(currentTarget.x, currentTarget.y);
+        await move(
+          (currentTarget.real_x + character.real_x) / 2,
+          (currentTarget.real_y + character.real_y) / 2,
+        );
       else
         await advanceSmartMove({
           map: character.map,

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -1667,8 +1667,8 @@ async function changeToDailyEventTargets() {
 
     const dragoldInstance = get_nearest_monster({ type: "dragold" });
     if (!dragoldInstance) {
-      await smartMove(parent.S.dragold);
-      change_target(get_nearest_monster({ type: "pinkgoo" }));
+      await advanceSmartMove(parent.S.dragold);
+      change_target(get_nearest_monster({ type: "dragold" }));
       return get_nearest_monster({ type: "dragold" });
     } else {
       change_target(dragoldInstance);
@@ -1681,7 +1681,7 @@ async function changeToDailyEventTargets() {
     let pinkgooInstance = get_nearest_monster({ type: "pinkgoo" });
     if (!pinkgooInstance) {
       if (parent.S.pinkgoo?.x) {
-        await smartMove(parent.S.pinkgoo);
+        await advanceSmartMove(parent.S.pinkgoo);
         change_target(get_nearest_monster({ type: "pinkgoo" }));
         return get_nearest_monster({ type: "pinkgoo" });
       }

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -1955,12 +1955,12 @@ function attackErrorHandler(error) {
       }
 
       console.warn(
-        `Too far to use '${error.place}'` +
-          (error.place === "attack"
-            ? `, ${Math.round(error.distance)} distance / ${
-                character.range + character.xrange
-              } range`
-            : ""),
+        error,
+        error.distance
+          ? `| ${Math.round(error.distance)} distance / ${
+              character.range + character.xrange
+            } range`
+          : "",
       );
     }
   } else console.warn("Error while attacking:", error);

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -821,9 +821,10 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
 
   if (
     character.ctype === "warrior" &&
-    distance(character, target) > character.range * 0.5 &&
-    distance(character, target) <
-      character.range * rangeRate + character.xrange * 0.25
+    ((distance(character, target) > character.range * 0.5 &&
+      distance(character, target) <
+        character.range * rangeRate + character.xrange * 0.25) ||
+      target["1hp"])
   ) {
     const allEntities = Object.values(parent.entities);
     const noAggro = allEntities
@@ -1129,14 +1130,21 @@ async function midasLooting(forced = false) {
       !MIDAS_CHARACTER.includes(character.name) &&
       partyMidasUsers.length
     ) {
+      const currentTarget = get_target();
+      let modifier = 1;
+
+      if (currentTarget && currentTarget.type === "monster") {
+        modifier = Math.max(5000 / currentTarget.hp, 1);
+      }
+
       if (
-        chests.length >= LOOTING_LIMIT &&
+        chests.length >= LOOTING_LIMIT * modifier &&
         (smart.moving || isAdvanceSmartMoving || forced)
       ) {
         isLooting = true;
         shouldReset = true;
 
-        let breakFlag = LOOTING_LIMIT * 1.5;
+        let breakFlag = LOOTING_LIMIT * 1.5 * modifier;
         for (const chest of chests) {
           if (breakFlag-- <= 0) break;
 

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -838,7 +838,7 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
   }
 
   // CRABXX strategy: orbit the TANKER around the center of spawn
-  if (target?.mtype.includes("crabx") && isAssignedAsTanker()) {
+  if (target.type === "monster" && target?.mtype.includes("crabx") && isAssignedAsTanker()) {
     const crabxxSpawn = getMonsterSpawns("crabxx")[0];
     target = {
       ...target,

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -796,18 +796,22 @@ function extraDistanceWithinHitbox(target) {
   return Math.min(get_height(target) / 2, get_width(target) / 2) / 2;
 }
 
-var lastKitingTargetId = undefined;
+let lastKitingTargetId = undefined;
+
 async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
   // Debug: Fixed width and height of target
   if (target) {
     target.awidth = 24;
     target.aheight = 24;
+    target.width = 24;
+    target.height = 24;
   }
 
   const loopInterval = Math.max(200, getLoopInterval());
 
-  // --- 1. Early exits and sanity checks ---
+  // Early exits and sanity checks
   if (character.cc >= 125) return setTimeout(hitAndRun, loopInterval);
+
   if (!target || smart.moving || isAdvanceSmartMoving) {
     angle = undefined;
     lastKitingTargetId = undefined;
@@ -816,14 +820,16 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
 
   if (
     character.ctype === "warrior" &&
-    distance(character, target) > character.range * 0.5 &&
+    distance(character, target) > character.range * 0.35 &&
     distance(character, target) <
       character.range * rangeRate + character.xrange * 0.25
   ) {
     const allEntities = Object.values(parent.entities);
+
     const noAggro = allEntities
       .filter((entity) => entity.type === "monster")
       .every((mob) => mob.target !== character.name || mob["1hp"]);
+
     const noNearbyPlayers = allEntities
       .filter((entity) => entity.type === "character" && !entity.moving)
       .every((char) => distance(character, char) >= 8);
@@ -841,21 +847,22 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
     !lastKitingTargetId ||
     (lastKitingTargetId !== target.id &&
       distance(parent.entities[lastKitingTargetId], target) > 30);
+
   if (targetChanged) angle = undefined;
 
   lastKitingTargetId = target.id;
 
-  // --- 2. Initialize angle if needed ---
+  // Initialize angle if needed
   if (!angle) {
     const dx = character.real_x - target.real_x;
     const dy = character.real_y - target.real_y;
     angle = Math.atan2(dy, dx);
   }
 
-  const cosA = Math.cos(angle);
-  const sinA = Math.sin(angle);
+  const cosAngle = Math.cos(angle);
+  const sinAngle = Math.sin(angle);
 
-  // --- 3. Track recent movement to detect being stuck ---
+  // Track recent movement to detect being stuck
   movementHistory.push({ x: character.real_x, y: character.real_y });
   if (movementHistory.length > 5) movementHistory.shift();
 
@@ -863,35 +870,34 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
   for (let i = 1; i < movementHistory.length; i++) {
     const dx = movementHistory[i].x - movementHistory[i - 1].x;
     const dy = movementHistory[i].y - movementHistory[i - 1].y;
-    totalMovement += Math.sqrt(dx * dx + dy * dy);
+    totalMovement += Math.hypot(dx, dy);
   }
 
   const averageMovement = totalMovement / movementHistory.length;
+
   if (averageMovement < stuckThreshold) {
     if (flipRotationCooldown <= 0) {
       flipRotation *= -1;
       flipRotationCooldown = 4;
-      angle += (flipRotation * Math.PI) / 2; // turn 90°
+      angle += (flipRotation * Math.PI) / 2;
     }
   }
 
-  // const totalExtraRange = extraRangeTarget + extraRangeSelf;
   const rangeRadius = character.range * rangeRateFn;
   const extendedRadius = character.xrange;
-  // + totalExtraRange;
 
-  // --- 5. Desired destination based on current orbit angle ---
-  let new_x = target.x + (rangeRadius + extendedRadius) * cosA;
-  let new_y = target.y + (rangeRadius + extendedRadius) * sinA;
+  // Desired destination based on current orbit angle
+  let newX = target.x + (rangeRadius + extendedRadius) * cosAngle;
+  let newY = target.y + (rangeRadius + extendedRadius) * sinAngle;
 
-  // --- 6. Smooth micro-rotation when close to target ---
+  // Smooth micro-rotation when close to target
   if (flipCooldown > 9) {
     const closeToTarget =
       distance(character, target) <=
       (character.range + character.xrange) * 0.1 * rangeRateFn;
 
     if (closeToTarget) {
-      angle += (flipRotation * Math.PI) / 16; // subtle orbit shift
+      angle += (flipRotation * Math.PI) / 16;
     }
 
     flipCooldown = 0;
@@ -900,43 +906,61 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
   flipCooldown++;
   flipRotationCooldown--;
 
-  // --- 7. Collision handling and alternative movement path ---
-  let destinationX, destinationY;
+  // Collision handling and alternative movement path
+  let destinationX;
+  let destinationY;
 
-  if (!can_move_to(new_x, new_y)) {
-    // Try small angular adjustments in the current flip direction
+  if (!can_move_to(newX, newY)) {
     if (flipRotationCooldown < 0) {
       flipRotation *= -1;
       flipRotationCooldown = 6;
     }
+
     for (let i = 1; i <= 48; i++) {
       const adjustedAngle = angle + (flipRotation * Math.PI) / (48 / i);
-      const alt_x =
+
+      const altX =
         target.x + (rangeRadius + extendedRadius) * Math.cos(adjustedAngle);
-      const alt_y =
+      const altY =
         target.y + (rangeRadius + extendedRadius) * Math.sin(adjustedAngle);
 
-      if (can_move_to(alt_x, alt_y)) {
+      if (can_move_to(altX, altY)) {
         angle = adjustedAngle;
-        destinationX = alt_x;
-        destinationY = alt_y;
+        destinationX = altX;
+        destinationY = altY;
         break;
       }
     }
   } else {
-    destinationX = new_x;
-    destinationY = new_y;
+    destinationX = newX;
+    destinationY = newY;
   }
 
-  // --- 8. Execute movement or retry later ---
+  // Trim & execute movement or retry later
   if (destinationX && destinationY) {
-    move(destinationX, destinationY);
+    const maxStep = ((character.speed * loopInterval) / 1000) * 0.9;
+
+    const dx = destinationX - character.real_x;
+    const dy = destinationY - character.real_y;
+    const distanceToMove = Math.hypot(dx, dy);
+
+    let moveX = destinationX;
+    let moveY = destinationY;
+
+    if (distanceToMove > maxStep) {
+      const scale = maxStep / distanceToMove;
+      moveX = character.real_x + dx * scale;
+      moveY = character.real_y + dy * scale;
+    }
+
+    move(moveX, moveY);
   } else {
     return setTimeout(hitAndRun, loopInterval);
   }
 
   // --- 9. Advance orbit angle for next iteration ---
   const radiusTotal = rangeRadius + extendedRadius;
+
   const rotationStep =
     flipRotation *
     Math.asin((character.speed * loopInterval) / 1000 / 2 / radiusTotal) *
@@ -953,12 +977,11 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
 }
 hitAndRun();
 
-const HEAL_IGNORE = ["Geoffriel"];
-
 function prioritizedNames() {
   return [...new Set([...partyMems, partyMerchant, ...parent.party_list])];
 }
 
+const HEAL_IGNORE = ["Geoffriel"];
 function getPlayersToHeal() {
   const minHealMod = 0.9;
   const healThreshold = character.ctype === "priest" ? 0.8 : 0.65;

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -944,16 +944,13 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
     const dy = destinationY - character.real_y;
     const distanceToMove = Math.hypot(dx, dy);
 
-    let moveX = destinationX;
-    let moveY = destinationY;
-
     if (distanceToMove > maxStep) {
       const scale = maxStep / distanceToMove;
-      moveX = character.real_x + dx * scale;
-      moveY = character.real_y + dy * scale;
+      destinationX = character.real_x + dx * scale;
+      destinationY = character.real_y + dy * scale;
     }
 
-    move(moveX, moveY);
+    move(destinationX, destinationY);
   } else {
     return setTimeout(hitAndRun, loopInterval);
   }

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -1974,7 +1974,7 @@ function attackErrorHandler(error) {
     if (error.response === "cooldown" && error.place) {
       reduce_cooldown(error.place, -error.ms + Math.min(...parent.pings) / 2);
     } else if (error.reason === "too_far") {
-      if (character.cc < 125 && !character.moving) {
+      if (character.cc < 125) {
         const currentX = character.x;
         const currentY = character.y;
 

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -799,7 +799,6 @@ function extraDistanceWithinHitbox(target) {
 let lastKitingTargetId = undefined;
 
 async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
-  // Debug: Fixed width and height of target
   if (target) {
     target.awidth = 24;
     target.aheight = 24;
@@ -809,7 +808,6 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
 
   const loopInterval = Math.max(200, getLoopInterval());
 
-  // Early exits and sanity checks
   if (character.cc >= 125) return setTimeout(hitAndRun, loopInterval);
 
   if (!target || smart.moving || isAdvanceSmartMoving) {
@@ -827,11 +825,11 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
     const allEntities = Object.values(parent.entities);
 
     const noAggro = allEntities
-      .filter((entity) => entity.type === "monster")
+      .filter((e) => e.type === "monster")
       .every((mob) => mob.target !== character.name || mob["1hp"]);
 
     const noNearbyPlayers = allEntities
-      .filter((entity) => entity.type === "character" && !entity.moving)
+      .filter((e) => e.type === "character" && !e.moving)
       .every((char) => distance(character, char) >= 8);
 
     if (noAggro && noNearbyPlayers) {
@@ -842,27 +840,20 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
     }
   }
 
-  // Reset angle when switching or losing target
   const targetChanged =
     !lastKitingTargetId ||
     (lastKitingTargetId !== target.id &&
       distance(parent.entities[lastKitingTargetId], target) > 30);
 
   if (targetChanged) angle = undefined;
-
   lastKitingTargetId = target.id;
 
-  // Initialize angle if needed
-  if (!angle) {
+  if (angle === undefined) {
     const dx = character.real_x - target.real_x;
     const dy = character.real_y - target.real_y;
     angle = Math.atan2(dy, dx);
   }
 
-  const cosAngle = Math.cos(angle);
-  const sinAngle = Math.sin(angle);
-
-  // Track recent movement to detect being stuck
   movementHistory.push({ x: character.real_x, y: character.real_y });
   if (movementHistory.length > 5) movementHistory.shift();
 
@@ -875,103 +866,47 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
 
   const averageMovement = totalMovement / movementHistory.length;
 
-  if (averageMovement < stuckThreshold) {
-    if (flipRotationCooldown <= 0) {
-      flipRotation *= -1;
-      flipRotationCooldown = 4;
-      angle += (flipRotation * Math.PI) / 2;
-    }
+  if (averageMovement < stuckThreshold && flipRotationCooldown <= 0) {
+    flipRotation *= -1;
+    flipRotationCooldown = 4;
+    angle += (flipRotation * Math.PI) / 2;
   }
+
+  flipRotationCooldown--;
 
   const rangeRadius = character.range * rangeRateFn;
   const extendedRadius = character.xrange;
-
-  // Desired destination based on current orbit angle
-  let newX = target.x + (rangeRadius + extendedRadius) * cosAngle;
-  let newY = target.y + (rangeRadius + extendedRadius) * sinAngle;
-
-  // Smooth micro-rotation when close to target
-  if (flipCooldown > 9) {
-    const closeToTarget =
-      distance(character, target) <=
-      (character.range + character.xrange) * 0.1 * rangeRateFn;
-
-    if (closeToTarget) {
-      angle += (flipRotation * Math.PI) / 16;
-    }
-
-    flipCooldown = 0;
-  }
-
-  flipCooldown++;
-  flipRotationCooldown--;
-
-  // Collision handling and alternative movement path
-  let destinationX;
-  let destinationY;
-
-  if (!can_move_to(newX, newY)) {
-    if (flipRotationCooldown < 0) {
-      flipRotation *= -1;
-      flipRotationCooldown = 6;
-    }
-
-    for (let i = 1; i <= 48; i++) {
-      const adjustedAngle = angle + (flipRotation * Math.PI) / (48 / i);
-
-      const altX =
-        target.x + (rangeRadius + extendedRadius) * Math.cos(adjustedAngle);
-      const altY =
-        target.y + (rangeRadius + extendedRadius) * Math.sin(adjustedAngle);
-
-      if (can_move_to(altX, altY)) {
-        angle = adjustedAngle;
-        destinationX = altX;
-        destinationY = altY;
-        break;
-      }
-    }
-  } else {
-    destinationX = newX;
-    destinationY = newY;
-  }
-
-  // Trim & execute movement or retry later
-  if (destinationX && destinationY) {
-    const maxStep = ((character.speed * loopInterval) / 1000) * 0.9;
-
-    const dx = destinationX - character.real_x;
-    const dy = destinationY - character.real_y;
-    const distanceToMove = Math.hypot(dx, dy);
-
-    if (distanceToMove > maxStep) {
-      const scale = maxStep / distanceToMove;
-      destinationX = character.real_x + dx * scale;
-      destinationY = character.real_y + dy * scale;
-    }
-
-    move(destinationX, destinationY);
-  } else {
-    return setTimeout(hitAndRun, loopInterval);
-  }
-
-  // --- 9. Advance orbit angle for next iteration ---
   const radiusTotal = rangeRadius + extendedRadius;
 
-  const rotationStep =
-    flipRotation *
-    Math.asin((character.speed * loopInterval) / 1000 / 2 / radiusTotal) *
-    2;
+  const leadTime = 120;
+  const centerX = target.real_x + (target.vx || 0) * leadTime;
+  const centerY = target.real_y + (target.vy || 0) * leadTime;
 
-  angle += rotationStep;
+  const maxStep = ((character.speed * loopInterval) / 1000) * 0.9;
 
-  const moveTime =
-    (distance(character, { x: destinationX, y: destinationY }) /
-      character.speed) *
-    1000;
+  let angleStep = flipRotation * (maxStep / radiusTotal);
 
-  setTimeout(hitAndRun, Math.max(moveTime, 200));
+  const maxRotation = Math.PI / 20;
+  angleStep = Math.max(-maxRotation, Math.min(angleStep, maxRotation));
+
+  angle += angleStep;
+
+  let destinationX = centerX + radiusTotal * Math.cos(angle);
+  let destinationY = centerY + radiusTotal * Math.sin(angle);
+
+  if (!can_move_to(destinationX, destinationY)) {
+    angle += (flipRotation * Math.PI) / 32;
+    destinationX = centerX + radiusTotal * Math.cos(angle);
+    destinationY = centerY + radiusTotal * Math.sin(angle);
+  }
+
+  if (can_move_to(destinationX, destinationY)) {
+    move(destinationX, destinationY);
+  }
+
+  setTimeout(hitAndRun, loopInterval);
 }
+
 hitAndRun();
 
 function prioritizedNames() {

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -311,7 +311,6 @@ var IGNORE = [
   "rod",
   "tracker",
   "sword",
-  "throwingstars",
   "orboffire",
   "orboffrost",
   "orbofplague",
@@ -324,6 +323,7 @@ var IGNORE = [
   "staffofthedead",
   "swordofthedead",
   "supermittens",
+  "horsecapeg",
   ...BUYABLE,
 ];
 
@@ -463,7 +463,6 @@ const SALE_ABLE = [
   "hboots",
   "sword",
   "spear",
-  "throwingstars",
   // Easter's loots
   // "eears",
   // "eslippers",

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -1669,6 +1669,7 @@ async function changeToDailyEventTargets() {
     if (!dragoldInstance) {
       await smartMove(parent.S.dragold);
       change_target(get_nearest_monster({ type: "pinkgoo" }));
+      return get_nearest_monster({ type: "dragold" });
     } else {
       change_target(dragoldInstance);
       return dragoldInstance;

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -763,7 +763,7 @@ function getLoopInterval() {
   const frequencyInterval = (1 / character.frequency) * 1000;
 
   return ms_to_next_skill("attack") <= dynamicInterval
-    ? Math.max(ms_to_next_skill("attack"), 25)
+    ? Math.max(ms_to_next_skill("attack"), 1)
     : dynamicInterval ?? frequencyInterval;
 }
 
@@ -1931,10 +1931,10 @@ function on_magiport(name) {
 
 function attackErrorHandler(error) {
   if (error.failed) {
-    if (error.response === "cooldown") {
+    if (error.response === "cooldown" && error.place) {
       reduce_cooldown(
-        "attack",
-        -error.ms + Math.min(...parent.pings) / 2 + ms_to_next_skill("attack"),
+        error.place,
+        -error.ms + Math.min(...parent.pings) / 2 ,
       );
     } else if (
       error.reason === "too_far" &&

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -148,8 +148,8 @@ const MELEE_IGNORE_LIST = ["porcupine"];
 // var mapY = -1160;
 
 var map = "spookytown";
-var mapX = -512;
-var mapY = -625;
+var mapX = 412;
+var mapY = -694;
 
 // var mobsToFarm = ["grinch", "phoenix", "spider", "bigbird", "scorpion"];
 // var mobsToFarm = ["goldenbot", "sparkbot", "sparkbot"];

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -1861,7 +1861,7 @@ async function changeToDailyEventTargets() {
     changeToNormalStrategies();
     let frankyInstance = get_nearest_monster({ type: "franky" });
     if (!frankyInstance) {
-      await join("franky");
+      await join("franky").catch((e) => console.warn(e));
       await sleep(character.ping);
       await advanceSmartMove(parent.S.franky);
       frankyInstance = get_nearest_monster({ type: "franky" });

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -1610,7 +1610,7 @@ function getPresetMembers(preset, currentServer) {
   if (typeof preset === "string")
     return getPresetMembers(DYNAMIC_PARTY_PRESETS[preset], currentServer);
 
-  const value = preset[currentServer] ?? DYNAMIC_PARTY_PRESETS.default();
+  const value = preset[currentServer] ?? preset.default ?? DYNAMIC_PARTY_PRESETS.default();
   return typeof value === "function" ? value() : value;
 }
 

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -1580,10 +1580,12 @@ const DYNAMIC_PARTY_PRESETS = {
     },
   },
   crabxx: () => {
-    const isAggroed = !!parent.S.crabxx?.target;
-    if (isAggroed) RANGER = RANGER1;
-    HEALER = isAggroed ? RANGER1 : PRIEST;
-    return [WARRIOR, isAggroed ? RANGER1 : PRIEST, isAggroed ? RANGER2 : MAGE];
+    // const isAggroed = !!parent.S.crabxx?.target;
+    // if (isAggroed) RANGER = RANGER1;
+    // HEALER = isAggroed ? RANGER1 : PRIEST;
+    // return [WARRIOR, isAggroed ? RANGER1 : PRIEST, isAggroed ? RANGER2 : MAGE];
+    RANGER = RANGER1;
+    return [WARRIOR, PRIEST, RANGER1];
   },
 
   default: () => {
@@ -1772,10 +1774,10 @@ async function changeToDailyEventTargets() {
   }
 
   if (
-    parent.S.crabxx?.live &&
-    parent.S.crabxx.hp < parent.S.crabxx.max_hp &&
-    parent.S.crabxx?.target &&
-    !partyMems.includes(parent.S.crabxx.target)
+    parent.S.crabxx?.live
+    // parent.S.crabxx.hp < parent.S.crabxx.max_hp &&
+    // parent.S.crabxx?.target &&
+    // !partyMems.includes(parent.S.crabxx.target)
   ) {
     if (character.range > 100) rangeRate = 0.3;
 
@@ -1792,6 +1794,16 @@ async function changeToDailyEventTargets() {
             : lhs.hp - rhs.hp,
         )
         .pop();
+
+    const findCrabxNearCrabxx = (crabxx) => {
+      const crabxList = Object.values(parent.entities).filter(
+        (e) => e?.mtype === "crabx" && !e.rip,
+      );
+
+      return crabxList
+        .filter((crabx) => distance(crabx, crabxx) <= 17)
+        .sort((a, b) => a.hp - b.hp)[0]; // lowest hp first
+    };
 
     let crabxxInstance = get_nearest_monster({ type: "crabxx" });
     let crabxInstance = findBestCrabx();
@@ -1840,7 +1852,8 @@ async function changeToDailyEventTargets() {
 
     let targetCrab;
     if (character.ctype === "warrior") {
-      targetCrab = crabxxInstance?.target ? crabxxInstance : crabxInstance;
+      targetCrab =
+        findCrabxNearCrabxx(crabxxInstance) || crabxxInstance || crabxInstance;
     } else {
       targetCrab =
         crabxInstance || (crabxxInstance?.target ? crabxxInstance : undefined);
@@ -1853,7 +1866,7 @@ async function changeToDailyEventTargets() {
     // )
     //   changeToPullStrategies();
     // else
-    changeToNormalStrategies();
+    changeToPullStrategies();
 
     change_target(targetCrab);
     return targetCrab;

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -798,124 +798,179 @@ function extraDistanceWithinHitbox(target) {
 
 let lastKitingTargetId = undefined;
 
-async function hitAndRun(
-  target = get_target(),
-  rangeRateFn = typeof rangeRate === "function" ? rangeRate() : 0.85,
-) {
+async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
+  // Debug: Fixed width and height of target
+  if (target) {
+    target.awidth = 24;
+    target.aheight = 24;
+    target.width = 24;
+    target.height = 24;
+  }
+
   const loopInterval = Math.max(200, getLoopInterval());
 
-  // 1. Basic Constraints & State Resets
+  // Early exits and sanity checks
   if (character.cc >= 125) return setTimeout(hitAndRun, loopInterval);
 
-  if (
-    !target ||
-    smart.moving ||
-    (typeof isAdvanceSmartMoving !== "undefined" && isAdvanceSmartMoving)
-  ) {
+  if (!target || smart.moving || isAdvanceSmartMoving) {
     angle = undefined;
     lastKitingTargetId = undefined;
     return setTimeout(hitAndRun, loopInterval);
   }
 
-  // 2. Target Transition Logic
-  if (lastKitingTargetId !== target.id) {
-    angle = undefined;
-    lastKitingTargetId = target.id;
+  if (
+    character.ctype === "warrior" &&
+    distance(character, target) > character.range * 0.35 &&
+    distance(character, target) <
+      character.range * rangeRate + character.xrange * 0.25
+  ) {
+    const allEntities = Object.values(parent.entities);
+
+    const noAggro = allEntities
+      .filter((entity) => entity.type === "monster")
+      .every((mob) => mob.target !== character.name || mob["1hp"]);
+
+    const noNearbyPlayers = allEntities
+      .filter((entity) => entity.type === "character" && !entity.moving)
+      .every((char) => distance(character, char) >= 8);
+
+    if (noAggro && noNearbyPlayers) {
+      const dx = character.real_x - target.real_x;
+      const dy = character.real_y - target.real_y;
+      angle = Math.atan2(dy, dx);
+      return setTimeout(hitAndRun, loopInterval);
+    }
   }
 
-  // 3. Distance & Radius Calculation
-  const rangeRadius = character.range * rangeRateFn;
-  const extendedRadius = character.xrange || 0;
-  const radiusTotal = rangeRadius + extendedRadius;
+  // Reset angle when switching or losing target
+  const targetChanged =
+    !lastKitingTargetId ||
+    (lastKitingTargetId !== target.id &&
+      distance(parent.entities[lastKitingTargetId], target) > 30);
 
-  // 4. Position Prediction
-  const leadTime = 150;
-  const centerX = target.real_x + (target.vx || 0) * (leadTime / 1000) * 10;
-  const centerY = target.real_y + (target.vy || 0) * (leadTime / 1000) * 10;
+  if (targetChanged) angle = undefined;
 
-  const currentDist = distance(character, { x: centerX, y: centerY });
-  const currentAngle = Math.atan2(
-    character.real_y - centerY,
-    character.real_x - centerX,
-  );
+  lastKitingTargetId = target.id;
 
-  // 5. Stuck Detection
+  // Initialize angle if needed
+  if (!angle) {
+    const dx = character.real_x - target.real_x;
+    const dy = character.real_y - target.real_y;
+    angle = Math.atan2(dy, dx);
+  }
+
+  const cosAngle = Math.cos(angle);
+  const sinAngle = Math.sin(angle);
+
+  // Track recent movement to detect being stuck
   movementHistory.push({ x: character.real_x, y: character.real_y });
-  if (movementHistory.length > 6) movementHistory.shift();
+  if (movementHistory.length > 5) movementHistory.shift();
 
-  if (movementHistory.length >= 2) {
-    let totalMovement = 0;
-    for (let i = 1; i < movementHistory.length; i++) {
-      totalMovement += distance(movementHistory[i], movementHistory[i - 1]);
-    }
-    const averageMovement = totalMovement / movementHistory.length;
+  let totalMovement = 0;
+  for (let i = 1; i < movementHistory.length; i++) {
+    const dx = movementHistory[i].x - movementHistory[i - 1].x;
+    const dy = movementHistory[i].y - movementHistory[i - 1].y;
+    totalMovement += Math.hypot(dx, dy);
+  }
 
-    if (averageMovement < stuckThreshold && flipRotationCooldown <= 0) {
+  const averageMovement = totalMovement / movementHistory.length;
+
+  if (averageMovement < stuckThreshold) {
+    if (flipRotationCooldown <= 0) {
       flipRotation *= -1;
-      flipRotationCooldown = 8;
+      flipRotationCooldown = 4;
+      angle += (flipRotation * Math.PI) / 2;
     }
   }
-  if (flipRotationCooldown > 0) flipRotationCooldown--;
 
-  // 6. Calculate Movement Components
-  const maxStep = ((character.speed * loopInterval) / 1000) * 0.9;
-  
-  // How far off are we from the ideal radius?
-  const distError = currentDist - radiusTotal;
-  
-  // Split maxStep into tangential (orbit) and radial (correction) components
-  // When far from ideal radius, prioritize getting to correct distance
-  // When close, prioritize orbiting
-  const radialPortion = Math.min(Math.abs(distError) / radiusTotal, 0.5); // 0 to 0.5
-  const tangentialSpeed = maxStep * (1 - radialPortion);
-  const radialSpeed = maxStep * radialPortion;
-  
-  // Tangential: movement around the circle
-  const angleStep = (tangentialSpeed / Math.max(1, currentDist)) * flipRotation;
-  const newAngle = currentAngle + angleStep;
-  
-  // Radial: movement toward/away from ideal radius
-  const targetDist = currentDist - Math.sign(distError) * radialSpeed;
-  
-  // Calculate final destination
-  let destX = centerX + targetDist * Math.cos(newAngle);
-  let destY = centerY + targetDist * Math.sin(newAngle);
+  const rangeRadius = character.range * rangeRateFn;
+  const extendedRadius = character.xrange;
 
-  // 7. Clamp total movement to maxStep (prevents overshooting)
-  const moveDistX = destX - character.real_x;
-  const moveDistY = destY - character.real_y;
-  const totalMoveDist = Math.sqrt(moveDistX * moveDistX + moveDistY * moveDistY);
+  // Desired destination based on current orbit angle
+  let newX = target.x + (rangeRadius + extendedRadius) * cosAngle;
+  let newY = target.y + (rangeRadius + extendedRadius) * sinAngle;
 
-  if (totalMoveDist > maxStep) {
-    const scale = maxStep / totalMoveDist;
-    destX = character.real_x + moveDistX * scale;
-    destY = character.real_y + moveDistY * scale;
+  // Smooth micro-rotation when close to target
+  if (flipCooldown > 9) {
+    const closeToTarget =
+      distance(character, target) <=
+      (character.range + character.xrange) * 0.1 * rangeRateFn;
+
+    if (closeToTarget) {
+      angle += (flipRotation * Math.PI) / 16;
+    }
+
+    flipCooldown = 0;
   }
 
-  // 8. Collision & Execution
-  if (!can_move_to(destX, destY)) {
-    // Try opposite rotation
-    const altAngleStep = -angleStep;
-    const altAngle = currentAngle + altAngleStep;
-    const altX = centerX + targetDist * Math.cos(altAngle);
-    const altY = centerY + targetDist * Math.sin(altAngle);
+  flipCooldown++;
+  flipRotationCooldown--;
 
-    if (can_move_to(altX, altY)) {
-      move(altX, altY);
-    } else {
-      // If both blocked, just try to fix radius without orbiting
-      const radialOnlyX = centerX + (currentDist - Math.sign(distError) * maxStep * 0.5) * Math.cos(currentAngle);
-      const radialOnlyY = centerY + (currentDist - Math.sign(distError) * maxStep * 0.5) * Math.sin(currentAngle);
-      
-      if (can_move_to(radialOnlyX, radialOnlyY)) {
-        move(radialOnlyX, radialOnlyY);
+  // Collision handling and alternative movement path
+  let destinationX;
+  let destinationY;
+
+  if (!can_move_to(newX, newY)) {
+    if (flipRotationCooldown < 0) {
+      flipRotation *= -1;
+      flipRotationCooldown = 6;
+    }
+
+    for (let i = 1; i <= 48; i++) {
+      const adjustedAngle = angle + (flipRotation * Math.PI) / (48 / i);
+
+      const altX =
+        target.x + (rangeRadius + extendedRadius) * Math.cos(adjustedAngle);
+      const altY =
+        target.y + (rangeRadius + extendedRadius) * Math.sin(adjustedAngle);
+
+      if (can_move_to(altX, altY)) {
+        angle = adjustedAngle;
+        destinationX = altX;
+        destinationY = altY;
+        break;
       }
     }
   } else {
-    move(destX, destY);
+    destinationX = newX;
+    destinationY = newY;
   }
 
-  setTimeout(hitAndRun, loopInterval);
+  // Trim & execute movement or retry later
+  if (destinationX && destinationY) {
+    const maxStep = ((character.speed * loopInterval) / 1000) * 0.9;
+
+    const dx = destinationX - character.real_x;
+    const dy = destinationY - character.real_y;
+    const distanceToMove = Math.hypot(dx, dy);
+
+    if (distanceToMove > maxStep) {
+      const scale = maxStep / distanceToMove;
+      destinationX = character.real_x + dx * scale;
+      destinationY = character.real_y + dy * scale;
+    }
+
+    move(destinationX, destinationY);
+  } else {
+    return setTimeout(hitAndRun, loopInterval);
+  }
+
+  // --- 9. Advance orbit angle for next iteration ---
+  const radiusTotal = rangeRadius + extendedRadius;
+
+  const rotationStep =
+    flipRotation *
+    Math.asin((character.speed * loopInterval) / 1000 / 2 / radiusTotal) *
+    2;
+
+  angle += rotationStep;
+
+  const moveTime =
+    (distance(character, { x: destinationX, y: destinationY }) /
+      character.speed) *
+    1000;
+
+  setTimeout(hitAndRun, Math.max(moveTime, 200));
 }
 hitAndRun();
 

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -1511,10 +1511,11 @@ const DYNAMIC_PARTY_PRESETS = {
   },
   default: () => {
     const globalParty = get("currentParty");
+    const knownTankers = ["CrownPriest", "earthPri", "earthWar"];
 
     if (
       globalParty &&
-      globalParty.includes("CrownPriest") &&
+      globalParty.some((id) => knownTankers.includes(id)) &&
       !serverCurrentlyHasLiveEvent()
     ) {
       setRogueSpeedLastDeployment();

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -1543,6 +1543,11 @@ const DYNAMIC_PARTY_PRESETS = {
   },
   dragold: {
     USI: [WARRIOR, PRIEST, ROGUE],
+    EUI: () => {
+      RANGER = RANGER1;
+      HEALER = PRIEST;
+      return [ROGUE, RANGER, PRIEST];
+    },
     EUII: () => {
       RANGER = RANGER2;
       HEALER = PRIEST;

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -174,8 +174,12 @@ function item_info(item) {
 
   const baseInfo = parent.G.items[item.name];
   if (!baseInfo) return undefined;
-  const itemProperties = calculate_item_properties(item);
-  return {...baseInfo, ...itemProperties};
+  const itemProperties = calculate_item_properties(item, {
+    def: baseInfo,
+    class: character.class,
+    map: character.map,
+  });
+  return { ...baseInfo, ...itemProperties };
 }
 
 function isInvFull(slots = 1) {

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -308,6 +308,7 @@ var IGNORE = [
   "pmaceofthedead",
   "staffofthedead",
   "swordofthedead",
+  'lmace',
   ...BUYABLE,
 ];
 

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -111,9 +111,9 @@ const MELEE_IGNORE_LIST = ["porcupine"];
 // var mapX = 423;
 // var mapY = -2614;
 
-var map = "desertland";
-var mapX = 223;
-var mapY = -708;
+// var map = "desertland";
+// var mapX = 223;
+// var mapY = -708;
 
 // var map = "tunnel";
 // var mapX = 0;
@@ -135,9 +135,9 @@ var mapY = -708;
 // var mapX = -1111;
 // var mapY = 132;
 
-// var map = "desertland";
-// var mapX = -800;
-// var mapY = -354;
+var map = "desertland";
+var mapX = -800;
+var mapY = -354;
 
 // var map = "level1";
 // var mapX = 50;
@@ -146,7 +146,7 @@ var mapY = -708;
 // var mobsToFarm = ["grinch", "phoenix", "spider", "bigbird", "scorpion"];
 // var mobsToFarm = ["goldenbot", "sparkbot", "sparkbot"];
 // var mobsToFarm = ["phoenix", "stompy", "wolf"];
-var mobsToFarm = ["fireroamer"];
+// var mobsToFarm = ["fireroamer"];
 // var mobsToFarm = ["grinch", "phoenix", "mole"];
 
 // var mobsToFarm = ["phoenix", "xscorpion", "minimush"];
@@ -162,7 +162,7 @@ var mobsToFarm = ["fireroamer"];
 //   "turtle",
 //   "crabx",
 // ];
-// var mobsToFarm = ["plantoid"];
+var mobsToFarm = ["plantoid"];
 // var mobsToFarm = ["prat"];
 
 // desired elixir named

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -1870,7 +1870,7 @@ async function changeToDailyEventTargets() {
     let targetCrab;
 
     if (character.ctype === "warrior") {
-      targetCrab = bestClusteredCrabx || bestCrabx || crabxxInstance;
+      targetCrab = bestClusteredCrabx || crabxxInstance;
     } else {
       targetCrab =
         bestCrabx || (crabxxInstance?.target ? crabxxInstance : undefined);

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -1610,7 +1610,8 @@ function getPresetMembers(preset, currentServer) {
   if (typeof preset === "string")
     return getPresetMembers(DYNAMIC_PARTY_PRESETS[preset], currentServer);
 
-  const value = preset[currentServer] ?? preset.default ?? DYNAMIC_PARTY_PRESETS.default();
+  const value =
+    preset[currentServer] ?? preset.default ?? DYNAMIC_PARTY_PRESETS.default();
   return typeof value === "function" ? value() : value;
 }
 
@@ -1665,10 +1666,11 @@ async function changeToDailyEventTargets() {
     changeToPullStrategies();
 
     const dragoldInstance = get_nearest_monster({ type: "dragold" });
-    if (!dragoldInstance) advanceSmartMove(parent.S.dragold);
-    else {
+    if (!dragoldInstance) {
+      await smartMove(parent.S.dragold);
+      change_target(get_nearest_monster({ type: "pinkgoo" }));
+    } else {
       change_target(dragoldInstance);
-
       return dragoldInstance;
     }
   }
@@ -1678,7 +1680,7 @@ async function changeToDailyEventTargets() {
     let pinkgooInstance = get_nearest_monster({ type: "pinkgoo" });
     if (!pinkgooInstance) {
       if (parent.S.pinkgoo?.x) {
-        await advanceSmartMove(parent.S.pinkgoo);
+        await smartMove(parent.S.pinkgoo);
         change_target(get_nearest_monster({ type: "pinkgoo" }));
         return get_nearest_monster({ type: "pinkgoo" });
       }

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -143,9 +143,13 @@ const MELEE_IGNORE_LIST = ["porcupine"];
 // var mapX = 50;
 // var mapY = 425;
 
+// var map = "spookytown";
+// var mapX = 255;
+// var mapY = -1160;
+
 var map = "spookytown";
-var mapX = 255;
-var mapY = -1160;
+var mapX = -512;
+var mapY = -625;
 
 // var mobsToFarm = ["grinch", "phoenix", "spider", "bigbird", "scorpion"];
 // var mobsToFarm = ["goldenbot", "sparkbot", "sparkbot"];
@@ -168,7 +172,8 @@ var mapY = -1160;
 // ];
 // var mobsToFarm = ["plantoid"];
 // var mobsToFarm = ["prat"];
-var mobsToFarm = ["mummy"];
+// var mobsToFarm = ["mummy"];
+var mobsToFarm = ["jr", "booboo"];
 
 // desired elixir named
 var desiredElixir = "elixirluck";

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -1861,8 +1861,11 @@ async function changeToDailyEventTargets() {
     changeToNormalStrategies();
     let frankyInstance = get_nearest_monster({ type: "franky" });
     if (!frankyInstance) {
-      join("franky");
-      await advanceSmartMove(parent.S.franky);
+      try {
+        await join("franky");
+      } catch (e) {
+        await advanceSmartMove(parent.S.franky);
+      }
       change_target(get_nearest_monster({ type: "franky" }));
       frankyInstance = get_nearest_monster({ type: "franky" });
     }
@@ -1870,11 +1873,10 @@ async function changeToDailyEventTargets() {
     if (frankyInstance)
       if (frankyInstance.target && !partyMems.includes(frankyInstance.target)) {
         rangeRate = 0.2;
-        return frankyInstance;
       } else {
         scareAwayMobs();
-        return frankyInstance;
       }
+    return frankyInstance;
   }
 
   if (parent.S.abtesting && !character.s.hopsickness) {

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -932,7 +932,7 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
 
   // --- 8. Execute movement or retry later ---
   if (destinationX && destinationY) {
-    const maxStep = (character.speed * loopInterval) / 1000;
+    const maxStep = (character.speed * loopInterval * 1.5) / 1000;
 
     const dx = destinationX - character.real_x;
     const dy = destinationY - character.real_y;

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -1940,8 +1940,8 @@ function attackErrorHandler(error) {
   if (error.failed) {
     if (error.response === "cooldown" && error.place) {
       reduce_cooldown(error.place, -error.ms + Math.min(...parent.pings) / 2);
-    } else if (error.reason === "too_far" && error.place) {
-      if (character.cc < 125 && !character.moving && error.place === "attack") {
+    } else if (error.reason === "too_far") {
+      if (character.cc < 125 && !character.moving) {
         const currentX = character.x;
         const currentY = character.y;
 

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -1543,18 +1543,31 @@ const DYNAMIC_PARTY_PRESETS = {
   dragold: {
     USI: [WARRIOR, PRIEST, ROGUE],
     EUII: () => {
-      RANGER = RANGER1;
+      RANGER = RANGER2;
       HEALER = PRIEST;
       return [ROGUE, RANGER, PRIEST];
     },
     USII: () => {
-      RANGER = RANGER2;
+      RANGER = RANGER1;
       HEALER = PRIEST;
       return [WARRIOR, RANGER, PRIEST];
     },
     default: [WARRIOR, PRIEST, ROGUE],
   },
-  pinkgoo: "snowman",
+  pinkgoo: {
+    USI: [WARRIOR, MAGE, ROGUE],
+    EUII: () => {
+      RANGER = RANGER2;
+      HEALER = RANGER;
+      return [ROGUE, RANGER, MAGE];
+    },
+    USII: () => {
+      RANGER = RANGER1;
+      HEALER = PRIEST;
+      return [MAGE, RANGER, PRIEST];
+    },
+    default: [WARRIOR, RANGER, MAGE],
+  },
   crabxx: () => {
     const isAggroed = !!parent.S.crabxx?.target;
     if (isAggroed) RANGER = RANGER1;

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -1875,7 +1875,7 @@ async function changeToDailyEventTargets() {
     partyHealer &&
     !partyHealer.rip &&
     character.ping < 600 &&
-    (get_targeted_monster()?.level < 5 || get_targeted_monster()?.attack < 500)
+    (get_targeted_monster()?.level < 5 || get_target()?.attack < 500)
   )
     changeToPullStrategies();
   else changeToNormalStrategies();

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -139,6 +139,10 @@ var mapY = -2614;
 // var mapX = -800;
 // var mapY = -354;
 
+// var map = "level1";
+// var mapX = 50;
+// var mapY = 425;
+
 // var mobsToFarm = ["grinch", "phoenix", "spider", "bigbird", "scorpion"];
 // var mobsToFarm = ["goldenbot", "sparkbot", "sparkbot"];
 var mobsToFarm = ["phoenix", "stompy", "wolf"];
@@ -159,6 +163,7 @@ var mobsToFarm = ["phoenix", "stompy", "wolf"];
 //   "crabx",
 // ];
 // var mobsToFarm = ["plantoid"];
+// var mobsToFarm = ["prat"];
 
 // desired elixir named
 var desiredElixir = "elixirluck";
@@ -354,6 +359,7 @@ const STORE_ABLE = [
   "frozenkey",
   "funtoken",
   "gem1",
+  "rfangs",
   "whiteegg",
   "sstinger",
   "spores",
@@ -440,7 +446,6 @@ const SALE_ABLE = [
   "staffofthedead",
   "swordofthedead",
   "ringsj",
-  "mshield",
   "hhelmet",
   "hgloves",
   "harmor",
@@ -454,7 +459,14 @@ const SALE_ABLE = [
   // Easter's loots
   // "eears",
   // "eslippers",
-  // Sell and replace by crypts's drops
+
+  //Christmas loots
+  // "xmashat",
+  // "xmassweater",
+  // "xmaspants",
+  // "warmscarf",
+
+  // Sell and replace by crypt's loots
   "intearring",
   "strearring",
   // "dexring",
@@ -685,7 +697,8 @@ function getTarget() {
           (entity) =>
             entity.type === "monster" &&
             entity.target &&
-            party.has(entity.target),
+            party.has(entity.target) &&
+            distance(entity, character) < character.range + character.xrange,
         )
         .sort(
           (lhs, rhs) => distance(rhs, character) - distance(lhs, character),
@@ -845,7 +858,7 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
   for (let i = 1; i < movementHistory.length; i++) {
     const dx = movementHistory[i].x - movementHistory[i - 1].x;
     const dy = movementHistory[i].y - movementHistory[i - 1].y;
-    totalMovement += Math.hypot(dx, dy);
+    totalMovement += Math.sqrt(dx * dx + dy * dy);
   }
 
   const averageMovement = totalMovement / movementHistory.length;
@@ -857,9 +870,6 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
     }
   }
 
-  // --- 4. Calculate range offsets ---
-  const extraRangeTarget = extraDistanceWithinHitbox(target);
-  const extraRangeSelf = extraDistanceWithinHitbox(character);
   // const totalExtraRange = extraRangeTarget + extraRangeSelf;
   const rangeRadius = character.range * rangeRateFn;
   const extendedRadius = character.xrange;
@@ -1070,46 +1080,53 @@ async function midasLooting(forced = false) {
   const promises = [];
 
   const bestLooterCharacter = bestLooter();
-  const partyMidasUsers = [...parent.party_list, character.name]
+  const partyMidasUsers = [...parent.party_list, ...partyMems, character.name]
     .map((id) => get_player(id))
     .filter((player) => player && MIDAS_CHARACTER.includes(player.name));
 
   try {
-    if (
-      MIDAS_CHARACTER.includes(character.name) &&
-      (chests.length >= LOOTING_LIMIT ||
+    if (MIDAS_CHARACTER.includes(character.name)) {
+      if (
+        chests.length >= LOOTING_LIMIT ||
         ((smart.moving || isAdvanceSmartMoving) && !smartmoveDebug) ||
-        forced)
-    ) {
-      isLooting = true;
-      shouldReset = true;
+        forced
+      ) {
+        isLooting = true;
+        shouldReset = true;
 
-      if ((!smart.moving && !isAdvanceSmartMoving) || forced)
-        await withTimeout(
-          equipBatch(
-            {
-              helmet: "wcap",
-              chest: "wattire",
-              pants: "wbreeches",
-              shoes: "wshoes",
-              gloves: "handofmidas",
-              amulet: "spookyamulet",
-              booster: "goldbooster",
-            },
-            true,
-          ),
-          500,
-        );
+        if ((!smart.moving && !isAdvanceSmartMoving) || forced)
+          await withTimeout(
+            equipBatch(
+              {
+                helmet: "wcap",
+                chest: "wattire",
+                pants: "wbreeches",
+                shoes: "wshoes",
+                gloves: "handofmidas",
+                amulet: "spookyamulet",
+                booster: "goldbooster",
+              },
+              true,
+            ),
+            500,
+          );
 
-      let breakFlag = LOOTING_LIMIT * 2;
-      for (const chest of chests) {
-        if (breakFlag-- <= 0) break;
-        if (distance(chest, character) <= 800) {
-          promises.push(loot(chest.id));
+        let breakFlag = LOOTING_LIMIT * 2;
+        for (const chest of chests) {
+          if (breakFlag-- <= 0) break;
+          if (distance(chest, character) <= 800) {
+            promises.push(loot(chest.id));
+          }
         }
       }
-    } else if (!MIDAS_CHARACTER.includes(character.name) && partyMidasUsers.length) {
-      if (chests.length >= LOOTING_LIMIT && (smart.moving || isAdvanceSmartMoving || forced)) {
+    } else if (
+      !MIDAS_CHARACTER.includes(character.name) &&
+      partyMidasUsers.length
+    ) {
+      if (
+        chests.length >= LOOTING_LIMIT &&
+        (smart.moving || isAdvanceSmartMoving || forced)
+      ) {
         isLooting = true;
         shouldReset = true;
 
@@ -1366,7 +1383,13 @@ setInterval(async () => {
     );
   }
 
-  if (character.ping > 5000) disconnect();
+  if (character.ping > 1000) {
+    if (character.ctype === "merchant") disconnect();
+    else {
+      if (parent.caracAL) parent.caracAL.shutdown();
+      else disconnect();
+    }
+  }
 
   if (partyMems.some((id) => !parent.party_list.includes(id))) {
     if (character.name === partyMems[0]) {
@@ -1440,7 +1463,7 @@ const shouldDeployRogue = () => {
 
 const DYNAMIC_PARTY_PRESETS = {
   snowman: () => {
-    RANGER = RANGER1;
+    RANGER = RANGER2;
     HEALER = RANGER;
     return [WARRIOR, RANGER, MAGE];
   },
@@ -1582,8 +1605,7 @@ async function changeToDailyEventTargets() {
   }
 
   if (parent.S.snowman?.live) {
-    if (!["mage"].includes(character.ctype)) changeToPullStrategies();
-    else changeToNormalStrategies();
+    changeToPullStrategies();
 
     const currentTarget = get_target();
     const snowmanInstance = get_nearest_monster({ type: "snowman" });

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -1017,7 +1017,7 @@ function getPlayersToHeal() {
   ]
     .map((entity) => {
       const incomingNumber =
-        PROJECTILE_MANAGER?.getIncomingHeals(entity.name) ?? 0;
+        PROJECTILE_MANAGER?.getIncomingNumber(entity.name) ?? 0;
 
       const predictedHp =
         entity.name === character.name ? entity.hp : entity.hp + incomingNumber;

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -1861,12 +1861,9 @@ async function changeToDailyEventTargets() {
     changeToNormalStrategies();
     let frankyInstance = get_nearest_monster({ type: "franky" });
     if (!frankyInstance) {
-      try {
-        join("franky");
-        await sleep(character.ping);
-      } catch (e) {
-        await advanceSmartMove(parent.S.franky);
-      }
+      await join("franky");
+      await sleep(character.ping);
+      await advanceSmartMove(parent.S.franky);
       frankyInstance = get_nearest_monster({ type: "franky" });
       change_target(frankyInstance);
     }

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -1908,14 +1908,14 @@ function attackErrorHandler(error) {
 
       const newX = currentX + 0.4 * (targetX - currentX);
       const newY = currentY + 0.4 * (targetY - currentY);
-      console.log(
+      console.warn(
         `Too far, ${Math.round(error.distance)} distance / ${
           character.range + character.xrange
         } range`,
       );
       move(newX, newY);
     }
-  } else console.log("Error while attacking:", error);
+  } else console.warn("Error while attacking:", error);
 }
 
 setInterval(() => parent.socket.emit("send_updates", {}), 30000);

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -1219,14 +1219,22 @@ setInterval(async function () {
   ) {
     smartmoveDebug = true;
     log("Debug being stuck while kiting");
-    if (can_move_to(currentTarget.x, currentTarget.y))
-      await move(currentTarget.x, currentTarget.y);
-    else
-      await advanceSmartMove({
+    if (parent.caracAL) {
+      await smartMove({
         map: character.map,
         x: currentTarget.x,
         y: currentTarget.y,
       });
+    } else {
+      if (can_move_to(currentTarget.x, currentTarget.y))
+        await move(currentTarget.x, currentTarget.y);
+      else
+        await advanceSmartMove({
+          map: character.map,
+          x: currentTarget.x,
+          y: currentTarget.y,
+        });
+    }
 
     smartmoveDebug = false;
   }

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -999,29 +999,31 @@ function getPlayersToHeal() {
   const minHealMod = 0.9;
   const healThreshold = character.ctype === "priest" ? 0.8 : 0.65;
   const healPower = character.heal || character.attack * 2.5;
-  const prioritizedNamesList = prioritizedNames();
+  const prioritizedNamesList = new Set(prioritizedNames());
 
   const shouldHeal = (entity) => {
-    const missing = entity.max_hp - entity.hp;
+    const entityHp = entity.predictedHp ?? entity.hp;
+    const missing = entity.max_hp - entityHp;
     return (
       missing > minHealMod * healPower ||
-      entity.hp < healThreshold * entity.max_hp
+      entityHp < healThreshold * entity.max_hp
     );
   };
-
-  // Prioritized characters
-  // const prioritized = prioritizedNamesList
-  //   .map((name) => get_entity(name))
-  //   .filter(
-  //     (player) => player && !player.dead && !player.rip && shouldHeal(player),
-  //   )
-  //   .sort((lhs, rhs) => lhs.hp / lhs.max_hp - rhs.hp / rhs.max_hp);
 
   // Other healable entities
   const potentialHealees = [
     ...Object.values(parent.entities),
     ...(character.ctype === "priest" ? [character] : []),
   ]
+    .map((entity) => {
+      const incomingNumber =
+        PROJECTILE_MANAGER?.getIncomingHeals(entity.name) ?? 0;
+
+      const predictedHp =
+        entity.name === character.name ? entity.hp : entity.hp + incomingNumber;
+
+      return { ...entity, predictedHp };
+    })
     .filter((entity) => {
       if (!entity) return false;
       if (entity.dead || entity.rip) return false;
@@ -1038,8 +1040,8 @@ function getPlayersToHeal() {
     .sort((lhs, rhs) => {
       // Ghosts first if both exist
 
-      const isLhsPrioritized = prioritizedNamesList.includes(lhs.name);
-      const isRhsPrioritized = prioritizedNamesList.includes(rhs.name);
+      const isLhsPrioritized = prioritizedNamesList.has(lhs.name);
+      const isRhsPrioritized = prioritizedNamesList.has(rhs.name);
 
       if (isLhsPrioritized !== isRhsPrioritized)
         return isLhsPrioritized ? -1 : 1;
@@ -1047,7 +1049,10 @@ function getPlayersToHeal() {
       const ghostLhs = lhs.mtype === "ghost";
       const ghostRhs = rhs.mtype === "ghost";
       if (ghostLhs !== ghostRhs) return ghostLhs ? -1 : 1;
-      return lhs.hp / lhs.max_hp - rhs.hp / rhs.max_hp;
+
+      const lhsHp = lhs.predictedHp ?? lhs.hp;
+      const rhsHp = rhs.predictedHp ?? rhs.hp;
+      return lhsHp / lhs.max_hp - rhsHp / rhs.max_hp;
     });
 
   return potentialHealees;

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -757,11 +757,7 @@ function getTarget() {
 const INTERVAL_BREAKPOINTS = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1];
 function getLoopInterval() {
   const dynamicInterval = INTERVAL_BREAKPOINTS.map(
-    (breakpoint) =>
-      Math.max(
-        (1 / character.frequency) * 1000,
-        character.s.penalty_cd?.ms ?? 0,
-      ) / breakpoint,
+    (breakpoint) => Math.max((1 / character.frequency) * 1000) / breakpoint,
   ).find((loopInterval) => loopInterval > 250);
   const frequencyInterval = (1 / character.frequency) * 1000;
 
@@ -828,7 +824,7 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
     const allEntities = Object.values(parent.entities);
     const noAggro = allEntities
       .filter((entity) => entity.type === "monster")
-      .every((mob) => mob.target !== character.name || mob['1hp']);
+      .every((mob) => mob.target !== character.name || mob["1hp"]);
     const noNearbyPlayers = allEntities
       .filter((entity) => entity.type === "character" && !entity.moving)
       .every((char) => distance(character, char) >= 8);
@@ -910,12 +906,12 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
       flipRotation *= -1;
       flipRotationCooldown = 6;
     }
-    for (let i = 1; i <= 16; i++) {
-      const adjustedAngle = angle + (flipRotation * Math.PI) / (16 / i);
+    for (let i = 1; i <= 48; i++) {
+      const adjustedAngle = angle + (flipRotation * Math.PI) / (48 / i);
       const alt_x =
-        target.x + (rangeRadius + character.xrange) * Math.cos(adjustedAngle);
+        target.x + (rangeRadius + extendedRadius) * Math.cos(adjustedAngle);
       const alt_y =
-        target.y + (rangeRadius + character.xrange) * Math.sin(adjustedAngle);
+        target.y + (rangeRadius + extendedRadius) * Math.sin(adjustedAngle);
 
       if (can_move_to(alt_x, alt_y)) {
         angle = adjustedAngle;
@@ -1148,8 +1144,7 @@ async function midasLooting(forced = false) {
           if (breakFlag-- <= 0) break;
 
           if (
-            partyMidasUsers.every((player) => distance(chest, player) > 800) ||
-            300000 > mssince(chest.last_loot)
+            partyMidasUsers.every((player) => distance(chest, player) > 800) 
           ) {
             promises.push(loot(chest.id));
           }
@@ -1913,9 +1908,12 @@ function on_magiport(name) {
 
 function attackErrorHandler(error) {
   if (error.failed) {
-    if (error.response === "cooldown")
-      reduce_cooldown("attack", -error.ms + Math.min(...parent.pings) / 2);
-    else if (
+    if (error.response === "cooldown") {
+      reduce_cooldown(
+        "attack",
+        -error.ms + Math.min(...parent.pings) / 2 + ms_to_next_skill("attack"),
+      );
+    } else if (
       error.reason === "too_far" &&
       character.cc < 125 &&
       !character.moving

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -1469,7 +1469,7 @@ const shouldDeployRogue = () => {
 
 const DYNAMIC_PARTY_PRESETS = {
   snowman: () => {
-    RANGER = RANGER2;
+    RANGER = RANGER1;
     HEALER = RANGER;
     return [WARRIOR, RANGER, MAGE];
   },

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -323,6 +323,7 @@ var IGNORE = [
   "pmaceofthedead",
   "staffofthedead",
   "swordofthedead",
+  "supermittens",
   ...BUYABLE,
 ];
 

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -828,7 +828,7 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
     const allEntities = Object.values(parent.entities);
     const noAggro = allEntities
       .filter((entity) => entity.type === "monster")
-      .every((mob) => mob.target !== character.name || mob.);
+      .every((mob) => mob.target !== character.name || mob['1hp']);
     const noNearbyPlayers = allEntities
       .filter((entity) => entity.type === "character" && !entity.moving)
       .every((char) => distance(character, char) >= 8);

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -796,8 +796,7 @@ function extraDistanceWithinHitbox(target) {
   return Math.min(get_height(target) / 2, get_width(target) / 2) / 2;
 }
 
-let lastKitingTargetId = undefined;
-
+var lastKitingTargetId = undefined;
 async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
   // Debug: Fixed width and height of target
   if (target) {
@@ -809,9 +808,8 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
 
   const loopInterval = Math.max(200, getLoopInterval());
 
-  // Early exits and sanity checks
+  // --- 1. Early exits and sanity checks ---
   if (character.cc >= 125) return setTimeout(hitAndRun, loopInterval);
-
   if (!target || smart.moving || isAdvanceSmartMoving) {
     angle = undefined;
     lastKitingTargetId = undefined;
@@ -825,11 +823,9 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
       character.range * rangeRate + character.xrange * 0.25
   ) {
     const allEntities = Object.values(parent.entities);
-
     const noAggro = allEntities
       .filter((entity) => entity.type === "monster")
       .every((mob) => mob.target !== character.name || mob["1hp"]);
-
     const noNearbyPlayers = allEntities
       .filter((entity) => entity.type === "character" && !entity.moving)
       .every((char) => distance(character, char) >= 8);
@@ -847,19 +843,21 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
     !lastKitingTargetId ||
     (lastKitingTargetId !== target.id &&
       distance(parent.entities[lastKitingTargetId], target) > 30);
-
   if (targetChanged) angle = undefined;
 
   lastKitingTargetId = target.id;
 
-  // Initialize angle if needed
+  // --- 2. Initialize angle if needed ---
   if (!angle) {
     const dx = character.real_x - target.real_x;
     const dy = character.real_y - target.real_y;
     angle = Math.atan2(dy, dx);
   }
 
-  // Track recent movement to detect being stuck
+  const cosA = Math.cos(angle);
+  const sinA = Math.sin(angle);
+
+  // --- 3. Track recent movement to detect being stuck ---
   movementHistory.push({ x: character.real_x, y: character.real_y });
   if (movementHistory.length > 5) movementHistory.shift();
 
@@ -871,46 +869,31 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
   }
 
   const averageMovement = totalMovement / movementHistory.length;
-
   if (averageMovement < stuckThreshold) {
     if (flipRotationCooldown <= 0) {
       flipRotation *= -1;
       flipRotationCooldown = 4;
-      angle += (flipRotation * Math.PI) / 2;
+      angle += (flipRotation * Math.PI) / 2; // turn 90°
     }
   }
 
+  // const totalExtraRange = extraRangeTarget + extraRangeSelf;
   const rangeRadius = character.range * rangeRateFn;
   const extendedRadius = character.xrange;
-  const radiusTotal = rangeRadius + extendedRadius;
+  // + totalExtraRange;
 
-  // Calculate rotation step - use actual distance that will be moved
-  const maxStep = ((character.speed * loopInterval) / 1000) * 0.9;
+  // --- 5. Desired destination based on current orbit angle ---
+  let new_x = target.x + (rangeRadius + extendedRadius) * cosA;
+  let new_y = target.y + (rangeRadius + extendedRadius) * sinA;
 
-  // Better rotation calculation: arc_length / radius, with minimum step
-  // This ensures smooth rotation even at large radii
-  const baseRotationStep = maxStep / radiusTotal;
-  const minRotationStep = Math.PI / 32; // Minimum ~5.6 degrees per step
-  const rotationStep =
-    flipRotation * Math.max(baseRotationStep, minRotationStep);
-
-  angle += rotationStep;
-
-  const cosAngle = Math.cos(angle);
-  const sinAngle = Math.sin(angle);
-
-  // Desired destination based on current orbit angle
-  let newX = target.x + radiusTotal * cosAngle;
-  let newY = target.y + radiusTotal * sinAngle;
-
-  // Smooth micro-rotation when close to target
+  // --- 6. Smooth micro-rotation when close to target ---
   if (flipCooldown > 9) {
     const closeToTarget =
       distance(character, target) <=
       (character.range + character.xrange) * 0.1 * rangeRateFn;
 
     if (closeToTarget) {
-      angle += (flipRotation * Math.PI) / 16;
+      angle += (flipRotation * Math.PI) / 16; // subtle orbit shift
     }
 
     flipCooldown = 0;
@@ -919,65 +902,84 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
   flipCooldown++;
   flipRotationCooldown--;
 
-  // Collision handling and alternative movement path
-  let destinationX;
-  let destinationY;
+  // --- 7. Collision handling and alternative movement path ---
+  let destinationX, destinationY;
 
-  if (!can_move_to(newX, newY)) {
+  if (!can_move_to(new_x, new_y)) {
+    // Try small angular adjustments in the current flip direction
     if (flipRotationCooldown < 0) {
       flipRotation *= -1;
       flipRotationCooldown = 6;
     }
-
     for (let i = 1; i <= 48; i++) {
       const adjustedAngle = angle + (flipRotation * Math.PI) / (48 / i);
+      const alt_x =
+        target.x + (rangeRadius + extendedRadius) * Math.cos(adjustedAngle);
+      const alt_y =
+        target.y + (rangeRadius + extendedRadius) * Math.sin(adjustedAngle);
 
-      const altX = target.x + radiusTotal * Math.cos(adjustedAngle);
-      const altY = target.y + radiusTotal * Math.sin(adjustedAngle);
-
-      if (can_move_to(altX, altY)) {
+      if (can_move_to(alt_x, alt_y)) {
         angle = adjustedAngle;
-        destinationX = altX;
-        destinationY = altY;
+        destinationX = alt_x;
+        destinationY = alt_y;
         break;
       }
     }
   } else {
-    destinationX = newX;
-    destinationY = newY;
+    destinationX = new_x;
+    destinationY = new_y;
   }
 
-  // Trim & execute movement
+  // --- 8. Execute movement or retry later ---
   if (destinationX && destinationY) {
+    const maxStep = (character.speed * loopInterval) / 1000;
+
     const dx = destinationX - character.real_x;
     const dy = destinationY - character.real_y;
-    const distanceToMove = Math.sqrt(dx * dx + dy * dy);
+    const dist = Math.sqrt(dx * dx + dy * dy);
 
-    if (distanceToMove > maxStep) {
-      const scale = maxStep / distanceToMove;
-      destinationX = character.real_x + dx * scale;
-      destinationY = character.real_y + dy * scale;
+    let moveX = destinationX;
+    let moveY = destinationY;
+
+    if (dist > maxStep) {
+      const scale = maxStep / dist;
+      moveX = character.real_x + dx * scale;
+      moveY = character.real_y + dy * scale;
     }
 
-    move(destinationX, destinationY);
+    move(moveX, moveY);
   } else {
     return setTimeout(hitAndRun, loopInterval);
   }
 
-  const dx = destinationX - character.real_x;
-  const dy = destinationY - character.real_y;
-  const moveDistance = Math.sqrt(dx * dx + dy * dy);
-  const moveTime = (moveDistance / character.speed) * 1000;
+  const radiusTotal = rangeRadius + extendedRadius;
+
+  // Calculate the actual distance we moved (chord length)
+  const actualDx = moveX - character.real_x;
+  const actualDy = moveY - character.real_y;
+  const chordLength = Math.sqrt(actualDx * actualDx + actualDy * actualDy);
+
+  // Convert chord length to angle: angle = 2 * asin(chord / (2 * radius))
+  const rotationStep =
+    flipRotation * 2 * Math.asin(Math.min(1, chordLength / (2 * radiusTotal)));
+
+  angle += rotationStep;
+
+  const moveTime =
+    (distance(character, { x: destinationX, y: destinationY }) /
+      character.speed) *
+    1000;
 
   setTimeout(hitAndRun, Math.max(moveTime, 200));
 }
 hitAndRun();
 
+const HEAL_IGNORE = ["Geoffriel"];
+
 function prioritizedNames() {
   return [...new Set([...partyMems, partyMerchant, ...parent.party_list])];
 }
 
-const HEAL_IGNORE = ["Geoffriel"];
 function getPlayersToHeal() {
   const minHealMod = 0.9;
   const healThreshold = character.ctype === "priest" ? 0.8 : 0.65;
@@ -1725,6 +1727,8 @@ async function changeToDailyEventTargets() {
     parent.S.crabxx?.target &&
     !partyMems.includes(parent.S.crabxx.target)
   ) {
+    if (character.range > 100) rangeRate = 0.3;
+
     const findBestCrabx = () =>
       Object.values(parent.entities)
         .filter((m) => m.mtype === "crabx")

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -1781,95 +1781,87 @@ async function changeToDailyEventTargets() {
   ) {
     if (character.range > 100) rangeRate = 0.3;
 
-    const findBestCrabx = () =>
-      Object.values(parent.entities)
-        .filter((m) => m.mtype === "crabx")
-        .sort((lhs, rhs) =>
-          is_in_range(lhs, "attack") !== is_in_range(rhs, "attack")
-            ? is_in_range(lhs, "attack")
-              ? -1
-              : 1
-            : lhs.hp === rhs.hp
-            ? distance(rhs, character) - distance(lhs, character)
-            : lhs.hp - rhs.hp,
-        )
-        .pop();
+    const inRange = (entity) =>
+      distance(entity, character) < character.range + character.xrange * 0.8;
 
-    const findCrabxNearCrabxx = (crabxx) => {
-      const crabxList = Object.values(parent.entities).filter(
-        (e) => e?.mtype === "crabx" && !e.rip,
-      );
+    const getCrabs = () => {
+      const entities = Object.values(parent.entities);
+      const crabxList = [];
+      let crabxxInstance;
 
-      return crabxList
-        .filter((crabx) => distance(crabx, crabxx) <= 17)
-        .sort((a, b) => a.hp - b.hp)[0]; // lowest hp first
+      for (const entity of entities) {
+        if (!entity || entity.rip) continue;
+
+        if (entity.mtype === "crabxx" && !crabxxInstance) {
+          crabxxInstance = entity;
+        }
+
+        if (entity.mtype === "crabx") {
+          crabxList.push(entity);
+        }
+      }
+      return { crabxxInstance, crabxList };
     };
 
-    const crabxList = Object.values(parent.entities).filter(
-      (e) => e?.mtype === "crabx",
-    );
-    let crabxxInstance = get_nearest_monster({ type: "crabxx" });
-    let crabxInstance = findBestCrabx();
+    let { crabxxInstance, crabxList } = getCrabs();
 
     if (!crabxxInstance) {
       if (character.s.hopsickness) {
-        await advanceSmartMove({ map: "main", x: -960, y: 1655 });
+        await advanceSmartMove(parent.S.crabxx);
       } else {
         await join("crabxx");
         await sleep(character.ping);
       }
+      ({ crabxxInstance, crabxList } = getCrabs());
 
-      crabxxInstance = get_nearest_monster({ type: "crabxx" });
-      crabxInstance = findBestCrabx();
+      if (!crabxxInstance) return;
+    }
+
+    let bestCrabx;
+    let bestClusteredCrabx;
+
+    for (const crabx of crabxList) {
+      const isCurrentCrabxInRange = inRange(crabx);
+
+      if (!bestCrabx) {
+        bestCrabx = crabx;
+      } else {
+        const isBestCrabxInRange = inRange(bestCrabx);
+
+        if (isCurrentCrabxInRange && !isBestCrabxInRange) {
+          bestCrabx = crabx;
+        } else if (isCurrentCrabxInRange === isBestCrabxInRange) {
+          if (crabx.hp > bestCrabx.hp) {
+            bestCrabx = crabx;
+          }
+        }
+      }
+
+      if (distance(crabx, crabxxInstance) <= BLAST_RADIUS) {
+        if (!bestClusteredCrabx || crabx.hp > bestClusteredCrabx.hp) {
+          bestClusteredCrabx = crabx;
+        }
+      }
     }
 
     if (
       character.ctype === "warrior" &&
-      crabxxInstance &&
       !crabxxInstance.s.stunned &&
       (crabxList.length <= 1 || crabxList.length >= 6)
     ) {
-      await warriorStomp();
+      warriorStomp();
     }
-
-    // if (
-    //   character.ctype === "mage" &&
-    //   crabxxInstance &&
-    //   crabxxInstance.target &&
-    //   character.mp > 600 &&
-    //   is_in_range(crabxxInstance, "cburst") &&
-    //   !is_on_cooldown("cburst")
-    // ) {
-    //   const crabxToCBurst = Object.values(parent.entities)
-    //     .filter(
-    //       (entity) =>
-    //         entity.type === "monster" &&
-    //         entity.mtype === "crabx" &&
-    //         entity.hp < 500 &&
-    //         !entity.rip,
-    //     )
-    //     .map((crabx) => [crabx, crabx.hp * 2]);
-    //   use_skill("cburst", [[crabxxInstance, 1], ...crabxToCBurst]);
-    // }
 
     let targetCrab;
+
     if (character.ctype === "warrior") {
-      targetCrab =
-        findCrabxNearCrabxx(crabxxInstance) || crabxxInstance || crabxInstance;
+      targetCrab = bestClusteredCrabx || crabxxInstance || bestCrabx;
     } else {
       targetCrab =
-        crabxInstance || (crabxxInstance?.target ? crabxxInstance : undefined);
+        bestCrabx || (crabxxInstance?.target ? crabxxInstance : undefined);
     }
 
-    // if (
-    //   crabxxInstance &&
-    //   crabxxInstance.target &&
-    //   !partyMems.includes(crabxxInstance.target)
-    // )
-    //   changeToPullStrategies();
-    // else
     changeToPullStrategies();
-
     change_target(targetCrab);
     return targetCrab;
   }

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -1220,11 +1220,18 @@ setInterval(async function () {
     smartmoveDebug = true;
     log("Debug being stuck while kiting");
     if (parent.caracAL) {
-      await smartMove({
-        map: character.map,
-        x: currentTarget.going_x,
-        y: currentTarget.going_y,
-      });
+      if (can_move_to(currentTarget.x, currentTarget.y))
+        await smartMove({
+          map: character.map,
+          x: (character.x + currentTarget.x) / 2,
+          y: (character.y + currentTarget.y) / 2,
+        });
+      else
+        await smartMove({
+          map: character.map,
+          x: currentTarget.x,
+          y: currentTarget.y,
+        });
     } else {
       if (can_move_to(currentTarget.x, currentTarget.y))
         await move(currentTarget.x, currentTarget.y);

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -1463,7 +1463,7 @@ const PARTICIPATABLE_EVENTS = [
   "wabbit",
   "snowman",
   "pinkgoo",
-  "goobrawl",
+  // "goobrawl", // commented out to allow rspeed rogue deployments and merch's gnomes luring during goobrawl
   "abtesting",
 ];
 

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -820,8 +820,8 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
 
   if (
     character.ctype === "warrior" &&
-    distance(character, target) > character.range * 0.35 &&
-    distance(character, target) <
+    distance(character, target) < character.range * 0.35 &&
+    distance(character, target) >
       character.range * rangeRate + character.xrange * 0.25
   ) {
     const allEntities = Object.values(parent.entities);
@@ -870,7 +870,7 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
   for (let i = 1; i < movementHistory.length; i++) {
     const dx = movementHistory[i].x - movementHistory[i - 1].x;
     const dy = movementHistory[i].y - movementHistory[i - 1].y;
-    totalMovement += Math.hypot(dx, dy);
+    totalMovement += Math.sqrt(dx * dx + dy * dy);
   }
 
   const averageMovement = totalMovement / movementHistory.length;
@@ -885,10 +885,11 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
 
   const rangeRadius = character.range * rangeRateFn;
   const extendedRadius = character.xrange;
+  const radiusTotal = rangeRadius + extendedRadius;
 
   // Desired destination based on current orbit angle
-  let newX = target.x + (rangeRadius + extendedRadius) * cosAngle;
-  let newY = target.y + (rangeRadius + extendedRadius) * sinAngle;
+  let newX = target.x + radiusTotal * cosAngle;
+  let newY = target.y + radiusTotal * sinAngle;
 
   // Smooth micro-rotation when close to target
   if (flipCooldown > 9) {
@@ -919,10 +920,8 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
     for (let i = 1; i <= 48; i++) {
       const adjustedAngle = angle + (flipRotation * Math.PI) / (48 / i);
 
-      const altX =
-        target.x + (rangeRadius + extendedRadius) * Math.cos(adjustedAngle);
-      const altY =
-        target.y + (rangeRadius + extendedRadius) * Math.sin(adjustedAngle);
+      const altX = target.x + radiusTotal * Math.cos(adjustedAngle);
+      const altY = target.y + radiusTotal * Math.sin(adjustedAngle);
 
       if (can_move_to(altX, altY)) {
         angle = adjustedAngle;
@@ -936,13 +935,13 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
     destinationY = newY;
   }
 
-  // Trim & execute movement or retry later
+  // Trim & execute movement
   if (destinationX && destinationY) {
     const maxStep = ((character.speed * loopInterval) / 1000) * 0.9;
 
     const dx = destinationX - character.real_x;
     const dy = destinationY - character.real_y;
-    const distanceToMove = Math.hypot(dx, dy);
+    const distanceToMove = Math.sqrt(dx * dx + dy * dy);
 
     if (distanceToMove > maxStep) {
       const scale = maxStep / distanceToMove;
@@ -951,24 +950,30 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
     }
 
     move(destinationX, destinationY);
+
+    // Calculate angle increment based on ACTUAL movement distance
+    const actualDx = destinationX - character.real_x;
+    const actualDy = destinationY - character.real_y;
+    const actualDistanceMoved = Math.sqrt(
+      actualDx * actualDx + actualDy * actualDy,
+    );
+
+    // Arc length formula: angle = arcLength / radius
+    // We use asin for small angles: angle ≈ 2 * asin(chord/2 / radius)
+    const rotationStep =
+      flipRotation *
+      Math.asin(Math.min(1, actualDistanceMoved / 2 / radiusTotal)) *
+      2;
+
+    angle += rotationStep;
   } else {
     return setTimeout(hitAndRun, loopInterval);
   }
 
-  // --- 9. Advance orbit angle for next iteration ---
-  const radiusTotal = rangeRadius + extendedRadius;
-
-  const rotationStep =
-    flipRotation *
-    Math.asin((character.speed * loopInterval) / 1000 / 2 / radiusTotal) *
-    2;
-
-  angle += rotationStep;
-
-  const moveTime =
-    (distance(character, { x: destinationX, y: destinationY }) /
-      character.speed) *
-    1000;
+  const dx = destinationX - character.real_x;
+  const dy = destinationY - character.real_y;
+  const moveDistance = Math.sqrt(dx * dx + dy * dy);
+  const moveTime = (moveDistance / character.speed) * 1000;
 
   setTimeout(hitAndRun, Math.max(moveTime, 200));
 }

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -804,7 +804,7 @@ function extraDistanceWithinHitbox(target) {
   return Math.min(get_height(target) / 2, get_width(target) / 2) / 2;
 }
 
-var lastKitingTarget = undefined;
+var lastKitingTargetId = undefined;
 async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
   const loopInterval = Math.max(200, getLoopInterval());
 
@@ -812,6 +812,7 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
   if (character.cc >= 125) return setTimeout(hitAndRun, loopInterval);
   if (!target || smart.moving || isAdvanceSmartMoving) {
     angle = undefined;
+    lastKitingTargetId = undefined;
     return setTimeout(hitAndRun, loopInterval);
   }
 
@@ -839,8 +840,12 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
 
   // Reset angle when switching or losing target
   const targetChanged =
-    !lastKitingTarget || distance(lastKitingTarget, target) > 30;
+    !lastKitingTargetId ||
+    (lastKitingTargetId !== target.id &&
+      distance(parent.entities[lastKitingTargetId], target) > 30);
   if (targetChanged) angle = undefined;
+
+  lastKitingTargetId = target.id;
 
   // --- 2. Initialize angle if needed ---
   if (!angle) {
@@ -928,7 +933,6 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
   // --- 8. Execute movement or retry later ---
   if (destinationX && destinationY) {
     move(destinationX, destinationY);
-    lastKitingTarget = target;
   } else {
     return setTimeout(hitAndRun, loopInterval);
   }
@@ -1144,7 +1148,7 @@ async function midasLooting(forced = false) {
           if (breakFlag-- <= 0) break;
 
           if (
-            partyMidasUsers.every((player) => distance(chest, player) > 800) 
+            partyMidasUsers.every((player) => distance(chest, player) > 800)
           ) {
             promises.push(loot(chest.id));
           }

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -823,14 +823,6 @@ function extraDistanceWithinHitbox(target) {
 
 var lastKitingTargetId = undefined;
 async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
-  // Debug: Fixed width and height of target
-  if (target) {
-    target.awidth = 24;
-    target.aheight = 24;
-    target.width = 24;
-    target.height = 24;
-  }
-
   const loopInterval = Math.max(200, getLoopInterval());
   // const totalExtraRange = extraRangeTarget + extraRangeSelf;
   const rangeRadius = character.range * rangeRateFn;
@@ -843,6 +835,20 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
     angle = undefined;
     lastKitingTargetId = undefined;
     return setTimeout(hitAndRun, loopInterval);
+  }
+
+  // CRABXX strategy: orbit the TANKER around the center of spawn
+  if (target?.mtype.includes("crabx") && isAssignedAsTanker()) {
+    const crabxxSpawn = getMonsterSpawns("crabxx")[0];
+    target = {
+      ...target,
+      x: crabxxSpawn.x,
+      y: crabxxSpawn.y,
+      real_x: crabxxSpawn.x,
+      real_y: crabxxSpawn.y,
+      going_x: crabxxSpawn.x,
+      going_y: crabxxSpawn.y,
+    };
   }
 
   if (

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -798,115 +798,120 @@ function extraDistanceWithinHitbox(target) {
 
 let lastKitingTargetId = undefined;
 
-async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
-  if (target) {
-    target.awidth = 24;
-    target.aheight = 24;
-    target.width = 24;
-    target.height = 24;
-  }
-
+async function hitAndRun(
+  target = get_target(),
+  rangeRateFn = typeof rangeRate === "function" ? rangeRate() : 0.85,
+) {
   const loopInterval = Math.max(200, getLoopInterval());
 
+  // 1. Basic Constraints & State Resets
   if (character.cc >= 125) return setTimeout(hitAndRun, loopInterval);
 
-  if (!target || smart.moving || isAdvanceSmartMoving) {
+  if (
+    !target ||
+    smart.moving ||
+    (typeof isAdvanceSmartMoving !== "undefined" && isAdvanceSmartMoving)
+  ) {
     angle = undefined;
     lastKitingTargetId = undefined;
     return setTimeout(hitAndRun, loopInterval);
   }
 
-  if (
-    character.ctype === "warrior" &&
-    distance(character, target) > character.range * 0.35 &&
-    distance(character, target) <
-      character.range * rangeRate + character.xrange * 0.25
-  ) {
-    const allEntities = Object.values(parent.entities);
-
-    const noAggro = allEntities
-      .filter((e) => e.type === "monster")
-      .every((mob) => mob.target !== character.name || mob["1hp"]);
-
-    const noNearbyPlayers = allEntities
-      .filter((e) => e.type === "character" && !e.moving)
-      .every((char) => distance(character, char) >= 8);
-
-    if (noAggro && noNearbyPlayers) {
-      const dx = character.real_x - target.real_x;
-      const dy = character.real_y - target.real_y;
-      angle = Math.atan2(dy, dx);
-      return setTimeout(hitAndRun, loopInterval);
-    }
+  // 2. Target Transition Logic
+  if (lastKitingTargetId !== target.id) {
+    angle = undefined;
+    lastKitingTargetId = target.id;
   }
 
-  const targetChanged =
-    !lastKitingTargetId ||
-    (lastKitingTargetId !== target.id &&
-      distance(parent.entities[lastKitingTargetId], target) > 30);
-
-  if (targetChanged) angle = undefined;
-  lastKitingTargetId = target.id;
-
-  if (angle === undefined) {
-    const dx = character.real_x - target.real_x;
-    const dy = character.real_y - target.real_y;
-    angle = Math.atan2(dy, dx);
-  }
-
-  movementHistory.push({ x: character.real_x, y: character.real_y });
-  if (movementHistory.length > 5) movementHistory.shift();
-
-  let totalMovement = 0;
-  for (let i = 1; i < movementHistory.length; i++) {
-    const dx = movementHistory[i].x - movementHistory[i - 1].x;
-    const dy = movementHistory[i].y - movementHistory[i - 1].y;
-    totalMovement += Math.hypot(dx, dy);
-  }
-
-  const averageMovement = totalMovement / movementHistory.length;
-
-  if (averageMovement < stuckThreshold && flipRotationCooldown <= 0) {
-    flipRotation *= -1;
-    flipRotationCooldown = 4;
-    angle += (flipRotation * Math.PI) / 2;
-  }
-
-  flipRotationCooldown--;
-
+  // 3. Distance & Radius Calculation
   const rangeRadius = character.range * rangeRateFn;
-  const extendedRadius = character.xrange;
+  const extendedRadius = character.xrange || 0;
   const radiusTotal = rangeRadius + extendedRadius;
 
-  const leadTime = 120;
-  const centerX = target.real_x + (target.vx || 0) * leadTime;
-  const centerY = target.real_y + (target.vy || 0) * leadTime;
+  // 4. Position Prediction
+  const leadTime = 150;
+  const centerX = target.real_x + (target.vx || 0) * (leadTime / 1000) * 10;
+  const centerY = target.real_y + (target.vy || 0) * (leadTime / 1000) * 10;
 
+  const currentDist = distance(character, { x: centerX, y: centerY });
+  const currentAngle = Math.atan2(
+    character.real_y - centerY,
+    character.real_x - centerX,
+  );
+
+  // 5. Stuck Detection
+  movementHistory.push({ x: character.real_x, y: character.real_y });
+  if (movementHistory.length > 6) movementHistory.shift();
+
+  if (movementHistory.length >= 2) {
+    let totalMovement = 0;
+    for (let i = 1; i < movementHistory.length; i++) {
+      totalMovement += distance(movementHistory[i], movementHistory[i - 1]);
+    }
+    const averageMovement = totalMovement / movementHistory.length;
+
+    if (averageMovement < stuckThreshold && flipRotationCooldown <= 0) {
+      flipRotation *= -1;
+      flipRotationCooldown = 8;
+    }
+  }
+  if (flipRotationCooldown > 0) flipRotationCooldown--;
+
+  // 6. Spiral Orbit Calculation
   const maxStep = ((character.speed * loopInterval) / 1000) * 0.9;
 
-  let angleStep = flipRotation * (maxStep / radiusTotal);
+  // Radial correction: stronger when far from optimal radius
+  const distDiff = currentDist - radiusTotal;
+  const radialAlpha = Math.asin(
+    Math.max(-1, Math.min(1, distDiff / Math.max(1, currentDist))),
+  );
 
-  const maxRotation = Math.PI / 20;
-  angleStep = Math.max(-maxRotation, Math.min(angleStep, maxRotation));
+  // Angle step for circular motion
+  const angleStep = (maxStep / Math.max(1, currentDist)) * flipRotation;
 
-  angle += angleStep;
+  // Combined movement angle with stronger radial damping
+  const moveAngle = currentAngle + angleStep - radialAlpha * 0.8;
 
-  let destinationX = centerX + radiusTotal * Math.cos(angle);
-  let destinationY = centerY + radiusTotal * Math.sin(angle);
+  // Calculate ideal destination
+  let destX = centerX + radiusTotal * Math.cos(moveAngle);
+  let destY = centerY + radiusTotal * Math.sin(moveAngle);
 
-  if (!can_move_to(destinationX, destinationY)) {
-    angle += (flipRotation * Math.PI) / 32;
-    destinationX = centerX + radiusTotal * Math.cos(angle);
-    destinationY = centerY + radiusTotal * Math.sin(angle);
+  // CLAMP movement to maxStep to avoid overshooting
+  const moveDistX = destX - character.real_x;
+  const moveDistY = destY - character.real_y;
+  const moveDist = Math.sqrt(moveDistX * moveDistX + moveDistY * moveDistY);
+
+  if (moveDist > maxStep) {
+    // Scale down movement to maxStep
+    const scale = maxStep / moveDist;
+    destX = character.real_x + moveDistX * scale;
+    destY = character.real_y + moveDistY * scale;
   }
 
-  if (can_move_to(destinationX, destinationY)) {
-    move(destinationX, destinationY);
+  // 7. Collision & Execution
+  if (!can_move_to(destX, destY)) {
+    const altAngle = currentAngle - angleStep;
+    const altX = centerX + radiusTotal * Math.cos(altAngle);
+    const altY = centerY + radiusTotal * Math.sin(altAngle);
+
+    if (can_move_to(altX, altY)) {
+      move(altX, altY);
+    } else {
+      // Fallback: try moving directly toward/away from target
+      const fallbackDist =
+        currentDist > radiusTotal ? radiusTotal - 10 : radiusTotal + 10;
+      const fallbackX = centerX + fallbackDist * Math.cos(currentAngle);
+      const fallbackY = centerY + fallbackDist * Math.sin(currentAngle);
+      if (can_move_to(fallbackX, fallbackY)) {
+        move(fallbackX, fallbackY);
+      }
+    }
+  } else {
+    move(destX, destY);
   }
 
   setTimeout(hitAndRun, loopInterval);
 }
-
 hitAndRun();
 
 function prioritizedNames() {

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -1756,10 +1756,6 @@ async function changeToDailyEventTargets() {
     let targetCrab;
     if (character.ctype === "warrior") {
       targetCrab = crabxxInstance?.target ? crabxxInstance : crabxInstance;
-
-      if (targetCrab && targetCrab.moving) {
-        rangeRate = 0.05;
-      }
     } else {
       targetCrab =
         crabxInstance || (crabxxInstance?.target ? crabxxInstance : undefined);

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -1690,7 +1690,7 @@ async function changeToDailyEventTargets() {
   }
 
   if (parent.S.pinkgoo?.live) {
-    changeToNormalStrategies();
+    changeToPullStrategies();
     let pinkgooInstance = get_nearest_monster({ type: "pinkgoo" });
     if (!pinkgooInstance) {
       if (parent.S.pinkgoo?.x) {

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -632,29 +632,35 @@ async function buff() {
         character.hp < character.max_hp - 500 &&
         !is_on_cooldown("use_hp")
       ) {
-        await withTimeout(use_skill("use_hp"), 2000);
+        await withTimeout(use_skill("use_hp"), 500);
         adjustPotionsCooldown();
       } else if (
         character.hp < character.max_hp - 50 &&
         !is_on_cooldown("regen_hp")
       ) {
-        await withTimeout(use_skill("regen_hp"), 2000);
+        await withTimeout(use_skill("regen_hp"), 500);
         adjustPotionsCooldown();
       }
     } else {
       if (character.mp < character.max_mp - 500 && !is_on_cooldown("use_mp")) {
-        await withTimeout(use_skill("use_mp"), 2000);
+        await withTimeout(use_skill("use_mp"), 500);
         adjustPotionsCooldown();
       } else if (
         character.mp < character.max_mp - 100 &&
         !is_on_cooldown("regen_mp")
       ) {
-        await withTimeout(use_skill("regen_mp"), 2000);
+        await withTimeout(use_skill("regen_mp"), 500);
         adjustPotionsCooldown();
       }
     }
   } catch (e) {}
-  setTimeout(async () => buff(), Math.max(ms_to_next_skill("use_mp"), 5));
+  setTimeout(
+    async () => buff(),
+    Math.min(
+      Math.max(ms_to_next_skill("use_mp"), 5),
+      Math.max(ms_to_next_skill("use_hp"), 5),
+    ),
+  );
 }
 buff();
 

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -174,20 +174,8 @@ function item_info(item) {
 
   const baseInfo = parent.G.items[item.name];
   if (!baseInfo) return undefined;
-
-  // Clone to avoid mutating global data
-  const itemInfo = JSON.parse(JSON.stringify(baseInfo));
-  const levelBonuses = itemInfo.upgrade ?? itemInfo.compound ?? undefined;
-
-  if (item.level && levelBonuses) {
-    for (const [key, value] of Object.entries(levelBonuses)) {
-      if (typeof value === "number") {
-        itemInfo[key] = (itemInfo[key] ?? 0) + value * item.level;
-      }
-    }
-  }
-
-  return itemInfo;
+  const itemProperties = calculate_item_properties(item);
+  return [...baseInfo, ...itemProperties];
 }
 
 function isInvFull(slots = 1) {

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -816,6 +816,10 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
   }
 
   const loopInterval = Math.max(200, getLoopInterval());
+  // const totalExtraRange = extraRangeTarget + extraRangeSelf;
+  const rangeRadius = character.range * rangeRateFn;
+  const extendedRadius = character.xrange;
+  // + totalExtraRange;
 
   // --- 1. Early exits and sanity checks ---
   if (character.cc >= 125) return setTimeout(hitAndRun, loopInterval);
@@ -828,8 +832,7 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
   if (
     character.ctype === "warrior" &&
     distance(character, target) > character.range * 0.35 &&
-    distance(character, target) <
-      character.range * rangeRate + character.xrange * 0.25
+    distance(character, target) < rangeRadius + extendedRadius
   ) {
     const allEntities = Object.values(parent.entities);
     const noAggro = allEntities
@@ -885,11 +888,6 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
       angle += (flipRotation * Math.PI) / 2; // turn 90°
     }
   }
-
-  // const totalExtraRange = extraRangeTarget + extraRangeSelf;
-  const rangeRadius = character.range * rangeRateFn;
-  const extendedRadius = character.xrange;
-  // + totalExtraRange;
 
   // --- 5. Desired destination based on current orbit angle ---
   let new_x = target.x + (rangeRadius + extendedRadius) * cosA;
@@ -1236,24 +1234,18 @@ setInterval(async function () {
     currentTarget.type === "monster" &&
     distance(currentTarget, character) >
       character.range + character.xrange * 0.9 &&
-    !smart.moving && !character.moving &&
+    !smart.moving &&
+    !character.moving &&
     !isAdvanceSmartMoving
   ) {
     smartmoveDebug = true;
     log("Debug being stuck while kiting");
     if (parent.caracAL) {
-      if (can_move_to(currentTarget.x, currentTarget.y))
-        await smartMove({
-          map: character.map,
-          x: (character.x + currentTarget.real_x) / 2,
-          y: (character.y + currentTarget.real_y) / 2,
-        });
-      else
-        await smartMove({
-          map: character.map,
-          x: currentTarget.real_x,
-          y: currentTarget.real_y,
-        });
+      await smartMove({
+        map: character.map,
+        x: currentTarget.real_x,
+        y: currentTarget.real_y,
+      });
     } else {
       if (can_move_to(currentTarget.x, currentTarget.y))
         await move(currentTarget.x, currentTarget.y);

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -119,9 +119,9 @@ var mapY = -2614;
 // var mapX = 0;
 // var mapY = -775;
 
-var map = "halloween";
-var mapX = -219;
-var mapY = 681;
+// var map = "halloween";
+// var mapX = -219;
+// var mapY = 681;
 
 // var map = "main";
 // var mapX = 676;
@@ -145,11 +145,11 @@ var mapY = 681;
 
 // var mobsToFarm = ["grinch", "phoenix", "spider", "bigbird", "scorpion"];
 // var mobsToFarm = ["goldenbot", "sparkbot", "sparkbot"];
-// var mobsToFarm = ["phoenix", "stompy", "wolf"];
+var mobsToFarm = ["phoenix", "stompy", "wolf"];
 // var mobsToFarm = ["fireroamer"];
 // var mobsToFarm = ["grinch", "phoenix", "mole"];
 
-var mobsToFarm = ["phoenix", "xscorpion", "minimush"];
+// var mobsToFarm = ["phoenix", "xscorpion", "minimush"];
 
 // var mobsToFarm = ["phoenix", "croc", "armadillo"];
 // var mobsToFarm = ["fvampire", "grinch", "phoenix", "ghost"];

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -953,15 +953,10 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
   }
 
   const radiusTotal = rangeRadius + extendedRadius;
-
-  // Calculate the actual distance we moved (chord length)
-  const actualDx = moveX - character.real_x;
-  const actualDy = moveY - character.real_y;
-  const chordLength = Math.sqrt(actualDx * actualDx + actualDy * actualDy);
-
-  // Convert chord length to angle: angle = 2 * asin(chord / (2 * radius))
   const rotationStep =
-    flipRotation * 2 * Math.asin(Math.min(1, chordLength / (2 * radiusTotal)));
+    flipRotation *
+    Math.asin((character.speed * loopInterval) / 1000 / 2 / radiusTotal) *
+    2;
 
   angle += rotationStep;
 

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -932,7 +932,7 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
 
   // --- 8. Execute movement or retry later ---
   if (destinationX && destinationY) {
-    const maxStep = (character.speed * loopInterval * 1.5) / 1000;
+    const maxStep = (character.speed * 500) / 1000;
 
     const dx = destinationX - character.real_x;
     const dy = destinationY - character.real_y;

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -1860,7 +1860,7 @@ async function changeToDailyEventTargets() {
     let targetCrab;
 
     if (character.ctype === "warrior") {
-      targetCrab = bestClusteredCrabx || crabxxInstance || bestCrabx;
+      targetCrab = bestClusteredCrabx|| bestCrabx || crabxxInstance;
     } else {
       targetCrab =
         bestCrabx || (crabxxInstance?.target ? crabxxInstance : undefined);

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -1862,21 +1862,23 @@ async function changeToDailyEventTargets() {
     let frankyInstance = get_nearest_monster({ type: "franky" });
     if (!frankyInstance) {
       try {
-        await join("franky");
+        join("franky");
+        await sleep(character.ping);
       } catch (e) {
         await advanceSmartMove(parent.S.franky);
       }
-      change_target(get_nearest_monster({ type: "franky" }));
       frankyInstance = get_nearest_monster({ type: "franky" });
+      change_target(frankyInstance);
     }
 
     if (frankyInstance)
       if (frankyInstance.target && !partyMems.includes(frankyInstance.target)) {
         rangeRate = 0.2;
+        return frankyInstance;
       } else {
         scareAwayMobs();
+        return frankyInstance;
       }
-    return frankyInstance;
   }
 
   if (parent.S.abtesting && !character.s.hopsickness) {

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -308,7 +308,6 @@ var IGNORE = [
   "pmaceofthedead",
   "staffofthedead",
   "swordofthedead",
-  'lmace',
   ...BUYABLE,
 ];
 

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -1975,7 +1975,7 @@ function attackErrorHandler(error, target = get_target()) {
     if (error.response === "cooldown" && error.place) {
       reduce_cooldown(error.place, -error.ms + Math.min(...parent.pings) / 2);
     } else if (error.reason === "too_far") {
-      if (character.cc < 125 && target) {
+      if (character.cc < 125 && target && !character.moving) {
         const currentX = character.x;
         const currentY = character.y;
 

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -1408,6 +1408,7 @@ setInterval(async () => {
   const whitelistPartyMembers = serverCharacters.filter(
     (char) =>
       !partyMems.includes(char.name) &&
+      char.type !== "merchant" &&
       partyWhitelistRegex.some((regex) => regex.test(char.party)),
   );
   const hasWhitelistedMember = parent.party_list.some((member) =>
@@ -1463,7 +1464,7 @@ const PARTICIPATABLE_EVENTS = [
   "wabbit",
   "snowman",
   "pinkgoo",
-  // "goobrawl", // commented out to allow rspeed rogue deployments and merch's gnomes luring during goobrawl
+  "goobrawl",
   "abtesting",
 ];
 

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -107,21 +107,21 @@ const MELEE_IGNORE_LIST = ["porcupine"];
 // var mapX = -289;
 // var mapY = -188;
 
-// var map = "winterland";
-// var mapX = 423;
-// var mapY = -2614;
+var map = "winterland";
+var mapX = 423;
+var mapY = -2614;
 
-var map = "desertland";
-var mapX = 223;
-var mapY = -708;
+// var map = "desertland";
+// var mapX = 223;
+// var mapY = -708;
 
 // var map = "tunnel";
 // var mapX = 0;
 // var mapY = -775;
 
-// var map = "halloween";
-// var mapX = -219;
-// var mapY = 681;
+var map = "halloween";
+var mapX = -219;
+var mapY = 681;
 
 // var map = "main";
 // var mapX = 676;
@@ -146,10 +146,10 @@ var mapY = -708;
 // var mobsToFarm = ["grinch", "phoenix", "spider", "bigbird", "scorpion"];
 // var mobsToFarm = ["goldenbot", "sparkbot", "sparkbot"];
 // var mobsToFarm = ["phoenix", "stompy", "wolf"];
-var mobsToFarm = ["fireroamer"];
+// var mobsToFarm = ["fireroamer"];
 // var mobsToFarm = ["grinch", "phoenix", "mole"];
 
-// var mobsToFarm = ["phoenix", "xscorpion", "minimush"];
+var mobsToFarm = ["phoenix", "xscorpion", "minimush"];
 
 // var mobsToFarm = ["phoenix", "croc", "armadillo"];
 // var mobsToFarm = ["fvampire", "grinch", "phoenix", "ghost"];

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -1491,9 +1491,10 @@ const DYNAMIC_PARTY_PRESETS = {
     HEALER = PRIEST;
     return [PRIEST, ROGUE, MAGE];
   },
-
   crabxx: () => {
     const isAggroed = !!parent.S.crabxx?.target;
+    if (isAggroed) RANGER = RANGER1;
+    HEALER = isAggroed ? RANGER1 : PRIEST;
     return [WARRIOR, isAggroed ? RANGER1 : PRIEST, isAggroed ? RANGER2 : MAGE];
   },
   default: () => {

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -857,53 +857,58 @@ async function hitAndRun(
   }
   if (flipRotationCooldown > 0) flipRotationCooldown--;
 
-  // 6. Spiral Orbit Calculation
+  // 6. Calculate Movement Components
   const maxStep = ((character.speed * loopInterval) / 1000) * 0.9;
+  
+  // How far off are we from the ideal radius?
+  const distError = currentDist - radiusTotal;
+  
+  // Split maxStep into tangential (orbit) and radial (correction) components
+  // When far from ideal radius, prioritize getting to correct distance
+  // When close, prioritize orbiting
+  const radialPortion = Math.min(Math.abs(distError) / radiusTotal, 0.5); // 0 to 0.5
+  const tangentialSpeed = maxStep * (1 - radialPortion);
+  const radialSpeed = maxStep * radialPortion;
+  
+  // Tangential: movement around the circle
+  const angleStep = (tangentialSpeed / Math.max(1, currentDist)) * flipRotation;
+  const newAngle = currentAngle + angleStep;
+  
+  // Radial: movement toward/away from ideal radius
+  const targetDist = currentDist - Math.sign(distError) * radialSpeed;
+  
+  // Calculate final destination
+  let destX = centerX + targetDist * Math.cos(newAngle);
+  let destY = centerY + targetDist * Math.sin(newAngle);
 
-  // Radial correction: stronger when far from optimal radius
-  const distDiff = currentDist - radiusTotal;
-  const radialAlpha = Math.asin(
-    Math.max(-1, Math.min(1, distDiff / Math.max(1, currentDist))),
-  );
-
-  // Angle step for circular motion
-  const angleStep = (maxStep / Math.max(1, currentDist)) * flipRotation;
-
-  // Combined movement angle with stronger radial damping
-  const moveAngle = currentAngle + angleStep - radialAlpha * 0.8;
-
-  // Calculate ideal destination
-  let destX = centerX + radiusTotal * Math.cos(moveAngle);
-  let destY = centerY + radiusTotal * Math.sin(moveAngle);
-
-  // CLAMP movement to maxStep to avoid overshooting
+  // 7. Clamp total movement to maxStep (prevents overshooting)
   const moveDistX = destX - character.real_x;
   const moveDistY = destY - character.real_y;
-  const moveDist = Math.sqrt(moveDistX * moveDistX + moveDistY * moveDistY);
+  const totalMoveDist = Math.sqrt(moveDistX * moveDistX + moveDistY * moveDistY);
 
-  if (moveDist > maxStep) {
-    // Scale down movement to maxStep
-    const scale = maxStep / moveDist;
+  if (totalMoveDist > maxStep) {
+    const scale = maxStep / totalMoveDist;
     destX = character.real_x + moveDistX * scale;
     destY = character.real_y + moveDistY * scale;
   }
 
-  // 7. Collision & Execution
+  // 8. Collision & Execution
   if (!can_move_to(destX, destY)) {
-    const altAngle = currentAngle - angleStep;
-    const altX = centerX + radiusTotal * Math.cos(altAngle);
-    const altY = centerY + radiusTotal * Math.sin(altAngle);
+    // Try opposite rotation
+    const altAngleStep = -angleStep;
+    const altAngle = currentAngle + altAngleStep;
+    const altX = centerX + targetDist * Math.cos(altAngle);
+    const altY = centerY + targetDist * Math.sin(altAngle);
 
     if (can_move_to(altX, altY)) {
       move(altX, altY);
     } else {
-      // Fallback: try moving directly toward/away from target
-      const fallbackDist =
-        currentDist > radiusTotal ? radiusTotal - 10 : radiusTotal + 10;
-      const fallbackX = centerX + fallbackDist * Math.cos(currentAngle);
-      const fallbackY = centerY + fallbackDist * Math.sin(currentAngle);
-      if (can_move_to(fallbackX, fallbackY)) {
-        move(fallbackX, fallbackY);
+      // If both blocked, just try to fix radius without orbiting
+      const radialOnlyX = centerX + (currentDist - Math.sign(distError) * maxStep * 0.5) * Math.cos(currentAngle);
+      const radialOnlyY = centerY + (currentDist - Math.sign(distError) * maxStep * 0.5) * Math.sin(currentAngle);
+      
+      if (can_move_to(radialOnlyX, radialOnlyY)) {
+        move(radialOnlyX, radialOnlyY);
       }
     }
   } else {

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -1826,8 +1826,8 @@ async function changeToDailyEventTargets() {
         rangeRate = 0.2;
         return frankyInstance;
       } else {
-        change_target();
-        await advanceSmartMove({ map: "level2w", x: -530, y: -173 });
+        scareAwayMobs();
+        return frankyInstance;
       }
   }
 
@@ -1943,8 +1943,8 @@ function attackErrorHandler(error) {
       const currentY = character.y;
 
       const target = get_target();
-      const targetX = target.going_x ?? target.x;
-      const targetY = target.going_y ?? target.y;
+      const targetX = target.real_x ?? target.x;
+      const targetY = target.real_y ?? target.y;
 
       const newX = currentX + 0.4 * (targetX - currentX);
       const newY = currentY + 0.4 * (targetY - currentY);

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -604,6 +604,15 @@ async function withTimeout(
   ]);
 }
 
+async function waitUntil(fn, timeout = 10_000, interval = character.ping) {
+  const start = Date.now();
+  while (!fn()) {
+    if (Date.now() - start > timeout) return false;
+    await sleep(interval);
+  }
+  return true;
+}
+
 async function buff() {
   try {
     if (Object.keys(character.c).length) {
@@ -1392,7 +1401,7 @@ setTimeout(deployCharacters, 5000);
 setInterval(deployCharacters, 30000);
 
 setInterval(async () => {
-  if (isMerchant()) return;
+  // if (isMerchant()) return;
 
   const serverCharacters = await getServerPlayers();
   const partyWhitelistRegex = [/^earth/];
@@ -1417,12 +1426,9 @@ setInterval(async () => {
     );
   }
 
-  if (Math.min(...parent.pings) > 1000) {
-    if (character.ctype === "merchant") disconnect();
-    else {
-      if (parent.caracAL) parent.caracAL.shutdown();
-      else disconnect();
-    }
+  if (Math.min(...parent.pings) > 1000 && character.ctype !== "merchant") {
+    if (parent.caracAL) parent.caracAL.shutdown();
+    else disconnect();
   }
 
   if (partyMems.some((id) => !parent.party_list.includes(id))) {

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -323,7 +323,8 @@ var IGNORE = [
   "staffofthedead",
   "swordofthedead",
   "supermittens",
-  "horsecapeg",
+  // "horsecapeg",
+  "throwingstars",
   ...BUYABLE,
 ];
 

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -821,7 +821,7 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
   if (
     character.ctype === "warrior" &&
     distance(character, target) > character.range * 0.35 &&
-    distance(character, target) 
+    distance(character, target) <
       character.range * rangeRate + character.xrange * 0.25
   ) {
     const allEntities = Object.values(parent.entities);
@@ -886,13 +886,14 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
 
   // Calculate rotation step - use actual distance that will be moved
   const maxStep = ((character.speed * loopInterval) / 1000) * 0.9;
-  
+
   // Better rotation calculation: arc_length / radius, with minimum step
   // This ensures smooth rotation even at large radii
   const baseRotationStep = maxStep / radiusTotal;
   const minRotationStep = Math.PI / 32; // Minimum ~5.6 degrees per step
-  const rotationStep = flipRotation * Math.max(baseRotationStep, minRotationStep);
-  
+  const rotationStep =
+    flipRotation * Math.max(baseRotationStep, minRotationStep);
+
   angle += rotationStep;
 
   const cosAngle = Math.cos(angle);
@@ -905,7 +906,8 @@ async function hitAndRun(target = get_target(), rangeRateFn = rangeRate) {
   // Smooth micro-rotation when close to target
   if (flipCooldown > 9) {
     const closeToTarget =
-      distance(character, target) <= (character.range + character.xrange) * 0.1 * rangeRateFn;
+      distance(character, target) <=
+      (character.range + character.xrange) * 0.1 * rangeRateFn;
 
     if (closeToTarget) {
       angle += (flipRotation * Math.PI) / 16;

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -1731,8 +1731,6 @@ async function changeToDailyEventTargets() {
     parent.S.crabxx?.target &&
     !partyMems.includes(parent.S.crabxx.target)
   ) {
-    if (character.range > 100) rangeRate = 0.3;
-
     const findBestCrabx = () =>
       Object.values(parent.entities)
         .filter((m) => m.mtype === "crabx")

--- a/basic_function.7.js
+++ b/basic_function.7.js
@@ -135,13 +135,17 @@ const MELEE_IGNORE_LIST = ["porcupine"];
 // var mapX = -1111;
 // var mapY = 132;
 
-var map = "desertland";
-var mapX = -800;
-var mapY = -354;
+// var map = "desertland";
+// var mapX = -800;
+// var mapY = -354;
 
 // var map = "level1";
 // var mapX = 50;
 // var mapY = 425;
+
+var map = "spookytown";
+var mapX = 255;
+var mapY = -1160;
 
 // var mobsToFarm = ["grinch", "phoenix", "spider", "bigbird", "scorpion"];
 // var mobsToFarm = ["goldenbot", "sparkbot", "sparkbot"];
@@ -162,8 +166,9 @@ var mapY = -354;
 //   "turtle",
 //   "crabx",
 // ];
-var mobsToFarm = ["plantoid"];
+// var mobsToFarm = ["plantoid"];
 // var mobsToFarm = ["prat"];
+var mobsToFarm = ["mummy"];
 
 // desired elixir named
 var desiredElixir = "elixirluck";

--- a/basic_mage.4.js
+++ b/basic_mage.4.js
@@ -72,10 +72,7 @@ async function fight(target) {
 
   // --- Energize Logic ---
   const canEnergize = !is_on_cooldown("energize");
-  const isAttackReady =
-    ms_to_next_skill("attack") === 0 && !character.s.penalty_cd;
-  const shouldEnergizeSelf =
-    ms_to_next_skill("attack") < 300 && !character.s.penalty_cd;
+  const isAttackReady = ms_to_next_skill("attack") === 0;
   const isTargetInAttackRange =
     distance(target, character) <= character.range + character.xrange;
   if (canEnergize) {
@@ -91,7 +88,7 @@ async function fight(target) {
 
     if (shouldEnergizeBuffee) {
       energizeTarget = buffee;
-    } else if (shouldEnergizeSelf && isTargetInAttackRange) {
+    } else if (isAttackReady && isTargetInAttackRange) {
       energizeTarget = character;
     }
 

--- a/basic_mage.4.js
+++ b/basic_mage.4.js
@@ -72,7 +72,8 @@ async function fight(target) {
 
   // --- Energize Logic ---
   const canEnergize = !is_on_cooldown("energize");
-  const isAttackReady = ms_to_next_skill("attack") === 0 && !character.s.penalty_cd;
+  const isAttackReady =
+    ms_to_next_skill("attack") === 0 && !character.s.penalty_cd;
   const isTargetInAttackRange =
     distance(target, character) <= character.range + character.xrange;
   if (canEnergize) {
@@ -98,7 +99,9 @@ async function fight(target) {
           "energize",
           energizeTarget,
           Math.max(character.mp - G.skills["magiport"].mp * 1.5, 2),
-        ).then(() => reduceCd("energize")),
+        )
+          .then(() => reduceCd("energize"))
+          .catch((e) => attackErrorHandler(e)),
       );
     }
   }
@@ -126,10 +129,10 @@ async function fight(target) {
 
   // --- Reflection Logic ---
   const isMagicalTarget = target["damage_type"] === "magical";
-  const canReflect = !is_on_cooldown("reflection") && character.mp > 1000;
+  const canUseReflection = !is_on_cooldown("reflection") && character.mp > 1000;
   const targetAggroesParty = partyMems.includes(target.target);
 
-  if (isMagicalTarget && canReflect && targetAggroesParty) {
+  if (isMagicalTarget && canUseReflection && targetAggroesParty) {
     use_skill("reflection", get_entity(target.target)).then(() =>
       reduceCd("reflection"),
     );

--- a/basic_mage.4.js
+++ b/basic_mage.4.js
@@ -15,7 +15,7 @@ if (parent.caracAL) {
 }
 
 // Kiting
-var originRangeRate = 0.85;
+var originRangeRate = 0.75;
 rangeRate = originRangeRate;
 const loopInterval = Math.floor(((1 / character.frequency) * 1000) / 4);
 
@@ -91,7 +91,11 @@ async function fight(target) {
 
     if (energizeTarget) {
       promisesToAwait.push(
-        use_skill("energize", energizeTarget).then(() => reduceCd("energize")),
+        use_skill(
+          "energize",
+          energizeTarget,
+          Math.max(character.mp - G.skills["magiport"].mp * 1.5, 2),
+        ).then(() => reduceCd("energize")),
       );
     }
   }
@@ -194,11 +198,11 @@ async function mainLoop() {
       const needsToEnterCrypt = cryptKey && character.map !== "crypt";
       const isPartyLeaderOrAlone =
         TANKER === character.name || !get_entity(TANKER);
-      const isFarFromPartyLeader =
+      const isFarFromFarmingSpot =
         distance(character, { x: mapX, y: mapY, map }) > 500;
 
       const needsToMoveToFarmLocation =
-        !cryptKey && (isPartyLeaderOrAlone || isFarFromPartyLeader);
+        !cryptKey && (isPartyLeaderOrAlone || isFarFromFarmingSpot);
 
       if (needsToEnterCrypt) {
         // Move to Crypt start if a crypt instance is active but we aren't there

--- a/basic_mage.4.js
+++ b/basic_mage.4.js
@@ -106,12 +106,14 @@ async function fight(target) {
     }
   }
 
-  // --- Attack Logic ---
+  if (!isAttackReady && isTargetInAttackRange && shouldAttack()) {
+    promisesToAwait.push(currentStrategy(target));
+  }
 
   if (isAttackReady && isTargetInAttackRange && shouldAttack()) {
     set_message("Attacking");
     promisesToAwait.push(
-      currentStrategy(target), // Assumes currentStrategy includes moving/kiting logic
+      // currentStrategy(target),
       attack(target)
         .then(() => reduceCd("attack"))
         .catch((e) => {

--- a/basic_mage.4.js
+++ b/basic_mage.4.js
@@ -72,7 +72,7 @@ async function fight(target) {
 
   // --- Energize Logic ---
   const canEnergize = !is_on_cooldown("energize");
-  const isAttackReady = ms_to_next_skill("attack") === 0;
+  const isAttackReady = ms_to_next_skill("attack") === 0 && !character.s.penalty_cd;
   const isTargetInAttackRange =
     distance(target, character) <= character.range + character.xrange;
   if (canEnergize) {

--- a/basic_mage.4.js
+++ b/basic_mage.4.js
@@ -173,6 +173,7 @@ async function mainLoop() {
         map: character.map,
         x: character.x,
         y: character.y,
+        time: Date.now(),
       });
     }
 

--- a/basic_mage.4.js
+++ b/basic_mage.4.js
@@ -34,6 +34,7 @@ async function fight(target) {
           entity.type === "monster" &&
           entity.target && // Must be aggroed
           !entity.dead &&
+          !entity.s?.fullguardx &&
           !haveFormidableMonsterAroundTarget(entity) &&
           distance(entity, character) <= attackRange,
       )
@@ -45,18 +46,21 @@ async function fight(target) {
 
     if (aggroedMobs.length) {
       // Sort: Find the best mob to target for cluster damage
-      const bestPullTarget = aggroedMobs
+      const bestTarget = aggroedMobs
         .sort((lhs, rhs) => {
-          // 1. Prioritize highest cluster count
+          if (lhs.cooperative !== rhs.cooperative) {
+            return lhs.cooperative ? -1 : 1;
+          }
+          // Prioritize highest cluster count
           if (lhs.cluster_count !== rhs.cluster_count) {
             return rhs.cluster_count - lhs.cluster_count;
           }
-          // 2. If cluster counts are equal, prioritize highest HP to apply max damage
+          // If cluster counts are equal, prioritize highest HP to apply max damage
           return rhs.hp - lhs.hp;
         })
         .shift(); // Get the first (best) target
 
-      target = bestPullTarget ?? target;
+      target = bestTarget ?? target;
       change_target(target);
     }
   }
@@ -70,6 +74,8 @@ async function fight(target) {
   const canEnergize = !is_on_cooldown("energize");
   const isAttackReady =
     ms_to_next_skill("attack") === 0 && !character.s.penalty_cd;
+  const shouldEnergizeSelf =
+    ms_to_next_skill("attack") < 300 && !character.s.penalty_cd;
   const isTargetInAttackRange =
     distance(target, character) <= character.range + character.xrange;
   if (canEnergize) {
@@ -85,7 +91,7 @@ async function fight(target) {
 
     if (shouldEnergizeBuffee) {
       energizeTarget = buffee;
-    } else if (isAttackReady && isTargetInAttackRange) {
+    } else if (shouldEnergizeSelf && isTargetInAttackRange) {
       energizeTarget = character;
     }
 

--- a/basic_mage.4.js
+++ b/basic_mage.4.js
@@ -15,7 +15,7 @@ if (parent.caracAL) {
 }
 
 // Kiting
-var originRangeRate = 0.75;
+var originRangeRate = 0.4;
 rangeRate = originRangeRate;
 const loopInterval = Math.floor(((1 / character.frequency) * 1000) / 4);
 

--- a/basic_mage.4.js
+++ b/basic_mage.4.js
@@ -119,7 +119,7 @@ async function fight(target) {
 
   // --- Await and Error Handling ---
   try {
-    await withTimeout(Promise.allSettled(promisesToAwait), 1000);
+    await withTimeout(Promise.all(promisesToAwait), 1000);
   } catch (e) {
     console.log(e);
   }

--- a/basic_merchant.5.js
+++ b/basic_merchant.5.js
@@ -403,14 +403,36 @@ async function craft(item, craftQuantity = 1, place = find_npc("craftsman")) {
   }
 }
 
+var isLuringMobs = false;
+async function lureMechaGnome() {
+  if (isLuringMobs) return; // optional guard
+
+  isLuringMobs = true;
+  try {
+    close_stand();
+    await smartMove({ map: "cyberland" });
+
+    parent.socket.emit("eval", {
+      command: "mooooooh",
+    });
+
+    await sleep(character.ping);
+    advanceSmartMove(get("mageLocation"), { useScare: false });
+  } catch (e) {
+    console.error(e);
+  } finally {
+    isLuringMobs = false;
+  }
+}
+
 setInterval(async function () {
   loot();
   if (character.rip) {
     respawn();
     return;
   }
-
-  scareAwayMobs();
+  
+  if (!isLuringMobs) scareAwayMobs();
 
   await sortInv();
 

--- a/basic_merchant.5.js
+++ b/basic_merchant.5.js
@@ -16,6 +16,8 @@ var isExeing = false;
 
 const fishingLocation = { map: "main", x: -1368, y: -82 };
 const miningLocation = { map: "tunnel", x: -279, y: -148 };
+const haveAComputer = () =>
+  locate_item("computer") !== -1 || locate_item("ancientcomputer") !== -1;
 
 function equipBroom() {
   const currentWeapon = character.slots.mainhand;
@@ -71,7 +73,7 @@ async function holidayExchange() {
     },
   ];
 
-  const exchangableItem = holidayItems.find(async (item) => {
+  const exchangableItem = holidayItems.find((item) => {
     const itemName = item.name;
     const slot = locate_item(itemName);
     if (slot === -1 && getItemBankSlots(itemName).length) {
@@ -84,7 +86,7 @@ async function holidayExchange() {
 
   if (!exchangableItem || smart.moving) return;
 
-  if (get_nearest_npc()?.npc !== exchangableItem.npc) {
+  if (get_nearest_npc()?.npc !== exchangableItem.npc && !haveAComputer()) {
     close_stand();
     equipBroom();
     await smart_move(find_npc(exchangableItem.npc));
@@ -145,7 +147,12 @@ async function exchangeMines() {
   });
 
   if (slot && character.items[slot].q >= 50) {
-    if (!smart.moving && !isAdvanceSmartMoving && character.map !== "tunnel") {
+    if (
+      !smart.moving &&
+      !isAdvanceSmartMoving &&
+      character.map !== "tunnel" &&
+      !haveAComputer()
+    ) {
       await smart_move(miningLocation);
     }
     await exchange(slot).catch((e) => {
@@ -387,7 +394,7 @@ async function craft(item, craftQuantity = 1, place = find_npc("craftsman")) {
   }
 
   if (isEnoughIngredients) {
-    if (get_nearest_npc()?.name !== "Leo") {
+    if (get_nearest_npc()?.name !== "Leo" && !haveAComputer()) {
       close_stand();
       await smart_move(place);
     }
@@ -407,6 +414,11 @@ setInterval(async function () {
   scareAwayMobs();
 
   await sortInv();
+
+  const computerSlot = locate_item("computer");
+  if (computerSlot === -1 && getItemBankSlots("computer").length) {
+    retrieveBankItem("computer");
+  }
 
   await withTimeout(
     Promise.allSettled([
@@ -462,7 +474,7 @@ setInterval(async function () {
     if (character.map === "bank") {
       try {
         character.items
-          .filter((item) => item && !IGNORE.includes(item.name))
+          .filter((item) => item && !item.l && !IGNORE.includes(item.name))
           .map((item, index) => {
             bank_store(index);
           });
@@ -499,6 +511,10 @@ const ITEM_NEEDED = [
   "firestaff",
   "firestars",
   "jacko",
+  "gcape",
+  "mshield",
+  "carrot",
+  "harbringer",
 ];
 
 function secondhandsHandler(events) {

--- a/basic_merchant.5.js
+++ b/basic_merchant.5.js
@@ -120,6 +120,7 @@ async function exchangeXyn() {
     { name: "mistletoe", quantity: 1 },
     { name: "candycane", quantity: 1 },
     { name: "greenenvelope", quantity: 1 },
+    { name: "brownenvelope", quantity: 1 },
     { name: "goldenegg", quantity: 1 },
     { name: "5bucks", quantity: 1 },
     { name: "candypop", quantity: 10 },
@@ -517,6 +518,7 @@ const ITEM_NEEDED = [
   "jacko",
   "gcape",
   "carrot",
+  "brownenvelope",
   "harbringer",
 ];
 

--- a/basic_merchant.5.js
+++ b/basic_merchant.5.js
@@ -437,7 +437,7 @@ setInterval(async function () {
       craft("carrotsword", 1, { map: "main", x: -2, y: 295 }),
       craft("wingedboots", character.esize - 8, { map: "main", x: -2, y: 295 }),
       craft("pouchbow", character.esize - 8, { map: "main", x: -2, y: 295 }),
-      // craft("firestaff", character.esize - 6, { map: "main", x: -2, y: 295 }),
+      craft("firebow", character.esize - 6, { map: "main", x: -2, y: 295 }),
       !isSortingInventory &&
         Promise.all(
           Array.from({ length: 42 }, (_, i) => i)

--- a/basic_merchant.5.js
+++ b/basic_merchant.5.js
@@ -20,8 +20,9 @@ const miningLocation = { map: "tunnel", x: -279, y: -148 };
 function equipBroom() {
   const currentWeapon = character.slots.mainhand;
   if (!currentWeapon || currentWeapon.name !== "broom") {
-    const broom = locate_item("broom");
-    if (broom !== -1)
+    const broom = findMaxLevelItem("broom");
+    if (broom === -1) retrieveBankItem("broom");
+    else
       equipBatch({
         mainhand: "broom",
         offhand: "wbookhs",
@@ -47,7 +48,7 @@ function shouldGoExchangeXmas() {
   );
 }
 async function holidayExchange() {
-  if (!shouldGoExchangeXmas() || !party.S.holiday) return;
+  if (!shouldGoExchangeXmas() || !parent.S["holidayseason"]) return;
 
   const holidayItems = [
     {
@@ -70,13 +71,18 @@ async function holidayExchange() {
     },
   ];
 
-  const exchangableItem = holidayItems.find((item) => {
-    const slot = locate_item(item.name);
+  const exchangableItem = holidayItems.find(async (item) => {
+    const itemName = item.name;
+    const slot = locate_item(itemName);
+    if (slot === -1 && getItemBankSlots(itemName).length) {
+      retrieveBankItem(itemName);
+    }
+
     if (slot === -1) return false;
     return character.items[slot]?.q >= item.quantity + item.keep;
   });
 
-  if (!exchangableItem) return;
+  if (!exchangableItem || smart.moving) return;
 
   if (get_nearest_npc()?.npc !== exchangableItem.npc) {
     close_stand();
@@ -407,7 +413,7 @@ setInterval(async function () {
       compoundInv(),
       upgradeInv(),
       exchangeXyn(),
-      // holidayExchange(),
+      holidayExchange(),
       craft("xbox"),
       craft("basketofeggs"),
       craft("orba", 1, { map: "main", x: -152, y: -137 }),
@@ -493,7 +499,6 @@ const ITEM_NEEDED = [
   "firestaff",
   "firestars",
   "jacko",
-  "intamulet",
 ];
 
 function secondhandsHandler(events) {

--- a/basic_merchant.5.js
+++ b/basic_merchant.5.js
@@ -438,7 +438,8 @@ setInterval(async function () {
       craft("carrotsword", 1, { map: "main", x: -2, y: 295 }),
       craft("wingedboots", character.esize - 8, { map: "main", x: -2, y: 295 }),
       craft("pouchbow", character.esize - 8, { map: "main", x: -2, y: 295 }),
-      // craft("firestaff", character.esize - 6, { map: "main", x: -2, y: 295 }),
+      craft("firestaff", character.esize - 6, { map: "main", x: -2, y: 295 }),
+      craft("firestars", character.esize - 6, { map: "main", x: -2, y: 295 }),
       !isSortingInventory &&
         Promise.all(
           Array.from({ length: 42 }, (_, i) => i)
@@ -519,7 +520,7 @@ const ITEM_NEEDED = [
   "gcape",
   "carrot",
   "brownenvelope",
-  "harbringer",
+  "harbringer","throwingstars",
 ];
 
 function secondhandsHandler(events) {

--- a/basic_merchant.5.js
+++ b/basic_merchant.5.js
@@ -512,7 +512,6 @@ const ITEM_NEEDED = [
   "firestars",
   "jacko",
   "gcape",
-  "mshield",
   "carrot",
   "harbringer",
 ];

--- a/basic_merchant.5.js
+++ b/basic_merchant.5.js
@@ -190,9 +190,9 @@ function moveHome() {
   return smart_move(homeLocation)
     .then(() => {
       onDuty = false;
-      if (locate_item("stand0") === -1) {
+      if (locate_item("stand0") === -1 && !haveAComputer()) {
         retrieveBankItem("stand0");
-      } else open_stand(locate_item("stand0"));
+      } else open_stand();
     })
     .catch((e) => {
       if (e.reason === "failed" && e.failed) use_skill("use_town");

--- a/basic_merchant.5.js
+++ b/basic_merchant.5.js
@@ -319,8 +319,6 @@ async function craft(item, craftQuantity = 1, place = find_npc("craftsman")) {
     isInvFull(4) ||
     smart.moving ||
     isAdvanceSmartMoving ||
-    (!is_on_cooldown("fishing") && locate_item("rod") !== -1) ||
-    (!is_on_cooldown("mining") && locate_item("pickaxe") !== -1) ||
     character.c.mining ||
     character.c.fishing ||
     !craftQuantity
@@ -403,35 +401,13 @@ async function craft(item, craftQuantity = 1, place = find_npc("craftsman")) {
   }
 }
 
-var isLuringMobs = false;
-async function lureMechaGnome() {
-  if (isLuringMobs) return; // optional guard
-
-  isLuringMobs = true;
-  try {
-    close_stand();
-    await smartMove({ map: "cyberland" });
-
-    parent.socket.emit("eval", {
-      command: "mooooooh",
-    });
-
-    await sleep(character.ping);
-    advanceSmartMove(get("mageLocation"), { useScare: false });
-  } catch (e) {
-    console.error(e);
-  } finally {
-    isLuringMobs = false;
-  }
-}
-
 setInterval(async function () {
   loot();
   if (character.rip) {
     respawn();
     return;
   }
-  
+
   if (!isLuringMobs) scareAwayMobs();
 
   await sortInv();
@@ -484,7 +460,7 @@ setInterval(async function () {
     !isAdvanceSmartMoving &&
     !character.c.mining &&
     !character.c.fishing &&
-    !character.q.exchanging
+    !character.q.exchanging 
   )
     await moveHome();
 

--- a/basic_merchant.5.js
+++ b/basic_merchant.5.js
@@ -520,7 +520,8 @@ const ITEM_NEEDED = [
   "gcape",
   "carrot",
   "brownenvelope",
-  "harbringer","throwingstars",
+  "harbringer",
+  "throwingstars",
 ];
 
 function secondhandsHandler(events) {

--- a/basic_merchant.5.js
+++ b/basic_merchant.5.js
@@ -16,6 +16,7 @@ var isExeing = false;
 
 const fishingLocation = { map: "main", x: -1368, y: -82 };
 const miningLocation = { map: "tunnel", x: -279, y: -148 };
+const homeLocation = { map: "main", x: -152, y: -137 };
 const haveAComputer = () =>
   locate_item("computer") !== -1 || locate_item("ancientcomputer") !== -1;
 
@@ -166,9 +167,7 @@ async function exchangeMines() {
 
 function moveHome() {
   if (
-    (character.map === "main" &&
-      character.real_x === -152 &&
-      character.real_y === -137) ||
+    distance(character, homeLocation) < 50 ||
     smart.moving ||
     isAdvanceSmartMoving ||
     character.moving ||
@@ -180,7 +179,7 @@ function moveHome() {
   log("Moving back Town!");
   close_stand();
   equipBroom();
-  return smart_move({ map: "main", x: -152, y: -137 })
+  return smart_move(homeLocation)
     .then(() => {
       onDuty = false;
       if (locate_item("stand0") === -1) {
@@ -428,7 +427,7 @@ setInterval(async function () {
       holidayExchange(),
       craft("xbox"),
       craft("basketofeggs"),
-      craft("orba", 1, { map: "main", x: -152, y: -137 }),
+      craft("orba", 1, homeLocation),
       craft("froststaff", 1, { map: "main", x: -2, y: 295 }),
       craft("carrotsword", 1, { map: "main", x: -2, y: 295 }),
       craft("wingedboots", character.esize - 8, { map: "main", x: -2, y: 295 }),

--- a/basic_merchant.5.js
+++ b/basic_merchant.5.js
@@ -438,7 +438,7 @@ setInterval(async function () {
       craft("carrotsword", 1, { map: "main", x: -2, y: 295 }),
       craft("wingedboots", character.esize - 8, { map: "main", x: -2, y: 295 }),
       craft("pouchbow", character.esize - 8, { map: "main", x: -2, y: 295 }),
-      craft("firestaff", character.esize - 6, { map: "main", x: -2, y: 295 }),
+      // craft("firestaff", character.esize - 6, { map: "main", x: -2, y: 295 }),
       craft("firestars", character.esize - 6, { map: "main", x: -2, y: 295 }),
       !isSortingInventory &&
         Promise.all(

--- a/basic_merchant.5.js
+++ b/basic_merchant.5.js
@@ -21,7 +21,7 @@ if (parent.caracAL) {
 var onDuty = false;
 var isExeing = false;
 
-const fishingLocation = { map: "main", x: -1368, y: -82 };
+const fishingLocation = { map: "main", x: -1367, y: -82 };
 const miningLocation = { map: "tunnel", x: -279, y: -148 };
 const homeLocation = { map: "main", x: -152, y: -137 };
 const haveAComputer = () =>

--- a/basic_merchant.5.js
+++ b/basic_merchant.5.js
@@ -460,7 +460,7 @@ setInterval(async function () {
     !isAdvanceSmartMoving &&
     !character.c.mining &&
     !character.c.fishing &&
-    !character.q.exchanging 
+    !character.q.exchanging
   )
     await moveHome();
 
@@ -542,9 +542,11 @@ setInterval(() => {
 }, 12000);
 
 if (parent.caracAL) {
-  parent.caracAL.load_scripts([
-    "adventure-land-scripts-backup/merchant_service.19.js",
-  ]);
+  parent.caracAL
+    .load_scripts(["adventure-land-scripts-backup/merchant_service.19.js"])
+    .then(() => {
+      lureMechaGnome();
+    });
 } else load_code(19);
 // setInterval(() => {
 //   if (

--- a/basic_merchant.5.js
+++ b/basic_merchant.5.js
@@ -437,7 +437,7 @@ setInterval(async function () {
       craft("carrotsword", 1, { map: "main", x: -2, y: 295 }),
       craft("wingedboots", character.esize - 8, { map: "main", x: -2, y: 295 }),
       craft("pouchbow", character.esize - 8, { map: "main", x: -2, y: 295 }),
-      craft("firebow", character.esize - 6, { map: "main", x: -2, y: 295 }),
+      craft("firestaff", character.esize - 6, { map: "main", x: -2, y: 295 }),
       !isSortingInventory &&
         Promise.all(
           Array.from({ length: 42 }, (_, i) => i)

--- a/basic_merchant.5.js
+++ b/basic_merchant.5.js
@@ -4,12 +4,19 @@
 // Just set attack_mode to true and ENGAGE!
 
 if (parent.caracAL) {
-  parent.caracAL.load_scripts([
-    "adventure-land-scripts-backup/merchant_crafting.10.js",
-  ]);
+  parent.caracAL
+    .load_scripts([
+      "adventure-land-scripts-backup/merchant_crafting.10.js",
+      "adventure-land-scripts-backup/merchant_service.19.js",
+    ])
+    .then(() => {
+      lureMechaGnome();
+    });
 } else {
   load_code(10);
+  load_code(19);
 }
+
 // Global Vars
 var onDuty = false;
 var isExeing = false;
@@ -541,13 +548,6 @@ setInterval(() => {
   parent.socket.emit("secondhands");
 }, 12000);
 
-if (parent.caracAL) {
-  parent.caracAL
-    .load_scripts(["adventure-land-scripts-backup/merchant_service.19.js"])
-    .then(() => {
-      lureMechaGnome();
-    });
-} else load_code(19);
 // setInterval(() => {
 //   if (
 //     !isInvFull(5) &&

--- a/basic_merchant.5.js
+++ b/basic_merchant.5.js
@@ -562,6 +562,3 @@ if (parent.caracAL) {
 //     }
 //   }
 // }, 2000);
-
-// Learn Javascript: https://www.codecademy.com/learn/introduction-to-javascript
-// Write your own CODE: https://github.com/kaansoral/adventureland

--- a/basic_merchant.5.js
+++ b/basic_merchant.5.js
@@ -437,7 +437,7 @@ setInterval(async function () {
       craft("carrotsword", 1, { map: "main", x: -2, y: 295 }),
       craft("wingedboots", character.esize - 8, { map: "main", x: -2, y: 295 }),
       craft("pouchbow", character.esize - 8, { map: "main", x: -2, y: 295 }),
-      craft("firestaff", character.esize - 6, { map: "main", x: -2, y: 295 }),
+      // craft("firestaff", character.esize - 6, { map: "main", x: -2, y: 295 }),
       !isSortingInventory &&
         Promise.all(
           Array.from({ length: 42 }, (_, i) => i)

--- a/basic_priest.2.js
+++ b/basic_priest.2.js
@@ -154,6 +154,11 @@ async function priestBuff() {
       const bufferedRange = character.range + character.xrange * 0.9;
       const dist = distance(buffee, character);
 
+      if (!isAttackReady) {
+        promises.push(currentStrategy(buffee));
+        break;
+      }
+
       if (
         !smart.moving &&
         dist >= bufferedRange &&
@@ -164,11 +169,6 @@ async function priestBuff() {
         );
         set_message(`Moving to ${buffee.name}`);
         continue;
-      }
-
-      if (!isAttackReady) {
-        promises.push(currentStrategy(buffee));
-        break;
       }
 
       if (dist < bufferedRange && isAttackReady) {
@@ -231,7 +231,12 @@ async function priestBuff() {
       }
     }
   }
-  await withTimeout(Promise.allSettled(promises), 750);
+  try {
+    await withTimeout(Promise.allSettled(promises), 2500);
+  }
+  catch(e) {
+    console.error(e);
+  }
   return buffees.length > 0;
 }
 

--- a/basic_priest.2.js
+++ b/basic_priest.2.js
@@ -27,6 +27,7 @@ const reduceCd = (skillName) =>
 async function fight(target, isDeterminedToHeal = false) {
   const partyDmgRecieved = avgPartyDmgTaken(partyMems);
   const characterBufferedRange = character.range + character.xrange;
+  const prioritizedCharacter = prioritizedNames();
   const mobsInRange = Object.values(parent.entities)
     .filter(
       (entity) =>
@@ -61,7 +62,8 @@ async function fight(target, isDeterminedToHeal = false) {
     !target?.cooperative
       ? mobsInRange
           .filter(
-            (mob) => !mob.s.poisoned && prioritizedNames().includes(mob.target),
+            (mob) =>
+              !mob.s.poisoned && prioritizedCharacter.includes(mob.target),
           )
           .sort((lhs, rhs) => {
             if (rhs.attack === lhs.attack) {
@@ -85,7 +87,11 @@ async function fight(target, isDeterminedToHeal = false) {
   const targetToCurse =
     mobsInRange
       .filter(
-        (mob) => !mob.s.curse && is_in_range(mob, "curse") && mob.max_hp > 3000,
+        (mob) =>
+          !mob.s.curse &&
+          is_in_range(mob, "curse") &&
+          mob.max_hp > 3000 &&
+          prioritizedCharacter.includes(mob.target),
       )
       .sort((lhs, rhs) => {
         if (lhs.cooperative !== rhs.cooperative) {

--- a/basic_priest.2.js
+++ b/basic_priest.2.js
@@ -24,7 +24,7 @@ const reduceCd = (skillName) =>
 
 // Combat Logic
 
-async function fight(target) {
+async function fight(target, isDeterminedToHeal = false) {
   const partyDmgRecieved = avgPartyDmgTaken(partyMems);
   const characterBufferedRange = character.range + character.xrange;
   const mobsInRange = Object.values(parent.entities)
@@ -112,19 +112,24 @@ async function fight(target) {
   }
 
   // Attack Logic
-  const isAttackReady =
-    ms_to_next_skill("attack") === 0 && !character.s.penalty_cd;
-  const isTargetInAttackRange =
-    distance(target, character) <= characterBufferedRange;
+  if (!isDeterminedToHeal) {
+    const isAttackReady =
+      ms_to_next_skill("attack") === 0 && !character.s.penalty_cd;
+    const isTargetInAttackRange =
+      distance(target, character) <= characterBufferedRange;
 
-  if (isAttackReady && isTargetInAttackRange && shouldAttack()) {
-    set_message("Attacking");
-    promisesToAwait.push(
-      currentStrategy(target),
-      attack(target)
-        .then(() => reduceCd("attack"))
-        .catch((e) => attackErrorHandler(e)),
-    );
+    if (!isAttackReady && isTargetInAttackRange && shouldAttack()) {
+      promisesToAwait.push(currentStrategy(target));
+    }
+
+    if (isAttackReady && isTargetInAttackRange && shouldAttack()) {
+      set_message("Attacking");
+      promisesToAwait.push(
+        attack(target)
+          .then(() => reduceCd("attack"))
+          .catch((e) => attackErrorHandler(e)),
+      );
+    }
   }
 
   // Await All Actions
@@ -139,10 +144,12 @@ async function priestBuff() {
   const promises = [];
 
   // Heal Logic
-  if (ms_to_next_skill("attack") === 0 && !character.s.penalty_cd) {
-    const buffees = getPlayersToHeal();
-    const prioritizedBuffeesNames = prioritizedNames();
+  const buffees = getPlayersToHeal();
+  const prioritizedBuffeesNames = prioritizedNames();
+  const isAttackReady =
+    ms_to_next_skill("attack") === 0 && !character.s.penalty_cd;
 
+  if (buffees.length !== 0) {
     for (const buffee of buffees) {
       const bufferedRange = character.range + character.xrange * 0.9;
       const dist = distance(buffee, character);
@@ -159,7 +166,12 @@ async function priestBuff() {
         continue;
       }
 
-      if (dist < bufferedRange) {
+      if (!isAttackReady) {
+        promises.push(currentStrategy(buffee));
+        break;
+      }
+
+      if (dist < bufferedRange && isAttackReady) {
         set_message(`Heal ${buffee.name}`);
         promises.push(
           currentStrategy(buffee),
@@ -219,8 +231,8 @@ async function priestBuff() {
       }
     }
   }
-
-  return withTimeout(Promise.allSettled(promises), 750);
+  await withTimeout(Promise.allSettled(promises), 750);
+  return buffees.length > 0;
 }
 
 // Specialized Loops
@@ -299,7 +311,7 @@ async function mainLoop() {
       }
     }
 
-    await priestBuff();
+    const isDeterminedToHeal = await priestBuff();
 
     const isMovingControlled =
       (smart.moving || isAdvanceSmartMoving) && !smartmoveDebug;
@@ -331,7 +343,7 @@ async function mainLoop() {
         advanceSmartMove({ map, x: mapX, y: mapY });
       }
     } else {
-      await fight(target);
+      await fight(target, isDeterminedToHeal);
     }
   } catch (e) {
     if (e.cause !== "smart_move" && e.cause !== "death") console.error(e);

--- a/basic_priest.2.js
+++ b/basic_priest.2.js
@@ -213,7 +213,7 @@ async function priestBuff() {
   }
 
   // Absorb Skill Logic
-  const vulnerableMems = partyMems.filter(
+  const vulnerableMems = [...partyMems, partyMerchant].filter(
     (memberId) => memberId !== character.name && memberId !== TANKER,
   );
   for (const memberId of vulnerableMems) {

--- a/basic_priest.2.js
+++ b/basic_priest.2.js
@@ -29,15 +29,15 @@ async function fight(target) {
   const characterBufferedRange = character.range + character.xrange;
   const mobsInRange = Object.values(parent.entities)
     .filter(
-      (mob) =>
-        mob.type === "monster" &&
-        !mob.dead &&
-        distance(character, mob) <= characterBufferedRange,
+      (entity) =>
+        entity.type === "monster" &&
+        !entity.dead &&
+        distance(character, entity) <= characterBufferedRange,
     )
-    .map((mob) => {
-      mob.cluster_count = numberOfMonsterAroundTarget(mob, 17);
-      return mob;
-    });
+    .map((mob) => ({
+      ...mob,
+      cluster_count: numberOfMonsterAroundTarget(mob, 17),
+    }));
 
   // Target Selection (Taunt & Debuff Logic)
   const targetToTaunt =
@@ -56,7 +56,9 @@ async function fight(target) {
       : null;
 
   const targetToAttack =
-    character.slots.orb?.name === "test_orb" && !target.cooperative
+    (character.slots.orb?.name === "test_orb" ||
+      character.slots.mainhand?.name === "oozingterror") &&
+    !target?.cooperative
       ? mobsInRange
           .filter(
             (mob) => !mob.s.poisoned && prioritizedNames().includes(mob.target),
@@ -70,7 +72,7 @@ async function fight(target) {
           .shift() ?? target
       : target;
 
-  target = targetToTaunt ?? targetToAttack ?? target;
+  target = targetToTaunt ?? targetToAttack;
   if (target) change_target(target);
 
   // Early Exit
@@ -148,7 +150,7 @@ async function priestBuff() {
       if (
         !smart.moving &&
         dist >= bufferedRange &&
-        prioritizedBuffeesNames().includes(buffee.name)
+        prioritizedBuffeesNames.includes(buffee.name)
       ) {
         promises.push(
           move((buffee.x + character.x) / 2, (buffee.y + character.y) / 2),
@@ -170,8 +172,8 @@ async function priestBuff() {
 
   // Party Heal Logic
   const allies = (parent.party_list || [])
-    .map((n) => get_entity(n))
-    .filter((v) => v);
+    .map((name) => get_entity(name))
+    .filter((entity) => entity);
   const modInjuredThreshold = character.level * 20;
 
   if (!is_on_cooldown("partyheal") && character.mp > 1000 && allies.length) {
@@ -193,10 +195,10 @@ async function priestBuff() {
 
   // Absorb Skill Logic
   const vulnerableMems = partyMems.filter(
-    (m) => m !== character.name && m !== TANKER,
+    (memberId) => memberId !== character.name && memberId !== TANKER,
   );
-  for (const mName of vulnerableMems) {
-    const member = get_entity(mName);
+  for (const memberId of vulnerableMems) {
+    const member = get_entity(memberId);
     if (
       member &&
       !is_on_cooldown("absorb") &&
@@ -204,11 +206,11 @@ async function priestBuff() {
       character.mp >= G.skills["absorb"].mp
     ) {
       const hasAggro = Object.values(parent.entities).some(
-        (e) => e.target === mName,
+        (e) => e.target === memberId,
       );
       if (hasAggro) {
         use_skill("absorb", member);
-        set_message(`Absorb ${mName}`);
+        set_message(`Absorb ${memberId}`);
         break;
       }
     }

--- a/basic_priest.2.js
+++ b/basic_priest.2.js
@@ -118,24 +118,27 @@ async function fight(target, isDeterminedToHeal = false) {
   }
 
   // Attack Logic
-  if (!isDeterminedToHeal) {
-    const isAttackReady =
-      ms_to_next_skill("attack") === 0 && !character.s.penalty_cd;
-    const isTargetInAttackRange =
-      distance(target, character) <= characterBufferedRange;
+  const isAttackReady =
+    ms_to_next_skill("attack") === 0 && !character.s.penalty_cd;
+  const isTargetInAttackRange =
+    distance(target, character) <= characterBufferedRange;
 
-    if (!isAttackReady && isTargetInAttackRange && shouldAttack()) {
-      promisesToAwait.push(currentStrategy(target));
-    }
+  if (
+    !isAttackReady &&
+    isTargetInAttackRange &&
+    shouldAttack() &&
+    !isDeterminedToHeal
+  ) {
+    promisesToAwait.push(currentStrategy(target));
+  }
 
-    if (isAttackReady && isTargetInAttackRange && shouldAttack()) {
-      set_message("Attacking");
-      promisesToAwait.push(
-        attack(target)
-          .then(() => reduceCd("attack"))
-          .catch((e) => attackErrorHandler(e)),
-      );
-    }
+  if (isAttackReady && isTargetInAttackRange && shouldAttack()) {
+    set_message("Attacking");
+    promisesToAwait.push(
+      attack(target)
+        .then(() => reduceCd("attack"))
+        .catch((e) => attackErrorHandler(e)),
+    );
   }
 
   // Await All Actions
@@ -254,7 +257,8 @@ async function zapperLoop() {
     zapCd !== 0 ||
     character.mp < character.max_mp * 0.6 ||
     character.penalty_cd ||
-    !hasZapper || Object.keys(character.c).length
+    !hasZapper ||
+    Object.keys(character.c).length
   ) {
     return setTimeout(zapperLoop, Math.max(zapCd, 50));
   }

--- a/basic_priest.2.js
+++ b/basic_priest.2.js
@@ -174,7 +174,6 @@ async function priestBuff() {
       if (dist < bufferedRange && isAttackReady) {
         set_message(`Heal ${buffee.name}`);
         promises.push(
-          currentStrategy(buffee),
           heal(buffee).then(() => reduceCd("attack")),
         );
         break;

--- a/basic_priest.2.js
+++ b/basic_priest.2.js
@@ -81,7 +81,7 @@ async function fight(target) {
   const promisesToAwait = [];
 
   // Curse Logic
-  const canCurse = !is_on_cooldown("curse") && character.mp > 1100;
+  const canCurse = !is_on_cooldown("curse") && character.mp > 1600;
   const targetToCurse =
     mobsInRange
       .filter(
@@ -176,7 +176,11 @@ async function priestBuff() {
     .filter((entity) => entity);
   const modInjuredThreshold = character.level * 20;
 
-  if (!is_on_cooldown("partyheal") && character.mp > 1000 && allies.length) {
+  if (
+    !is_on_cooldown("partyheal") &&
+    character.mp > G.skills["partyheal"].mp + 400 &&
+    allies.length
+  ) {
     const shouldPartyHeal =
       allies.some(
         (lhs) =>
@@ -203,7 +207,7 @@ async function priestBuff() {
       member &&
       !is_on_cooldown("absorb") &&
       is_in_range(member, "absorb") &&
-      character.mp >= G.skills["absorb"].mp
+      character.mp >= G.skills["absorb"].mp + 200
     ) {
       const hasAggro = Object.values(parent.entities).some(
         (e) => e.target === memberId,

--- a/basic_priest.2.js
+++ b/basic_priest.2.js
@@ -173,9 +173,7 @@ async function priestBuff() {
 
       if (dist < bufferedRange && isAttackReady) {
         set_message(`Heal ${buffee.name}`);
-        promises.push(
-          heal(buffee).then(() => reduceCd("attack")),
-        );
+        promises.push(heal(buffee).then(() => reduceCd("attack")));
         break;
       }
     }
@@ -199,7 +197,7 @@ async function priestBuff() {
           (lhs.hp < lhs.max_hp - modInjuredThreshold &&
             !is_in_range(lhs, "heal")),
       ) ||
-      (allies.every((lhs) => lhs.hp < lhs.max_hp - modInjuredThreshold) &&
+      (allies.every((lhs) => lhs.hp < lhs.max_hp - modInjuredThreshold * 5) &&
         allies.length > 1);
 
     if (shouldPartyHeal) {

--- a/basic_priest.2.js
+++ b/basic_priest.2.js
@@ -254,7 +254,7 @@ async function zapperLoop() {
     zapCd !== 0 ||
     character.mp < character.max_mp * 0.6 ||
     character.penalty_cd ||
-    !hasZapper
+    !hasZapper || Object.keys(character.c).length
   ) {
     return setTimeout(zapperLoop, Math.max(zapCd, 50));
   }

--- a/basic_priest.2.js
+++ b/basic_priest.2.js
@@ -61,8 +61,13 @@ async function fight(target) {
           .filter(
             (mob) => !mob.s.poisoned && prioritizedNames().includes(mob.target),
           )
-          .sort((lhs, rhs) => rhs.attack - lhs.attack)
-          .pop() ?? target
+          .sort((lhs, rhs) => {
+            if (rhs.attack === lhs.attack) {
+              return rhs.hp - lhs.hp;
+            }
+            return rhs.attack - lhs.attack;
+          })
+          .shift() ?? target
       : target;
 
   target = targetToTaunt ?? targetToAttack ?? target;

--- a/basic_priest.2.js
+++ b/basic_priest.2.js
@@ -210,13 +210,11 @@ async function priestBuff() {
       (entity) => entity.type === "monster" && entity.target === memberName,
     );
 
-    const requiredMonsterCount = isAssignedAsTanker() ? 1 : 2;
-
     if (
       is_in_range(member, "absorb") &&
       !is_on_cooldown("absorb") &&
       character.mp >= G.skills["absorb"].mp &&
-      monstersTargetingMember.length >= requiredMonsterCount
+      monstersTargetingMember.length
     ) {
       use_skill("absorb", member);
       set_message("Absorb " + memberName);

--- a/basic_priest.2.js
+++ b/basic_priest.2.js
@@ -185,9 +185,10 @@ async function priestBuff() {
           (ally.hp < ally.max_hp - moderatelyInjuredThreshold &&
             !is_in_range(ally, "heal")), // Moderately low & out of range
       ) ||
-      allies.every(
+      (allies.every(
         (ally) => ally.hp < ally.max_hp - moderatelyInjuredThreshold, // All moderately low
-      );
+      ) &&
+        allies.length > 1);
 
     if (shouldPartyHeal) {
       use_skill("partyheal").then(() =>
@@ -256,35 +257,35 @@ async function zapperLoop() {
         weak: entity.max_hp < 1000,
       }));
 
-    if (isTanking) {
-    } else {
-      const sortedTargets = targetInSight.sort((lhs, rhs) => {
-        const lhsHasTarget = Boolean(lhs.target);
-        const rhsHasTarget = Boolean(rhs.target);
-        if (lhsHasTarget !== rhsHasTarget) return lhsHasTarget ? -1 : 1;
+    // if (isTanking) {
+    // } else {
+    const sortedTargets = targetInSight.sort((lhs, rhs) => {
+      const lhsHasTarget = Boolean(lhs.target);
+      const rhsHasTarget = Boolean(rhs.target);
+      if (lhsHasTarget !== rhsHasTarget) return lhsHasTarget ? -1 : 1;
 
-        // higher hp% mobs first to balance the aoe cluster
-        if (lhsHasTarget && rhsHasTarget) {
-          if (lhs.hp_percent !== rhs.hp_percent)
-            return rhs.hp_percent - lhs.hp_percent;
-          else return rhs.distance - lhs.distance;
-        }
-
-        // sort weak mobs among other mob if above criterias not met
-        if (lhs.weak !== rhs.weak) return lhs.weak ? -1 : 1;
-
-        // fallback: furthest ones
-        return rhs.distance - lhs.distance;
-      });
-      if (sortedTargets) {
-        const zapTarget = sortedTargets[0];
-        promisesToAwait.push(
-          use_skill("zapperzap", zapTarget).then(() =>
-            reduce_cooldown("zapperzap", Math.min(...parent.pings)),
-          ),
-        );
+      // higher hp% mobs first to balance the aoe cluster
+      if (lhsHasTarget && rhsHasTarget) {
+        if (lhs.hp_percent !== rhs.hp_percent)
+          return rhs.hp_percent - lhs.hp_percent;
+        else return rhs.distance - lhs.distance;
       }
+
+      // sort weak mobs among other mob if above criterias not met
+      if (lhs.weak !== rhs.weak) return lhs.weak ? -1 : 1;
+
+      // fallback: furthest ones
+      return rhs.distance - lhs.distance;
+    });
+    if (sortedTargets) {
+      const zapTarget = sortedTargets[0];
+      promisesToAwait.push(
+        use_skill("zapperzap", zapTarget).then(() =>
+          reduce_cooldown("zapperzap", Math.min(...parent.pings)),
+        ),
+      );
     }
+    // }
     await withTimeout(Promise.all(promisesToAwait), 500);
   } catch (e) {
     console.log("Error while zapping: ", e);
@@ -301,6 +302,15 @@ async function mainLoop() {
       throw new Error("Character's down", {
         cause: "death",
       });
+    }
+
+    if (!character.skin || character.skin !== "snow_angel") {
+      if (!character.slots.cape || character.slots.cape.name !== "angelwings") {
+        await equipBatch({ cape: "angelwings" });
+      }
+      if (character.slots.cape && character.slots.cape.name === "angelwings") {
+        parent.socket.emit("activate", { slot: "cape" });
+      }
     }
 
     await priestBuff();

--- a/basic_priest.2.js
+++ b/basic_priest.2.js
@@ -1,5 +1,4 @@
 // Load basic functions from other code snippet
-
 if (parent.caracAL) {
   parent.caracAL
     .load_scripts([
@@ -15,231 +14,222 @@ if (parent.caracAL) {
   load_code(8);
 }
 
-// Kiting
+// Kiting & Global Config
 var originRangeRate = 0.5;
-var rangeRate = 0.5;
-const loopInterval = ((1 / character.frequency) * 1000) / 4;
+var rangeRate = originRangeRate;
+const loopInterval = Math.floor(((1 / character.frequency) * 1000) / 4);
+
+const reduceCd = (skillName) =>
+  reduce_cooldown(skillName, Math.min(...parent.pings));
+
+// Combat Logic
 
 async function fight(target) {
-  // Make Priest prior mobs without poison effect that attacking the party, to reduce their attack spped
   const partyDmgRecieved = avgPartyDmgTaken(partyMems);
   const characterBufferedRange = character.range + character.xrange;
+  const mobsInRange = Object.values(parent.entities)
+    .filter(
+      (mob) =>
+        mob.type === "monster" &&
+        !mob.dead &&
+        distance(character, mob) <= characterBufferedRange,
+    )
+    .map((mob) => {
+      mob.cluster_count = numberOfMonsterAroundTarget(mob, 17);
+      return mob;
+    });
 
+  // Target Selection (Taunt & Debuff Logic)
   const targetToTaunt =
     isAssignedAsTanker() && currentStrategy === usePullStrategies
-      ? Object.values(parent.entities)
+      ? mobsInRange
           .filter(
             (mob) =>
-              mob.type === "monster" &&
-              !mob.dead &&
               !mob.target &&
-              is_in_range(mob, "attack") &&
               partyDmgRecieved + calculateDamage(mob, character) <
                 character.heal * 0.9 * character.frequency,
           )
           .sort(
-            (lhs, rhs) => distance(lhs, character) - distance(rhs, character),
+            (lhs, rhs) => distance(rhs, character) - distance(lhs, character),
           )
           .shift()
       : null;
 
   const targetToAttack =
     character.slots.orb?.name === "test_orb" && !target.cooperative
-      ? Object.values(parent.entities)
+      ? mobsInRange
           .filter(
-            (mob) =>
-              mob.type === "monster" &&
-              !mob.s.poisoned &&
-              !mob.dead &&
-              mob.hp &&
-              distance(character, mob) < characterBufferedRange &&
-              (parent.party_list && parent.party_list.length > 0
-                ? parent.party_list
-                : partyMems
-              ).includes(mob.target),
+            (mob) => !mob.s.poisoned && prioritizedNames().includes(mob.target),
           )
           .sort((lhs, rhs) => rhs.attack - lhs.attack)
           .pop() ?? target
       : target;
-  target = targetToTaunt ?? targetToAttack;
-  change_target(target);
+
+  target = targetToTaunt ?? targetToAttack ?? target;
+  if (target) change_target(target);
+
+  // Early Exit
+  if (!target) return;
 
   const promisesToAwait = [];
 
-  if (
-    target &&
-    !target.s.curse &&
-    character.mp > 1100 &&
-    !is_on_cooldown("curse") &&
-    is_in_range(target, "curse") &&
-    target.max_hp > 3000
-  )
+  // Curse Logic
+  const canCurse = !is_on_cooldown("curse") && character.mp > 1100;
+  const targetToCurse =
+    mobsInRange
+      .filter(
+        (mob) => !mob.s.curse && is_in_range(mob, "curse") && mob.max_hp > 3000,
+      )
+      .sort((lhs, rhs) => {
+        if (lhs.cooperative !== rhs.cooperative) {
+          return lhs.cooperative ? -1 : 1;
+        }
+        if (lhs.cluster_count === rhs.cluster_count) return rhs.hp - lhs.hp;
+        return rhs.cluster_count - lhs.cluster_count;
+      })
+      .shift() ?? target;
+  if (canCurse && is_in_range(targetToCurse, "curse")) {
     promisesToAwait.push(
-      withTimeout(use_skill("curse", target), 2500).then(() =>
-        reduce_cooldown("curse", Math.min(...parent.pings)),
-      ),
-    );
-
-  if (
-    target &&
-    shouldAttack() &&
-    !is_on_cooldown("darkblessing") &&
-    character.mp > G.skills["darkblessing"].mp &&
-    !character.s?.darkblessing
-  )
-    promisesToAwait.push(
-      withTimeout(use_skill("darkblessing"), 2500).then(() =>
-        reduce_cooldown("darkblessing", Math.min(...parent.pings)),
-      ),
-    );
-
-  if (
-    ms_to_next_skill("attack") === 0 &&
-    distance(target, character) <
-      character.range +
-        character.xrange +
-        extraDistanceWithinHitbox(target) +
-        extraDistanceWithinHitbox(character) &&
-    shouldAttack()
-  ) {
-    set_message("Attacking");
-    promisesToAwait.push(
-      currentStrategy(target),
-      withTimeout(attack(target), 2500)
-        .then(() => {
-          reduce_cooldown("attack", Math.min(...parent.pings));
-        })
-        .catch((e) => {
-          attackErrorHandler(e);
-        }),
+      use_skill("curse", targetToCurse).then(() => reduceCd("curse")),
     );
   }
 
+  // Dark Blessing Logic
+  const canDarkBless =
+    !is_on_cooldown("darkblessing") &&
+    character.mp > G.skills["darkblessing"].mp;
+  if (canDarkBless && shouldAttack() && !character.s?.darkblessing) {
+    promisesToAwait.push(
+      use_skill("darkblessing").then(() => reduceCd("darkblessing")),
+    );
+  }
+
+  // Attack Logic
+  const isAttackReady =
+    ms_to_next_skill("attack") === 0 && !character.s.penalty_cd;
+  const isTargetInAttackRange =
+    distance(target, character) <= characterBufferedRange;
+
+  if (isAttackReady && isTargetInAttackRange && shouldAttack()) {
+    set_message("Attacking");
+    promisesToAwait.push(
+      currentStrategy(target),
+      attack(target)
+        .then(() => reduceCd("attack"))
+        .catch((e) => attackErrorHandler(e)),
+    );
+  }
+
+  // Await All Actions
   try {
-    await withTimeout(Promise.all(promisesToAwait), 2500);
-  } catch (e) {}
+    await withTimeout(Promise.allSettled(promisesToAwait), 2500);
+  } catch (e) {
+    console.error(e);
+  }
 }
 
 async function priestBuff() {
   const promises = [];
-  const minPing = () => Math.min(...parent.pings);
 
-  // --- Single Target Heal (Attack Cooldown) ---
-  if (ms_to_next_skill("attack") === 0) {
+  // Heal Logic
+  if (ms_to_next_skill("attack") === 0 && !character.s.penalty_cd) {
     const buffees = getPlayersToHeal();
+    const prioritizedBuffeesNames = prioritizedNames();
 
     for (const buffee of buffees) {
-      const characterBufferedRange = character.range + character.xrange * 0.9;
-      const distanceToTarget = distance(buffee, character);
+      const bufferedRange = character.range + character.xrange * 0.9;
+      const dist = distance(buffee, character);
 
-      // If too far, and a party member (prioritized), move closer.
       if (
         !smart.moving &&
-        distanceToTarget >= characterBufferedRange &&
-        prioritizedNames().includes(buffee.name)
+        dist >= bufferedRange &&
+        prioritizedBuffeesNames().includes(buffee.name)
       ) {
-        // To the midpoint between the priest and the target
         promises.push(
           move((buffee.x + character.x) / 2, (buffee.y + character.y) / 2),
         );
-        set_message("Moving to heal " + buffee.name);
-        continue; // Stop and wait for movement
+        set_message(`Moving to ${buffee.name}`);
+        continue;
       }
 
-      // If in range, heal and stop the loop.
-      if (distanceToTarget < characterBufferedRange) {
-        try {
-          promises.push(currentStrategy(buffee));
-          promises.push(
-            withTimeout(
-              heal(buffee).then(() => {
-                reduce_cooldown("attack", minPing());
-              }),
-            ),
-          );
-          set_message("Heal " + buffee.name);
-        } catch (e) {
-          // console.error("Heal failed:", e);
-        }
-        break; // Heal one target and wait for the next attack cooldown
+      if (dist < bufferedRange) {
+        set_message(`Heal ${buffee.name}`);
+        promises.push(
+          currentStrategy(buffee),
+          heal(buffee).then(() => reduceCd("attack")),
+        );
+        break;
       }
     }
   }
 
-  // --- Party Heal Logic ---
-  const allies = parent.party_list
-    .map((name) => get_entity(name))
-    .filter((visible) => visible);
+  // Party Heal Logic
+  const allies = (parent.party_list || [])
+    .map((n) => get_entity(n))
+    .filter((v) => v);
+  const modInjuredThreshold = character.level * 20;
 
   if (!is_on_cooldown("partyheal") && character.mp > 1000 && allies.length) {
-    // Condition for Party Heal:
-    // any ally is critically low (under 30% HP) OR out of single-heal range while moderately injured.
-    // OR All allies are moderately injured (HP < max_hp - character.level * 20).
-    const moderatelyInjuredThreshold = character.level * 20;
-
     const shouldPartyHeal =
       allies.some(
-        (ally) =>
-          ally.hp < ally.max_hp * 0.3 || // Critically low
-          (ally.hp < ally.max_hp - moderatelyInjuredThreshold &&
-            !is_in_range(ally, "heal")), // Moderately low & out of range
+        (lhs) =>
+          lhs.hp < lhs.max_hp * 0.3 ||
+          (lhs.hp < lhs.max_hp - modInjuredThreshold &&
+            !is_in_range(lhs, "heal")),
       ) ||
-      (allies.every(
-        (ally) => ally.hp < ally.max_hp - moderatelyInjuredThreshold, // All moderately low
-      ) &&
+      (allies.every((lhs) => lhs.hp < lhs.max_hp - modInjuredThreshold) &&
         allies.length > 1);
 
     if (shouldPartyHeal) {
-      use_skill("partyheal").then(() =>
-        reduce_cooldown("partyheal", minPing()),
-      );
+      use_skill("partyheal").then(() => reduceCd("partyheal"));
       set_message("Party Heal");
     }
   }
 
-  // --- Absorb Skill Logic ---
-  const vulnerableMembers = partyMems.filter(
-    (member) => member !== character.name && member !== TANKER,
+  // Absorb Skill Logic
+  const vulnerableMems = partyMems.filter(
+    (m) => m !== character.name && m !== TANKER,
   );
-
-  for (const memberName of vulnerableMembers) {
-    const member = get_entity(memberName);
-    if (!member) continue;
-
-    const monstersTargetingMember = Object.values(parent.entities).filter(
-      (entity) => entity.type === "monster" && entity.target === memberName,
-    );
-
+  for (const mName of vulnerableMems) {
+    const member = get_entity(mName);
     if (
-      is_in_range(member, "absorb") &&
+      member &&
       !is_on_cooldown("absorb") &&
-      character.mp >= G.skills["absorb"].mp &&
-      monstersTargetingMember.length
+      is_in_range(member, "absorb") &&
+      character.mp >= G.skills["absorb"].mp
     ) {
-      use_skill("absorb", member);
-      set_message("Absorb " + memberName);
-      break; // Absorb one target and move on
+      const hasAggro = Object.values(parent.entities).some(
+        (e) => e.target === mName,
+      );
+      if (hasAggro) {
+        use_skill("absorb", member);
+        set_message(`Absorb ${mName}`);
+        break;
+      }
     }
   }
 
-  return withTimeout(Promise.all(promises), 750);
+  return withTimeout(Promise.allSettled(promises), 750);
 }
 
+// Specialized Loops
 async function zapperLoop() {
+  const zapCd = ms_to_next_skill("zapperzap");
+  const hasZapper =
+    character.slots.ring1?.name === "zapper" ||
+    character.slots.ring2?.name === "zapper";
+
   if (
-    ms_to_next_skill("zapperzap") !== 0 ||
+    zapCd !== 0 ||
     character.mp < character.max_mp * 0.6 ||
     character.penalty_cd ||
-    character.cc > 100 ||
-    (character.slots.ring1?.name !== "zapper" &&
-      character.slots.ring2?.name !== "zapper")
-  )
-    return setTimeout(zapperLoop, Math.max(ms_to_next_skill("zapperzap"), 50));
+    !hasZapper
+  ) {
+    return setTimeout(zapperLoop, Math.max(zapCd, 50));
+  }
 
   try {
-    const promisesToAwait = [];
-    const isTanking = isAssignedAsTanker();
-    const targetInSight = Object.values(parent.entities)
+    const targets = Object.values(parent.entities)
       .filter(
         (entity) =>
           entity.type === "monster" &&
@@ -251,46 +241,33 @@ async function zapperLoop() {
       )
       .map((entity) => ({
         ...entity,
-        distance: distance(entity, character),
-        hp_percent: entity.hp / entity.max_hp,
-        weak: entity.max_hp < 1000,
-      }));
+        dist: distance(entity, character),
+        hp_p: entity.hp / entity.max_hp,
+        weak: entity.max_hp < 2000,
+      }))
+      .sort((lhs, rhs) => {
+        if (!!lhs.target !== !!rhs.target) return lhs.target ? -1 : 1;
+        if (lhs.target && rhs.target)
+          return lhs.hp_p !== rhs.hp_p
+            ? rhs.hp_p - lhs.hp_p
+            : rhs.dist - lhs.dist;
+        return lhs.weak !== rhs.weak
+          ? lhs.weak
+            ? -1
+            : 1
+          : rhs.dist - lhs.dist;
+      });
 
-    // if (isTanking) {
-    // } else {
-    const sortedTargets = targetInSight.sort((lhs, rhs) => {
-      const lhsHasTarget = Boolean(lhs.target);
-      const rhsHasTarget = Boolean(rhs.target);
-      if (lhsHasTarget !== rhsHasTarget) return lhsHasTarget ? -1 : 1;
-
-      // higher hp% mobs first to balance the aoe cluster
-      if (lhsHasTarget && rhsHasTarget) {
-        if (lhs.hp_percent !== rhs.hp_percent)
-          return rhs.hp_percent - lhs.hp_percent;
-        else return rhs.distance - lhs.distance;
-      }
-
-      // sort weak mobs among other mob if above criterias not met
-      if (lhs.weak !== rhs.weak) return lhs.weak ? -1 : 1;
-
-      // fallback: furthest ones
-      return rhs.distance - lhs.distance;
-    });
-    if (sortedTargets) {
-      const zapTarget = sortedTargets[0];
-      promisesToAwait.push(
-        use_skill("zapperzap", zapTarget).then(() =>
-          reduce_cooldown("zapperzap", Math.min(...parent.pings)),
-        ),
-      );
+    if (targets.length) {
+      use_skill("zapperzap", targets[0]).then(() => reduceCd("zapperzap"));
     }
-    // }
-    await withTimeout(Promise.all(promisesToAwait), 500);
   } catch (e) {
-    console.log("Error while zapping: ", e);
+    console.log("Zap Error:", e);
   }
   setTimeout(zapperLoop, Math.max(ms_to_next_skill("zapperzap"), 50));
 }
+
+// Main Control Loop
 
 async function mainLoop() {
   try {
@@ -298,60 +275,55 @@ async function mainLoop() {
 
     if (character.rip) {
       respawn();
-      throw new Error("Character's down", {
-        cause: "death",
-      });
+      throw new Error("Character down", { cause: "death" });
     }
 
+    // Costume & Cape Logic
     if (!character.skin || character.skin !== "snow_angel") {
-      if (!character.slots.cape || character.slots.cape.name !== "angelwings") {
+      if (character.slots.cape?.name !== "angelwings") {
         await equipBatch({ cape: "angelwings" });
       }
-      if (character.slots.cape && character.slots.cape.name === "angelwings") {
+      if (character.slots.cape?.name === "angelwings") {
         parent.socket.emit("activate", { slot: "cape" });
       }
     }
 
     await priestBuff();
 
-    if ((smart.moving || isAdvanceSmartMoving) && !smartmoveDebug)
-      throw new Error("Smart moving", {
-        cause: "smart_move",
-      });
+    const isMovingControlled =
+      (smart.moving || isAdvanceSmartMoving) && !smartmoveDebug;
+    if (isMovingControlled) {
+      throw new Error("Smart moving", { cause: "smart_move" });
+    }
 
+    // Target Selection
     let target = getTarget();
+    if (get("cryptInstance")) {
+      target = await useCryptStrategy(target);
+    } else {
+      target = await changeToDailyEventTargets();
+    }
 
-    //// THE CRYPT & EVENTS
-    if (get("cryptInstance")) target = await useCryptStrategy(target);
-    else target = await changeToDailyEventTargets();
-
-    //// Logic to targets and farm places
+    // Movement Logic
     if (!target) {
-      if (
-        !smart.moving &&
-        !isAdvanceSmartMoving &&
-        get("cryptInstance") &&
-        character.map !== "crypt"
-      ) {
+      const cryptKey = get("cryptInstance");
+      const isPartyLeaderOrAlone =
+        partyMems[0] === character.name || !get_entity(partyMems[0]);
+      const isFarFromFarm =
+        distance(character, { x: mapX, y: mapY, map }) > 500;
+
+      if (cryptKey && character.map !== "crypt") {
         changeToNormalStrategies();
         advanceSmartMove(CRYPT_STARTING_LOCATION);
-      } else if (
-        !smart.moving &&
-        !get("cryptInstance") &&
-        (partyMems[0] == character.name ||
-          !get_entity(partyMems[0]) ||
-          distance(character, { x: mapX, y: mapY, map }) > 500)
-      ) {
+      } else if (!cryptKey && (isPartyLeaderOrAlone || isFarFromFarm)) {
         changeToNormalStrategies();
-        advanceSmartMove({
-          map,
-          x: mapX,
-          y: mapY,
-        });
+        advanceSmartMove({ map, x: mapX, y: mapY });
       }
-    } else await fight(target);
+    } else {
+      await fight(target);
+    }
   } catch (e) {
-    console.error(e);
+    if (e.cause !== "smart_move" && e.cause !== "death") console.error(e);
   }
 
   setTimeout(mainLoop, getLoopInterval());

--- a/basic_priest.2.js
+++ b/basic_priest.2.js
@@ -233,9 +233,9 @@ async function priestBuff() {
   }
   try {
     await withTimeout(Promise.allSettled(promises), 2500);
-  }
-  catch(e) {
+  } catch (e) {
     console.error(e);
+    return false;
   }
   return buffees.length > 0;
 }

--- a/basic_priest.2.js
+++ b/basic_priest.2.js
@@ -94,7 +94,6 @@ async function fight(target) {
     );
 
   if (
-    !character.s.penalty_cd &&
     ms_to_next_skill("attack") === 0 &&
     distance(target, character) <
       character.range +

--- a/basic_priest.2.js
+++ b/basic_priest.2.js
@@ -170,12 +170,25 @@ async function priestBuff() {
 
       if (
         !smart.moving &&
+        !isAdvanceSmartMoving &&
         dist >= bufferedRange &&
         prioritizedBuffeesNames.includes(buffee.name)
       ) {
-        promises.push(
-          move((buffee.x + character.x) / 2, (buffee.y + character.y) / 2),
-        );
+        const middleX = (buffee.x + character.x) / 2;
+        const middleY = (buffee.y + character.y) / 2;
+        if (parent.caracAL)
+          promises.push(
+            advanceSmartMove({
+              map: character.map,
+              x: middleX,
+              y: middleY,
+            }),
+          );
+        else if (can_move_to(middleX, middleY))
+          promises.push(
+            move((buffee.x + character.x) / 2, (buffee.y + character.y) / 2),
+          );
+        else advanceSmartMove({ map: character.map, x: buffee.x, y: buffee.y });
         set_message(`Moving to ${buffee.name}`);
         continue;
       }

--- a/basic_ranger.32.js
+++ b/basic_ranger.32.js
@@ -14,7 +14,7 @@ if (parent.caracAL) {
 }
 
 // Kiting (unchanged)
-var originRangeRate = 0.85;
+var originRangeRate = 0.65;
 rangeRate = originRangeRate;
 
 // --- Helper Functions ---
@@ -31,7 +31,7 @@ const tryMultiShot = async (skill, entityList) => {
   if (entityList.length === 0) return false;
   set_message(`${skill} Shooting`);
   return use_skill(skill, entityList)
-    .then(() => reduceCd(skill)) // Use reduceCd for the skill (was incorrectly hardcoded to "attack")
+    .then(() => reduceCd("attack")) // Use reduceCd for the skill (was incorrectly hardcoded to "attack")
     .catch((e) => attackErrorHandler(e));
 };
 
@@ -302,11 +302,11 @@ async function mainLoop() {
         get("cryptInstance") && character.map !== "crypt";
       const isPartyLeaderOrAlone =
         partyMems[0] === character.name || !get_entity(partyMems[0]);
-      const isFarFromPartyLeader =
+      const isFarFromFarmingSpot =
         distance(character, { x: mapX, y: mapY, map }) > 500;
 
       const needsToMoveToFarmLocation =
-        !get("cryptInstance") && (isPartyLeaderOrAlone || isFarFromPartyLeader);
+        !get("cryptInstance") && (isPartyLeaderOrAlone || isFarFromFarmingSpot);
 
       if (needsToEnterCrypt) {
         changeToNormalStrategies();

--- a/basic_ranger.32.js
+++ b/basic_ranger.32.js
@@ -129,21 +129,22 @@ async function fight(target) {
   if (is5ShotReady) {
     const mobsTo5Shot = weakMobs.slice(0, 5);
     promisesToAwait.push(currentStrategy(mobsTo5Shot));
-    if (notCupid) promisesToAwait.push(tryMultiShot("5shot", mobsTo5Shot));
+    // if (notCupid)
+    promisesToAwait.push(tryMultiShot("5shot", mobsTo5Shot));
   } else if (is3ShotReady) {
     const mobsTo3Shot = potentialTargets.slice(0, 3);
     promisesToAwait.push(currentStrategy(mobsTo3Shot));
-    if (notCupid)
-      promisesToAwait.push(tryMultiShot("3shot", potentialTargets.slice(0, 3)));
+    // if (notCupid)
+    promisesToAwait.push(tryMultiShot("3shot", potentialTargets.slice(0, 3)));
   } else if (target && distance(target, character) < nearRange) {
     set_message("Shooting");
     promisesToAwait.push(currentStrategy(target));
-    if (notCupid)
-      promisesToAwait.push(
-        attack(target)
-          .then(() => reduceCd("attack"))
-          .catch((e) => attackErrorHandler(e)),
-      );
+    // if (notCupid)
+    promisesToAwait.push(
+      use_skill("attack", target)
+        .then(() => reduceCd("attack"))
+        .catch((e) => attackErrorHandler(e)),
+    );
   }
 
   // --- Supershot ---
@@ -177,7 +178,7 @@ async function fight(target) {
 
   // --- Await and Error Handling ---
   try {
-    await withTimeout(Promise.allSettled(promisesToAwait), 1500);
+    await withTimeout(Promise.all(promisesToAwait), 1500);
   } catch (e) {
     console.log(e);
   }
@@ -238,7 +239,7 @@ async function cupidHeal(playersToHeal) {
       // Multi-shot healing
       set_message(`${skillName} Cupid`);
       const targets = lowHealthPlayersInRange.slice(0, sliceAmount);
-      log(`Healing ${targets.map((player) => player.name).join(", ")}`);
+      console.log(`Healing ${targets.map((player) => player.name).join(", ")}`);
       promisesToAwait.push(tryMultiShot(skillName, targets));
     } else if (healingTarget) {
       // Single shot healing
@@ -253,7 +254,7 @@ async function cupidHeal(playersToHeal) {
   }
 
   try {
-    await withTimeout(Promise.allSettled(promisesToAwait), 1000);
+    await withTimeout(Promise.all(promisesToAwait), 1000);
   } catch (e) {
     attackErrorHandler(e);
     console.error("Error while Cupiding!", e);

--- a/basic_ranger.32.js
+++ b/basic_ranger.32.js
@@ -119,7 +119,7 @@ async function fight(target) {
     hpOk &&
     character.mp > G.skills["5shot"].mp + G.skills["huntersmark"].mp + 1000 &&
     weakMobs.length >= 4 &&
-    mobsTo5Shot.all((mob) => shouldAttack(mob));
+    mobsTo5Shot.every((mob) => shouldAttack(mob));
 
   const mobsTo3Shot = potentialTargets.slice(0, 3);
   const is3ShotReady =
@@ -128,7 +128,7 @@ async function fight(target) {
     hpOk &&
     character.mp > G.skills["3shot"].mp + G.skills["huntersmark"].mp + 1000 &&
     potentialTargets.length >= 2 &&
-    mobsTo3Shot.all((mob) => shouldAttack(mob));
+    mobsTo3Shot.every((mob) => shouldAttack(mob));
 
   if (is5ShotReady) {
     if (!isAttackReady) promisesToAwait.push(currentStrategy(mobsTo5Shot));

--- a/basic_ranger.32.js
+++ b/basic_ranger.32.js
@@ -14,7 +14,7 @@ if (parent.caracAL) {
 }
 
 // Kiting
-var originRangeRate = 0.35;
+var originRangeRate = 0.6;
 rangeRate = originRangeRate;
 
 // Utils

--- a/basic_ranger.32.js
+++ b/basic_ranger.32.js
@@ -102,7 +102,7 @@ async function fight(target) {
   const canHuntersMark =
     target &&
     !target.s?.marked &&
-    character.mp > 300 &&
+    character.mp > 300 + 1000 &&
     !is_on_cooldown("huntersmark") &&
     target.hp > 3000;
   if (canHuntersMark) {
@@ -117,13 +117,13 @@ async function fight(target) {
     character.level >= G.skills["5shot"].level &&
     canMultiShot &&
     hpOk &&
-    character.mp > G.skills["5shot"].mp + G.skills["huntersmark"].mp &&
+    character.mp > G.skills["5shot"].mp + G.skills["huntersmark"].mp + 1000 &&
     weakMobs.length >= 4;
   const is3ShotReady =
     character.level >= G.skills["3shot"].level &&
     canMultiShot &&
     hpOk &&
-    character.mp > G.skills["3shot"].mp + G.skills["huntersmark"].mp &&
+    character.mp > G.skills["3shot"].mp + G.skills["huntersmark"].mp + 1000 &&
     potentialTargets.length >= 2;
 
   if (is5ShotReady) {
@@ -148,7 +148,7 @@ async function fight(target) {
   }
 
   // --- Supershot ---
-  const canSuperShot = character.mp > 400 && !is_on_cooldown("supershot");
+  const canSuperShot = character.mp > 400 + 1000 && !is_on_cooldown("supershot");
 
   if (canSuperShot) {
     const coopTarget = target?.cooperative

--- a/basic_ranger.32.js
+++ b/basic_ranger.32.js
@@ -83,7 +83,7 @@ async function fight(target) {
 
   const weakMobs = potentialTargets.filter(isWeak);
 
-  if (potentialTargets.length) {
+  if (potentialTargets.length && !target?.name.includes("crabx")) {
     target = potentialTargets[0];
     change_target(target);
   } // Reacquire target if feared

--- a/basic_ranger.32.js
+++ b/basic_ranger.32.js
@@ -36,15 +36,14 @@ const tryMultiShot = async (skill, entityList) => {
 };
 
 async function fight(target) {
-  if (ms_to_next_skill("attack") > 0 || character.s.penalty_cd) return;
-
+  const isAttackReady =
+    ms_to_next_skill("attack") === 0 && !character.s.penalty_cd;
   const canMultiShot = !character.fear;
   const inRange = (entity) => distance(entity, character) < nearRange;
   const nearRange = character.range + character.xrange;
   const explosionRadius = character.explosion
     ? character.explosion / 3.6
     : BLAST_RADIUS;
-  const notCupid = character.slots.mainhand?.name !== "cupid";
   const entitiesInVision = Object.values(parent.entities);
   const promisesToAwait = []; // --- Target Selection & Optimization ---
 
@@ -128,23 +127,22 @@ async function fight(target) {
 
   if (is5ShotReady) {
     const mobsTo5Shot = weakMobs.slice(0, 5);
-    promisesToAwait.push(currentStrategy(mobsTo5Shot));
-    // if (notCupid)
-    promisesToAwait.push(tryMultiShot("5shot", mobsTo5Shot));
+    if (!isAttackReady) promisesToAwait.push(currentStrategy(mobsTo5Shot));
+    else promisesToAwait.push(tryMultiShot("5shot", mobsTo5Shot));
   } else if (is3ShotReady) {
     const mobsTo3Shot = potentialTargets.slice(0, 3);
-    promisesToAwait.push(currentStrategy(mobsTo3Shot));
-    // if (notCupid)
-    promisesToAwait.push(tryMultiShot("3shot", potentialTargets.slice(0, 3)));
+    if (!isAttackReady) promisesToAwait.push(currentStrategy(mobsTo3Shot));
+    else
+      promisesToAwait.push(tryMultiShot("3shot", potentialTargets.slice(0, 3)));
   } else if (target && distance(target, character) < nearRange) {
     set_message("Shooting");
-    promisesToAwait.push(currentStrategy(target));
-    // if (notCupid)
-    promisesToAwait.push(
-      use_skill("attack", target)
-        .then(() => reduceCd("attack"))
-        .catch((e) => attackErrorHandler(e)),
-    );
+    if (!isAttackReady) promisesToAwait.push(currentStrategy(target));
+    else
+      promisesToAwait.push(
+        use_skill("attack", target)
+          .then(() => reduceCd("attack"))
+          .catch((e) => attackErrorHandler(e)),
+      );
   }
 
   // --- Supershot ---

--- a/basic_ranger.32.js
+++ b/basic_ranger.32.js
@@ -112,21 +112,25 @@ async function fight(target) {
 
   // 5shot > 3shot > single
   const hpOk = character.hp > character.max_hp * 0.55;
+  const mobsTo5Shot = weakMobs.slice(0, 5);
   const is5ShotReady =
     character.level >= G.skills["5shot"].level &&
     canMultiShot &&
     hpOk &&
     character.mp > G.skills["5shot"].mp + G.skills["huntersmark"].mp + 1000 &&
-    weakMobs.length >= 4;
+    weakMobs.length >= 4 &&
+    mobsTo5Shot.all((mob) => shouldAttack(mob));
+
+  const mobsTo3Shot = potentialTargets.slice(0, 3);
   const is3ShotReady =
     character.level >= G.skills["3shot"].level &&
     canMultiShot &&
     hpOk &&
     character.mp > G.skills["3shot"].mp + G.skills["huntersmark"].mp + 1000 &&
-    potentialTargets.length >= 2;
+    potentialTargets.length >= 2 &&
+    mobsTo3Shot.all((mob) => shouldAttack(mob));
 
   if (is5ShotReady) {
-    const mobsTo5Shot = weakMobs.slice(0, 5);
     if (!isAttackReady) promisesToAwait.push(currentStrategy(mobsTo5Shot));
     else if (!isCupid) promisesToAwait.push(tryMultiShot("5shot", mobsTo5Shot));
     else {
@@ -136,7 +140,6 @@ async function fight(target) {
       );
     }
   } else if (is3ShotReady) {
-    const mobsTo3Shot = potentialTargets.slice(0, 3);
     if (!isAttackReady) promisesToAwait.push(currentStrategy(mobsTo3Shot));
     else if (!isCupid)
       promisesToAwait.push(tryMultiShot("3shot", potentialTargets.slice(0, 3)));

--- a/basic_ranger.32.js
+++ b/basic_ranger.32.js
@@ -179,7 +179,7 @@ async function fight(target) {
   try {
     await withTimeout(Promise.all(promisesToAwait), 1500);
   } catch (e) {
-    console.log(e);
+    console.warn(e);
   }
 }
 
@@ -255,7 +255,7 @@ async function cupidHeal(playersToHeal) {
   try {
     await withTimeout(Promise.all(promisesToAwait), 1000);
   } catch (e) {
-    console.error("Error while Cupiding!", e);
+    console.warn("Error while Cupiding!", e);
   }
 }
 

--- a/basic_ranger.32.js
+++ b/basic_ranger.32.js
@@ -36,7 +36,7 @@ const tryMultiShot = async (skill, entityList) => {
 };
 
 async function fight(target) {
-  if (ms_to_next_skill("attack") > 0) return;
+  if (ms_to_next_skill("attack") > 0 || character.s.penalty_cd) return;
 
   const canMultiShot = !character.fear;
   const inRange = (entity) => distance(entity, character) < nearRange;
@@ -185,7 +185,7 @@ async function fight(target) {
 
 // --- Cupid Heal Logic (Refactored) ---
 async function cupidHeal(playersToHeal) {
-  const isAttackOnCD = ms_to_next_skill("attack") > 0;
+  const isAttackOnCD = ms_to_next_skill("attack") > 0 || character.s.penalty_cd;
   const hasCupid =
     locate_item("cupid") !== -1 || character.slots.mainhand?.name === "cupid";
   if (isAttackOnCD || !hasCupid) return;

--- a/basic_ranger.32.js
+++ b/basic_ranger.32.js
@@ -1,4 +1,4 @@
-// Load basic functions from other code snippet (unchanged)
+// Load basic functions from other code snippet
 if (parent.caracAL) {
   parent.caracAL
     .load_scripts([
@@ -13,17 +13,15 @@ if (parent.caracAL) {
   load_code(8);
 }
 
-// Kiting (unchanged)
+// Kiting
 var originRangeRate = 0.35;
 rangeRate = originRangeRate;
 
-// --- Helper Functions ---
+// Utils
 const isWeak = (monster) =>
   monster.hp < calculateDamage(character, monster) * 0.9 || monster.target;
 const isCooperative = (monster) => monster.cooperative;
 const isMob = (entity) => entity.type === "monster";
-
-// 1. Reusable Cooldown Reduction
 const reduceCd = (skillName) =>
   reduce_cooldown(skillName, Math.min(...parent.pings));
 
@@ -31,7 +29,7 @@ const tryMultiShot = async (skill, entityList) => {
   if (entityList.length === 0) return false;
   set_message(`${skill} Shooting`);
   return use_skill(skill, entityList)
-    .then(() => reduceCd("attack")) // Use reduceCd for the skill (was incorrectly hardcoded to "attack")
+    .then(() => reduceCd("attack"))
     .catch((e) => attackErrorHandler(e));
 };
 
@@ -45,7 +43,8 @@ async function fight(target) {
     ? character.explosion / 3.6
     : BLAST_RADIUS;
   const entitiesInVision = Object.values(parent.entities);
-  const promisesToAwait = []; // --- Target Selection & Optimization ---
+  const promisesToAwait = [];
+  const isCupid = character.slots.mainhand?.name === "cupid";
 
   const potentialTargets = entitiesInVision
     .filter(
@@ -61,7 +60,7 @@ async function fight(target) {
           entity.target),
     )
     .map((entity) => {
-      // Optimization: Pre-calculate cluster count and distance once
+      // Optimization: Pre-calculate cluster count and distance
       entity.cluster_count = numberOfMonsterAroundTarget(
         entity,
         explosionRadius,
@@ -75,14 +74,14 @@ async function fight(target) {
       if (rhs.cooperative || (rhs.target && !lhs.target)) return 1;
 
       return (
-        // 1. Maximize Cluster Count (Highest First: rhs - lhs)
-        rhs.cluster_count - lhs.cluster_count || // 2. Minimize HP (Lowest First: lhs - rhs) <-- Corrected from your initial code
-        lhs.hp - rhs.hp || // 3. Minimize Distance (Lowest First: lhs - rhs) <-- Corrected from your initial code
+        // Sort by cluster count
+        rhs.cluster_count - lhs.cluster_count ||
+        lhs.hp - rhs.hp ||
         lhs.distance - rhs.distance
       );
     });
 
-  const weakMobs = potentialTargets.filter(isWeak); // --- Target Acquisition ---
+  const weakMobs = potentialTargets.filter(isWeak);
 
   if (potentialTargets.length) {
     target = potentialTargets[0];
@@ -97,7 +96,8 @@ async function fight(target) {
     if (aggroing) target = aggroing;
   }
 
-  // --- Huntersmark ---
+  // Huntersmark
+  // TODO: Put in a seperate loop to narrow the gap between marks
   const canHuntersMark =
     target &&
     !target.s?.marked &&
@@ -110,7 +110,7 @@ async function fight(target) {
     );
   }
 
-  // --- Attack Priority: 5shot > 3shot > single ---
+  // 5shot > 3shot > single
   const hpOk = character.hp > character.max_hp * 0.55;
   const is5ShotReady =
     character.level >= G.skills["5shot"].level &&
@@ -128,24 +128,42 @@ async function fight(target) {
   if (is5ShotReady) {
     const mobsTo5Shot = weakMobs.slice(0, 5);
     if (!isAttackReady) promisesToAwait.push(currentStrategy(mobsTo5Shot));
-    else promisesToAwait.push(tryMultiShot("5shot", mobsTo5Shot));
+    else if (!isCupid) promisesToAwait.push(tryMultiShot("5shot", mobsTo5Shot));
+    else {
+      promisesToAwait.push(
+        currentStrategy(mobsTo5Shot),
+        tryMultiShot("5shot", potentialTargets.slice(0, 5)),
+      );
+    }
   } else if (is3ShotReady) {
     const mobsTo3Shot = potentialTargets.slice(0, 3);
     if (!isAttackReady) promisesToAwait.push(currentStrategy(mobsTo3Shot));
-    else
+    else if (!isCupid)
       promisesToAwait.push(tryMultiShot("3shot", potentialTargets.slice(0, 3)));
+    else
+      promisesToAwait.push(
+        currentStrategy(mobsTo3Shot),
+        tryMultiShot("3shot", mobsTo3Shot),
+      );
   } else if (target && distance(target, character) < nearRange) {
     set_message("Shooting");
     if (!isAttackReady) promisesToAwait.push(currentStrategy(target));
-    else
+    else if (!isCupid)
       promisesToAwait.push(
+        use_skill("attack", target)
+          .then(() => reduceCd("attack"))
+          .catch((e) => attackErrorHandler(e)),
+      );
+    else // Base case for Cupid: both attack and currentStrategy
+      promisesToAwait.push(
+        currentStrategy(target),
         use_skill("attack", target)
           .then(() => reduceCd("attack"))
           .catch((e) => attackErrorHandler(e)),
       );
   }
 
-  // --- Supershot ---
+  // Supershot
   const canSuperShot =
     character.mp > 400 + 1000 && !is_on_cooldown("supershot");
 
@@ -175,7 +193,7 @@ async function fight(target) {
       );
   }
 
-  // --- Await and Error Handling ---
+  // Await and Error Handling
   try {
     await withTimeout(Promise.all(promisesToAwait), 1500);
   } catch (e) {
@@ -183,7 +201,7 @@ async function fight(target) {
   }
 }
 
-// --- Cupid Heal Logic (Refactored) ---
+// Cupid Logic :cow2:
 async function cupidHeal(playersToHeal) {
   const isAttackOnCD = ms_to_next_skill("attack") > 0 || character.s.penalty_cd;
   const hasCupid =
@@ -207,17 +225,17 @@ async function cupidHeal(playersToHeal) {
     }
 
     if (!isAttackOnCD) {
-      // Determine the best shot for healing
-      const mpCost = G.skills["huntersmark"].mp;
+      // Determine the best skill for healing
+      const preservedMP = G.skills["huntersmark"].mp;
       const is5ShotReady =
         character.level >= G.skills["5shot"].level &&
         lowHealthPlayersInRange.length >= 4 &&
-        character.mp > G.skills["5shot"].mp + mpCost &&
+        character.mp > G.skills["5shot"].mp + preservedMP &&
         !character.fear;
       const is3ShotReady =
         character.level >= G.skills["3shot"].level &&
         lowHealthPlayersInRange.length >= 2 &&
-        character.mp > G.skills["3shot"].mp + mpCost &&
+        character.mp > G.skills["3shot"].mp + preservedMP &&
         !character.fear;
 
       let healingTarget = null;

--- a/basic_ranger.32.js
+++ b/basic_ranger.32.js
@@ -31,7 +31,8 @@ const tryMultiShot = async (skill, entityList) => {
   if (entityList.length === 0) return false;
   set_message(`${skill} Shooting`);
   return use_skill(skill, entityList)
-    .then(() => reduceCd("attack")) // Use reduceCd for the skill (was incorrectly hardcoded to "attack");
+    .then(() => reduceCd("attack")) // Use reduceCd for the skill (was incorrectly hardcoded to "attack")
+    .catch((e) => attackErrorHandler(e));
 };
 
 async function fight(target) {
@@ -147,7 +148,8 @@ async function fight(target) {
   }
 
   // --- Supershot ---
-  const canSuperShot = character.mp > 400 + 1000 && !is_on_cooldown("supershot");
+  const canSuperShot =
+    character.mp > 400 + 1000 && !is_on_cooldown("supershot");
 
   if (canSuperShot) {
     const coopTarget = target?.cooperative
@@ -179,7 +181,7 @@ async function fight(target) {
   try {
     await withTimeout(Promise.all(promisesToAwait), 1500);
   } catch (e) {
-    console.warn(e);
+    console.log(e);
   }
 }
 
@@ -255,7 +257,8 @@ async function cupidHeal(playersToHeal) {
   try {
     await withTimeout(Promise.all(promisesToAwait), 1000);
   } catch (e) {
-    console.warn("Error while Cupiding!", e);
+    attackErrorHandler(e);
+    console.error("Error while Cupiding!", e);
   }
 }
 

--- a/basic_ranger.32.js
+++ b/basic_ranger.32.js
@@ -188,7 +188,7 @@ async function cupidHeal(playersToHeal) {
   const isAttackOnCD = ms_to_next_skill("attack") > 0 || character.s.penalty_cd;
   const hasCupid =
     locate_item("cupid") !== -1 || character.slots.mainhand?.name === "cupid";
-  if (isAttackOnCD || !hasCupid) return;
+  if (!hasCupid) return;
 
   const characterRange = character.range + character.xrange;
   const lowHealthPlayersInRange = playersToHeal.filter(
@@ -201,54 +201,58 @@ async function cupidHeal(playersToHeal) {
 
   if (lowHealthPlayersInRange.length > 0) {
     // Equipping Cupid first
-    if (character.slots.mainhand?.name !== "cupid") {
+    if (character.slots.mainhand?.name !== "cupid" && isAttackOnCD) {
       const rangerItems = calculateRangerItems(lowHealthPlayersInRange);
       promisesToAwait.push(equipBatch({ ...rangerItems, mainhand: "cupid" }));
     }
 
-    // Determine the best shot for healing
-    const mpCost = G.skills["huntersmark"].mp;
-    const is5ShotReady =
-      character.level >= G.skills["5shot"].level &&
-      lowHealthPlayersInRange.length >= 4 &&
-      character.mp > G.skills["5shot"].mp + mpCost &&
-      !character.fear;
-    const is3ShotReady =
-      character.level >= G.skills["3shot"].level &&
-      lowHealthPlayersInRange.length >= 2 &&
-      character.mp > G.skills["3shot"].mp + mpCost &&
-      !character.fear;
+    if (!isAttackOnCD) {
+      // Determine the best shot for healing
+      const mpCost = G.skills["huntersmark"].mp;
+      const is5ShotReady =
+        character.level >= G.skills["5shot"].level &&
+        lowHealthPlayersInRange.length >= 4 &&
+        character.mp > G.skills["5shot"].mp + mpCost &&
+        !character.fear;
+      const is3ShotReady =
+        character.level >= G.skills["3shot"].level &&
+        lowHealthPlayersInRange.length >= 2 &&
+        character.mp > G.skills["3shot"].mp + mpCost &&
+        !character.fear;
 
-    let healingTarget = null;
-    let skillName = "attack";
-    let sliceAmount = 1;
+      let healingTarget = null;
+      let skillName = "attack";
+      let sliceAmount = 1;
 
-    if (is5ShotReady) {
-      skillName = "5shot";
-      sliceAmount = 5;
-    } else if (is3ShotReady) {
-      skillName = "3shot";
-      sliceAmount = 3;
-    } else {
-      // Single shot fallback
-      healingTarget = lowHealthPlayersInRange[0];
-    }
+      if (is5ShotReady) {
+        skillName = "5shot";
+        sliceAmount = 5;
+      } else if (is3ShotReady) {
+        skillName = "3shot";
+        sliceAmount = 3;
+      } else {
+        // Single shot fallback
+        healingTarget = lowHealthPlayersInRange[0];
+      }
 
-    if (skillName !== "attack") {
-      // Multi-shot healing
-      set_message(`${skillName} Cupid`);
-      const targets = lowHealthPlayersInRange.slice(0, sliceAmount);
-      console.log(`Healing ${targets.map((player) => player.name).join(", ")}`);
-      promisesToAwait.push(tryMultiShot(skillName, targets));
-    } else if (healingTarget) {
-      // Single shot healing
-      set_message("Single Cupid");
-      log(`Healing ${healingTarget.name}`);
-      promisesToAwait.push(
-        use_skill("attack", healingTarget).then(
-          () => reduceCd("attack"), // Use reduceCd
-        ),
-      );
+      if (skillName !== "attack") {
+        // Multi-shot healing
+        set_message(`${skillName} Cupid`);
+        const targets = lowHealthPlayersInRange.slice(0, sliceAmount);
+        console.log(
+          `Healing ${targets.map((player) => player.name).join(", ")}`,
+        );
+        promisesToAwait.push(tryMultiShot(skillName, targets));
+      } else if (healingTarget) {
+        // Single shot healing
+        set_message("Single Cupid");
+        log(`Healing ${healingTarget.name}`);
+        promisesToAwait.push(
+          use_skill("attack", healingTarget).then(
+            () => reduceCd("attack"), // Use reduceCd
+          ),
+        );
+      }
     }
   }
 
@@ -258,6 +262,10 @@ async function cupidHeal(playersToHeal) {
     attackErrorHandler(e);
     console.error("Error while Cupiding!", e);
   }
+
+  // This value determines if
+  // the ranger is about to Cupid (by equipping)/is currently Cupiding
+  return promisesToAwait.length === 0;
 }
 
 async function mainLoop() {
@@ -277,7 +285,7 @@ async function mainLoop() {
 
     // 2. Cupid Healing
     const playersToHeal = getPlayersToHeal();
-    await cupidHeal(playersToHeal);
+    const isDeterminedToBeCupid = await cupidHeal(playersToHeal);
 
     // 3. Movement Control Check
     const isMovingControlled =
@@ -322,7 +330,7 @@ async function mainLoop() {
           y: mapY,
         });
       }
-    } else {
+    } else if (!isDeterminedToBeCupid) {
       // Target found, engage in combat
       await fight(target);
     }

--- a/basic_ranger.32.js
+++ b/basic_ranger.32.js
@@ -154,7 +154,8 @@ async function fight(target) {
           .then(() => reduceCd("attack"))
           .catch((e) => attackErrorHandler(e)),
       );
-    else // Base case for Cupid: both attack and currentStrategy
+    // Base case for Cupid: both attack and currentStrategy
+    else
       promisesToAwait.push(
         currentStrategy(target),
         use_skill("attack", target)
@@ -219,7 +220,7 @@ async function cupidHeal(playersToHeal) {
 
   if (lowHealthPlayersInRange.length > 0) {
     // Equipping Cupid first
-    if (character.slots.mainhand?.name !== "cupid" && isAttackOnCD) {
+    if (character.slots.mainhand?.name !== "cupid") {
       const rangerItems = calculateRangerItems(lowHealthPlayersInRange);
       promisesToAwait.push(equipBatch({ ...rangerItems, mainhand: "cupid" }));
     }

--- a/basic_ranger.32.js
+++ b/basic_ranger.32.js
@@ -201,8 +201,10 @@ async function cupidHeal(playersToHeal) {
 
   if (lowHealthPlayersInRange.length > 0) {
     // Equipping Cupid first
-    if (character.slots.mainhand?.name !== "cupid")
-      promisesToAwait.push(equip(findMaxLevelItem("cupid")));
+    if (character.slots.mainhand?.name !== "cupid") {
+      const rangerItems = calculateRangerItems(lowHealthPlayersInRange);
+      promisesToAwait.push(equipBatch({ ...rangerItems, mainhand: "cupid" }));
+    }
 
     // Determine the best shot for healing
     const mpCost = G.skills["huntersmark"].mp;

--- a/basic_ranger.32.js
+++ b/basic_ranger.32.js
@@ -31,8 +31,7 @@ const tryMultiShot = async (skill, entityList) => {
   if (entityList.length === 0) return false;
   set_message(`${skill} Shooting`);
   return use_skill(skill, entityList)
-    .then(() => reduceCd("attack")) // Use reduceCd for the skill (was incorrectly hardcoded to "attack")
-    .catch((e) => attackErrorHandler(e));
+    .then(() => reduceCd("attack")) // Use reduceCd for the skill (was incorrectly hardcoded to "attack");
 };
 
 async function fight(target) {

--- a/basic_ranger.32.js
+++ b/basic_ranger.32.js
@@ -85,7 +85,7 @@ async function fight(target) {
 
   const weakMobs = potentialTargets.filter(isWeak); // --- Target Acquisition ---
 
-  if (currentStrategy === usePullStrategies && potentialTargets.length) {
+  if (potentialTargets.length) {
     target = potentialTargets[0];
     change_target(target);
   } // Reacquire target if feared

--- a/basic_ranger.32.js
+++ b/basic_ranger.32.js
@@ -255,7 +255,6 @@ async function cupidHeal(playersToHeal) {
   try {
     await withTimeout(Promise.all(promisesToAwait), 1000);
   } catch (e) {
-    attackErrorHandler(e);
     console.error("Error while Cupiding!", e);
   }
 }

--- a/basic_ranger.32.js
+++ b/basic_ranger.32.js
@@ -265,7 +265,7 @@ async function cupidHeal(playersToHeal) {
 
   // This value determines if
   // the ranger is about to Cupid (by equipping)/is currently Cupiding
-  return promisesToAwait.length === 0;
+  return lowHealthPlayersInRange.length > 0;
 }
 
 async function mainLoop() {

--- a/basic_ranger.32.js
+++ b/basic_ranger.32.js
@@ -14,7 +14,7 @@ if (parent.caracAL) {
 }
 
 // Kiting (unchanged)
-var originRangeRate = 0.65;
+var originRangeRate = 0.35;
 rangeRate = originRangeRate;
 
 // --- Helper Functions ---

--- a/basic_ranger.32.js
+++ b/basic_ranger.32.js
@@ -83,7 +83,7 @@ async function fight(target) {
 
   const weakMobs = potentialTargets.filter(isWeak);
 
-  if (potentialTargets.length && !target?.name.includes("crabx")) {
+  if (potentialTargets.length && !target?.mtype.includes("crabx")) {
     target = potentialTargets[0];
     change_target(target);
   } // Reacquire target if feared

--- a/basic_rogue.31.js
+++ b/basic_rogue.31.js
@@ -106,7 +106,7 @@ async function fuaLoop() {
     if (
       playersNearbyWithoutRogueSpeed.length &&
       ms_to_next_skill("rspeed") === 0 &&
-      character.mp > G.skills["rspeed"].mp
+      character.mp > G.skills["rspeed"].mp + 1000
     ) {
       use_skill("rspeed", playersNearbyWithoutRogueSpeed.shift());
     }
@@ -114,7 +114,7 @@ async function fuaLoop() {
     if (
       distance(character, currentTarget) < character.range + character.xrange &&
       ms_to_next_skill("quickstab") === 0 &&
-      character.mp > parent.G.skills["rspeed"].mp * 2
+      character.mp > parent.G.skills["rspeed"].mp * 2 + 1000
     ) {
       const currentMainhand = item_info(character.slots.mainhand);
       const skillToBeUsed =

--- a/basic_rogue.31.js
+++ b/basic_rogue.31.js
@@ -20,13 +20,17 @@ var originRangeRate = 0.95;
 rangeRate = originRangeRate;
 
 async function fight(target) {
+  const inRange = (entity) =>
+    distance(entity, character) < character.range + character.xrange;
+
   if (currentStrategy === usePullStrategies) {
     const allAggroedByParty = Object.values(parent.entities)
       .filter(
         (entity) =>
           entity.type === "monster" &&
           ([...partyMems, ...parent.party_list].includes(entity.target) ||
-            (entity.cooperative && entity.target)),
+            (entity.cooperative && entity.target)) &&
+          inRange(entity),
       )
       .sort((lhs, rhs) => {
         const lhsHpPercentage = lhs.hp / lhs.max_hp;
@@ -52,7 +56,7 @@ async function fight(target) {
   if (
     ms_to_next_skill("attack") === 0 &&
     !character.s.penalty_cd &&
-    distance(target, character) < character.range + character.xrange &&
+    inRange(target) &&
     shouldAttack()
   ) {
     if (!ms_to_next_skill("invis")) {
@@ -90,7 +94,7 @@ async function fuaLoop() {
       .filter(
         (entity) =>
           entity.type === "character" &&
-          (!entity.s.rspeed || entity.s.rspeed.ms < 2.1e6) &&
+          (!entity.s.rspeed || entity.s.rspeed.ms < 2.22e6) &&
           is_in_range(entity, "rspeed"),
       )
       .sort((lhs, rhs) => {
@@ -177,7 +181,7 @@ async function mainLoop() {
         !smart.moving &&
         !isAdvanceSmartMoving &&
         !get("cryptInstance") &&
-        (partyMems[0] == character.name ||
+        (partyMems[0] === character.name ||
           !get_entity(partyMems[0]) ||
           distance(character, { x: mapX, y: mapY, map }) > 500)
       ) {

--- a/basic_rogue.31.js
+++ b/basic_rogue.31.js
@@ -22,6 +22,8 @@ rangeRate = originRangeRate;
 async function fight(target) {
   const inRange = (entity) =>
     distance(entity, character) < character.range + character.xrange;
+  const isAttackReady =
+    ms_to_next_skill("attack") === 0 && !character.s.penalty_cd;
 
   if (currentStrategy === usePullStrategies) {
     const allAggroedByParty = Object.values(parent.entities)
@@ -53,19 +55,16 @@ async function fight(target) {
 
   const promisesToAwait = [];
 
-  if (
-    ms_to_next_skill("attack") === 0 &&
-    !character.s.penalty_cd &&
-    inRange(target) &&
-    shouldAttack()
-  ) {
+  if (!isAttackReady && inRange(target) && shouldAttack())
+    promisesToAwait.push(currentStrategy(target));
+
+  if (isAttackReady && inRange(target) && shouldAttack()) {
     if (!ms_to_next_skill("invis")) {
       use_skill("invis").then(() =>
         reduce_cooldown("invis", Math.min(...parent.pings)),
       );
     }
     promisesToAwait.push(
-      currentStrategy(target),
       withTimeout(attack(target), 2500)
         .then(() => reduce_cooldown("attack", Math.min(...parent.pings)))
         .catch((e) => {
@@ -108,7 +107,9 @@ async function fuaLoop() {
       ms_to_next_skill("rspeed") === 0 &&
       character.mp > G.skills["rspeed"].mp
     ) {
-      use_skill("rspeed", playersNearbyWithoutRogueSpeed.shift());
+      promisesToAwait.push(
+        use_skill("rspeed", playersNearbyWithoutRogueSpeed.shift()),
+      );
     }
 
     if (

--- a/basic_rogue.31.js
+++ b/basic_rogue.31.js
@@ -106,7 +106,7 @@ async function fuaLoop() {
     if (
       playersNearbyWithoutRogueSpeed.length &&
       ms_to_next_skill("rspeed") === 0 &&
-      character.mp > G.skills["rspeed"].mp + 1000
+      character.mp > G.skills["rspeed"].mp
     ) {
       use_skill("rspeed", playersNearbyWithoutRogueSpeed.shift());
     }
@@ -114,7 +114,7 @@ async function fuaLoop() {
     if (
       distance(character, currentTarget) < character.range + character.xrange &&
       ms_to_next_skill("quickstab") === 0 &&
-      character.mp > parent.G.skills["rspeed"].mp * 2 + 1000
+      character.mp > parent.G.skills["rspeed"].mp * 2
     ) {
       const currentMainhand = item_info(character.slots.mainhand);
       const skillToBeUsed =

--- a/basic_warrior.9.js
+++ b/basic_warrior.9.js
@@ -49,7 +49,7 @@ async function fight(target) {
   };
 
   // --- Target Aggregation & Selection (usePullStrategies) ---
-  if (currentStrategy === usePullStrategies && !target?.name.includes("crabx")) {
+  if (currentStrategy === usePullStrategies && !target?.mtype.includes("crabx")) {
     const aggroedMobs = Object.values(parent.entities)
       .filter((entity) => {
         return (

--- a/basic_warrior.9.js
+++ b/basic_warrior.9.js
@@ -217,10 +217,9 @@ async function fight(target) {
     const mobsTargetingAlly = Object.values(parent.entities).find(
       (mob) =>
         mob.type === "monster" &&
-        partyMems.some(
+        [...partyMems, partyMerchant].some(
           (ally) => ally !== character.name && mob.target === ally,
         ) &&
-        mob.attack > 120 && // Mob is dangerous enough
         calculateDamage(mob, character) < 1800 && // Warrior can take the damage
         !mob.cooperative &&
         is_in_range(mob, "taunt"),

--- a/basic_warrior.9.js
+++ b/basic_warrior.9.js
@@ -107,7 +107,7 @@ async function fight(target) {
   const isAttackReady =
     ms_to_next_skill("attack") === 0 && !character.s.penalty_cd;
 
-  if (isAttackReady && inRange(target) && shouldAttack()) {
+  if (!isAttackReady && shouldAttack()) {
     promisesToAwait.push(currentStrategy(target));
   }
 

--- a/basic_warrior.9.js
+++ b/basic_warrior.9.js
@@ -286,7 +286,11 @@ async function cleaveLoop() {
       distance(character, get_targeted_monster()) >
         character.range + character.xrange * 1.1;
 
-    if (shouldCleave && character.mp > 1720) {
+    if (
+      shouldCleave &&
+      character.mp > 1720 &&
+      !Object.keys(character.c).length
+    ) {
       await withTimeout(
         warriorCleave(
           currentStrategy === usePullStrategies ? "pull" : "normal",

--- a/basic_warrior.9.js
+++ b/basic_warrior.9.js
@@ -103,24 +103,20 @@ async function fight(target) {
   const promisesToAwait = [];
 
   // --- Attack & Warcry Logic ---
-  const isAttackReady = ms_to_next_skill("attack") === 0;
-  //  && !character.s.penalty_cd;
+  const isAttackReady =
+    ms_to_next_skill("attack") === 0 && !character.s.penalty_cd;
 
   if (isAttackReady && inRange(target) && shouldAttack()) {
     set_message("Attacking");
     const attackFrequencyBeforeComponsate = character.frequency;
-    const attackStartTime = Date.now();
 
     // Main attack execution
     promisesToAwait.push(
       currentStrategy(target),
       attack(target)
         .then(() => {
+          attackSpeedCompensate(attackFrequencyBeforeComponsate);
           reduceCd("attack");
-          attackPingCompensate(
-            attackStartTime,
-            attackFrequencyBeforeComponsate,
-          );
         })
         .catch((e) => attackErrorHandler(e)),
     );
@@ -130,16 +126,14 @@ async function fight(target) {
       character.ping < 1000 &&
       !character.s.sugarrush &&
       !isEquipingItems &&
-      (((character.slots.offhand?.name === "fireblade" ||
+      (character.slots.offhand?.name === "fireblade" ||
         character.slots.mainhand?.name === "fireblade") &&
-        character.slots.offhand?.name !== "mshield") ||
-        character.slots.mainhand?.name === "rapier") &&
+      character.slots.offhand?.name !== "mshield" &&
       character.cc < 100;
 
     if (shouldUseCandyCanes) {
       const candycane1 = findMaxLevelItem("candycanesword");
       const candycane2 = findMaxLevelItem("candycanesword", 1);
-      const unEquipCandyCane2 = character.slots.mainhand?.name === "rapier";
 
       if (candycane1 !== -1 && candycane2 !== -1) {
         isEquipingItems = true;
@@ -155,30 +149,22 @@ async function fight(target) {
               slot: "offhand",
             },
           ]),
-          // Promise.all([
-          //   equip(candycane1, "mainhand"),
-          //   equip(candycane2, "offhand"),
-          // ]),
 
           // Delayed re-equip
           new Promise((resolve) => {
             setTimeout(() => {
-              if (unEquipCandyCane2) {
-                resolve(Promise.all([unequip("offhand"), equip(candycane1)]));
-              } else {
-                resolve(
-                  equip_batch([
-                    {
-                      num: candycane1,
-                      slot: "mainhand",
-                    },
-                    {
-                      num: candycane2,
-                      slot: "offhand",
-                    },
-                  ]),
-                );
-              }
+              resolve(
+                equip_batch([
+                  {
+                    num: candycane1,
+                    slot: "mainhand",
+                  },
+                  {
+                    num: candycane2,
+                    slot: "offhand",
+                  },
+                ]),
+              );
             }, 150);
           }),
         ]).finally(() => {
@@ -306,7 +292,7 @@ async function cleaveLoop() {
   try {
     const shouldCleave =
       smart.moving ||
-      ms_to_next_skill("attack") > 360 ||
+      ms_to_next_skill("attack") > 0 ||
       distance(character, get_targeted_monster()) >
         character.range + character.xrange * 1.1;
 

--- a/basic_warrior.9.js
+++ b/basic_warrior.9.js
@@ -140,42 +140,45 @@ async function fight(target) {
 
       if (candycane1 !== -1 && candycane2 !== -1) {
         isEquipingItems = true;
-        const equipPromise = Promise.all([
+        const equipPromise =
+          // Promise.all([
           // Immediate equip
           equip_batch([
             { num: candycane1, slot: "mainhand" },
             { num: candycane2, slot: "offhand" },
-          ]),
+          ])
+            // ,
 
-          // Delayed re-equip
-          new Promise((resolve) => {
-            setTimeout(
-              () => {
-                const warriorItems = calculateWarriorItems();
-                const mainhandSlot = findMaxLevelItem(warriorItems.mainhand);
-                const offhandSlot = findMaxLevelItem(
-                  warriorItems.offhand,
-                  warriorItems.mainhand === warriorItems.offhand,
-                );
-                resolve(
-                  equip_batch([
-                    {
-                      num: mainhandSlot === -1 ? candycane1 : mainhandSlot,
-                      slot: "mainhand",
-                    },
-                    {
-                      num: offhandSlot === -1 ? candycane2 : offhandSlot,
-                      slot: "offhand",
-                    },
-                  ]),
-                );
-              },
-              Math.min(character.ping, 100),
-            );
-          }),
-        ]).finally(() => {
-          isEquipingItems = false;
-        });
+            // Delayed re-equip
+            // new Promise((resolve) => {
+            //   setTimeout(
+            //     () => {
+            //       const warriorItems = calculateWarriorItems();
+            //       const mainhandSlot = findMaxLevelItem(warriorItems.mainhand);
+            //       const offhandSlot = findMaxLevelItem(
+            //         warriorItems.offhand,
+            //         warriorItems.mainhand === warriorItems.offhand,
+            //       );
+            //       resolve(
+            //         equip_batch([
+            //           {
+            //             num: mainhandSlot === -1 ? candycane1 : mainhandSlot,
+            //             slot: "mainhand",
+            //           },
+            //           {
+            //             num: offhandSlot === -1 ? candycane2 : offhandSlot,
+            //             slot: "offhand",
+            //           },
+            //         ]),
+            //       );
+            //     },
+            //     Math.min(character.ping, 100),
+            //   );
+            // }),
+            // ])
+            .finally(() => {
+              isEquipingItems = false;
+            });
 
         promisesToAwait.push(equipPromise);
       }

--- a/basic_warrior.9.js
+++ b/basic_warrior.9.js
@@ -124,7 +124,6 @@ async function fight(target) {
         })
         .catch((e) => attackErrorHandler(e)),
     );
-    reduce_cooldown("attack", -1000 / character.frequency);
 
     // Offhand swap logic: Use Candy Canes for farming
     const shouldUseCandyCanes =

--- a/basic_warrior.9.js
+++ b/basic_warrior.9.js
@@ -53,6 +53,7 @@ async function fight(target) {
       .filter((entity) => {
         return (
           entity.type === "monster" &&
+          !entity.s?.fullguardx &&
           !MELEE_IGNORE_LIST.includes(entity.mtype) &&
           entity.target &&
           !haveFormidableMonsterAroundTarget(entity) &&
@@ -185,7 +186,7 @@ async function fight(target) {
   }
 
   // Warrior Stomp (Basher logic)
-  const hasBasherEquipped = locate_item("basher") !== -1;
+  const hasBasherInInventory = locate_item("basher") !== -1;
   const partyHasInjured = (
     parent.party_list.length ? parent.party_list : [character]
   )
@@ -193,7 +194,7 @@ async function fight(target) {
     .filter((entity) => entity)
     .some((player) => player.hp < player.max_hp * 0.4);
 
-  if (hasBasherEquipped && partyHasInjured) {
+  if (hasBasherInInventory && partyHasInjured) {
     promisesToAwait.push(warriorStomp());
   }
 
@@ -230,6 +231,7 @@ async function fight(target) {
     const shouldTauntTarget =
       !target.target ||
       (target.target !== character.name &&
+        partyMems.includes(target.target) &&
         target.attack < 1500 &&
         !target.cooperative &&
         is_in_range(target, "taunt"));
@@ -299,7 +301,10 @@ if (!parent.caracAL) cleaveLoop();
 async function mainLoop() {
   try {
     // --- Initialization and Status Checks ---
-    desiredElixir = isAssignedAsTanker() ? "elixirluck" : "pumpkinspice";
+    desiredElixir =
+      isAssignedAsTanker() && avgDmgTaken(character) > 300
+        ? "elixirluck"
+        : "pumpkinspice";
     assignRoles();
 
     // Use Charge if moving (for speed boost)
@@ -345,12 +350,12 @@ async function mainLoop() {
         get("cryptInstance") && character.map !== "crypt";
       const isPartyLeaderOrAlone =
         partyMems[0] === character.name || !get_entity(partyMems[0]);
-      const isFarFromPartyLeader =
+      const isFarFromFarmingSpot =
         distance(character, { x: mapX, y: mapY, map }) > 500;
 
       // Only move to farm location if not doing crypt and either the leader/alone or far away.
       const needsToMoveToFarmLocation =
-        !get("cryptInstance") && (isPartyLeaderOrAlone || isFarFromPartyLeader);
+        !get("cryptInstance") && isPartyLeaderOrAlone && isFarFromFarmingSpot;
 
       if (needsToEnterCrypt) {
         advanceSmartMove(CRYPT_STARTING_LOCATION);

--- a/basic_warrior.9.js
+++ b/basic_warrior.9.js
@@ -38,8 +38,9 @@ const bosses = {
 // Main fight function
 async function fight(target) {
   const blastRadius = character.explosion / 3.6 || BLAST_RADIUS;
-  const attackRange = character.range + character.xrange * 0.9;
-  const inRange = (entity, mult = 1) => distance(entity, character) < attackRange * mult;
+  const attackRange = character.range + character.xrange;
+  const inRange = (entity, mult = 1) =>
+    distance(entity, character) < attackRange * mult;
 
   const haveIgnoreMobAroundTarget = (targetMob) => {
     return mobsListAroundTarget(targetMob, blastRadius).some((mob) =>
@@ -120,7 +121,7 @@ async function fight(target) {
           // attackSpeedCompensate(attackFrequencyBeforeComponsate);
           reduceCd("attack");
         })
-        .catch((e) => attackErrorHandler(e)),
+        .catch((e) => attackErrorHandler(e, target)),
     );
 
     // Offhand swap logic: Use Candy Canes for farming

--- a/basic_warrior.9.js
+++ b/basic_warrior.9.js
@@ -145,7 +145,7 @@ async function fight(target) {
         );
 
         const backSwap =
-          character.ping < 150
+          character.ping < 300
             ? candySwap.then(() => equipBatch(calculateWarriorItems(), true))
             : new Promise((resolve) => {
                 setTimeout(() => {

--- a/basic_warrior.9.js
+++ b/basic_warrior.9.js
@@ -107,7 +107,7 @@ async function fight(target) {
   const isAttackReady =
     ms_to_next_skill("attack") === 0 && !character.s.penalty_cd;
 
-  if (!isAttackReady && shouldAttack()) {
+  if (!isAttackReady && inRange(target) && shouldAttack()) {
     promisesToAwait.push(currentStrategy(target));
   }
 
@@ -139,46 +139,37 @@ async function fight(target) {
       const candycane2 = findMaxLevelItem("candycanesword", 1);
 
       if (candycane1 !== -1 && candycane2 !== -1) {
-        // isEquipingItems = true;
-        const equipPromise =
-          // Promise.all([
+        isEquipingItems = true;
+        const equipPromise = Promise.all([
           // Immediate equip
           equip_batch([
             { num: candycane1, slot: "mainhand" },
             { num: candycane2, slot: "offhand" },
-          ]);
-        // ,
+          ]),
 
-        // Delayed re-equip
-        // new Promise((resolve) => {
-        //   setTimeout(
-        //     () => {
-        //       const warriorItems = calculateWarriorItems();
-        //       const mainhandSlot = findMaxLevelItem(warriorItems.mainhand);
-        //       const offhandSlot = findMaxLevelItem(
-        //         warriorItems.offhand,
-        //         warriorItems.mainhand === warriorItems.offhand,
-        //       );
-        //       resolve(
-        //         equip_batch([
-        //           {
-        //             num: mainhandSlot === -1 ? candycane1 : mainhandSlot,
-        //             slot: "mainhand",
-        //           },
-        //           {
-        //             num: offhandSlot === -1 ? candycane2 : offhandSlot,
-        //             slot: "offhand",
-        //           },
-        //         ]),
-        //       );
-        //     },
-        //     Math.min(character.ping, 100),
-        //   );
-        // }),
-        // ])
-        // .finally(() => {
-        //   isEquipingItems = false;
-        // });
+          // Delayed re-equip
+          new Promise((resolve) => {
+            setTimeout(
+              () => {
+                resolve(
+                  equip_batch([
+                    {
+                      num: candycane1,
+                      slot: "mainhand",
+                    },
+                    {
+                      num: candycane2,
+                      slot: "offhand",
+                    },
+                  ]),
+                );
+              },
+              Math.min(character.ping, 125),
+            );
+          }),
+        ]).finally(() => {
+          isEquipingItems = false;
+        });
 
         promisesToAwait.push(equipPromise);
       }

--- a/basic_warrior.9.js
+++ b/basic_warrior.9.js
@@ -108,7 +108,6 @@ async function fight(target) {
 
   if (isAttackReady && inRange(target) && shouldAttack()) {
     set_message("Attacking");
-    const attackFrequencyBeforeComponsate = character.frequency;
 
     // Main attack execution
     promisesToAwait.push(
@@ -137,41 +136,34 @@ async function fight(target) {
 
       if (candycane1 !== -1 && candycane2 !== -1) {
         isEquipingItems = true;
-        const equipPromise = Promise.all([
-          // Immediate equip
-          equip_batch([
-            {
-              num: candycane1,
-              slot: "mainhand",
-            },
-            {
-              num: candycane2,
-              slot: "offhand",
-            },
-          ]),
+        const candySwap = equipBatch(
+          {
+            mainhand: "candycanesword",
+            offhand: "candycanesword",
+          },
+          true,
+        );
 
-          // Delayed re-equip
-          new Promise((resolve) => {
-            setTimeout(() => {
-              resolve(
-                equip_batch([
-                  {
-                    num: candycane1,
-                    slot: "mainhand",
-                  },
-                  {
-                    num: candycane2,
-                    slot: "offhand",
-                  },
-                ]),
-              );
-            }, 150);
-          }),
-        ]).finally(() => {
-          isEquipingItems = false;
-        });
+        const backSwap =
+          character.ping < 150
+            ? candySwap.then(() => equipBatch(calculateWarriorItems(), true))
+            : new Promise((resolve) => {
+                setTimeout(() => {
+                  resolve(
+                    equip_batch([
+                      { num: candycane1, slot: "mainhand" },
+                      { num: candycane2, slot: "offhand" },
+                    ]),
+                  );
+                }, 150);
+              });
 
-        promisesToAwait.push(equipPromise);
+        const fireGlitchSwap = Promise.all([candySwap, backSwap]).finally(
+          () => {
+            isEquipingItems = false;
+          },
+        );
+        promisesToAwait.push(fireGlitchSwap);
       }
     }
 

--- a/basic_warrior.9.js
+++ b/basic_warrior.9.js
@@ -103,17 +103,25 @@ async function fight(target) {
   const promisesToAwait = [];
 
   // --- Attack & Warcry Logic ---
-  const isAttackReady =
-    ms_to_next_skill("attack") === 0 && !character.s.penalty_cd;
+  const isAttackReady = ms_to_next_skill("attack") === 0;
+  //  && !character.s.penalty_cd;
 
   if (isAttackReady && inRange(target) && shouldAttack()) {
     set_message("Attacking");
+    const attackFrequencyBeforeComponsate = character.frequency;
+    const attackStartTime = Date.now();
 
     // Main attack execution
     promisesToAwait.push(
       currentStrategy(target),
       attack(target)
-        .then(() => reduceCd("attack")) // <-- Use reduceCd()
+        .then(() => {
+          reduceCd("attack");
+          attackPingCompensate(
+            attackStartTime,
+            attackFrequencyBeforeComponsate,
+          );
+        })
         .catch((e) => attackErrorHandler(e)),
     );
     reduce_cooldown("attack", -1000 / character.frequency);
@@ -123,14 +131,16 @@ async function fight(target) {
       character.ping < 1000 &&
       !character.s.sugarrush &&
       !isEquipingItems &&
-      (character.slots.offhand?.name === "fireblade" ||
+      (((character.slots.offhand?.name === "fireblade" ||
         character.slots.mainhand?.name === "fireblade") &&
-      character.slots.offhand?.name !== "mshield" &&
+        character.slots.offhand?.name !== "mshield") ||
+        character.slots.mainhand?.name === "rapier") &&
       character.cc < 100;
 
     if (shouldUseCandyCanes) {
       const candycane1 = findMaxLevelItem("candycanesword");
       const candycane2 = findMaxLevelItem("candycanesword", 1);
+      const unEquipCandyCane2 = character.slots.mainhand?.name === "rapier";
 
       if (candycane1 !== -1 && candycane2 !== -1) {
         isEquipingItems = true;
@@ -154,18 +164,22 @@ async function fight(target) {
           // Delayed re-equip
           new Promise((resolve) => {
             setTimeout(() => {
-              resolve(
-                equip_batch([
-                  {
-                    num: candycane1,
-                    slot: "mainhand",
-                  },
-                  {
-                    num: candycane2,
-                    slot: "offhand",
-                  },
-                ]),
-              );
+              if (unEquipCandyCane2) {
+                resolve(Promise.all([unequip("offhand"), equip(candycane1)]));
+              } else {
+                resolve(
+                  equip_batch([
+                    {
+                      num: candycane1,
+                      slot: "mainhand",
+                    },
+                    {
+                      num: candycane2,
+                      slot: "offhand",
+                    },
+                  ]),
+                );
+              }
             }, 150);
           }),
         ]).finally(() => {

--- a/basic_warrior.9.js
+++ b/basic_warrior.9.js
@@ -49,7 +49,7 @@ async function fight(target) {
   };
 
   // --- Target Aggregation & Selection (usePullStrategies) ---
-  if (currentStrategy === usePullStrategies) {
+  if (currentStrategy === usePullStrategies && !target?.name.includes("crabx")) {
     const aggroedMobs = Object.values(parent.entities)
       .filter((entity) => {
         return (
@@ -62,7 +62,6 @@ async function fight(target) {
           !haveIgnoreMobAroundTarget(entity)
         );
       })
-      // Optimization: Pre-calculate the cluster count BEFORE sorting
       .map((mob) => {
         mob.cluster_count = numberOfMonsterAroundTarget(mob, blastRadius);
         return mob;

--- a/basic_warrior.9.js
+++ b/basic_warrior.9.js
@@ -38,8 +38,8 @@ const bosses = {
 // Main fight function
 async function fight(target) {
   const blastRadius = character.explosion / 3.6 || BLAST_RADIUS;
-  const attackRange = character.range + character.xrange;
-  const inRange = (entity) => distance(entity, character) < attackRange;
+  const attackRange = character.range + character.xrange * 0.9;
+  const inRange = (entity, mult = 1) => distance(entity, character) < attackRange * mult;
 
   const haveIgnoreMobAroundTarget = (targetMob) => {
     return mobsListAroundTarget(targetMob, blastRadius).some((mob) =>
@@ -57,7 +57,7 @@ async function fight(target) {
           !MELEE_IGNORE_LIST.includes(entity.mtype) &&
           entity.target &&
           !haveFormidableMonsterAroundTarget(entity) &&
-          inRange(entity) &&
+          inRange(entity, 2) &&
           !haveIgnoreMobAroundTarget(entity)
         );
       })
@@ -141,18 +141,18 @@ async function fight(target) {
         isEquipingItems = true;
         const equipPromise = Promise.all([
           // Immediate equip
-          Promise.all([
-            equip(candycane1, "mainhand"),
-            equip(candycane2, "offhand"),
+          equip_batch([
+            { num: candycane1, slot: "mainhand" },
+            { num: candycane2, slot: "offhand" },
           ]),
 
           // Delayed re-equip
           new Promise((resolve) => {
             setTimeout(() => {
               resolve(
-                Promise.all([
-                  equip(candycane1, "mainhand"),
-                  equip(candycane2, "offhand"),
+                equip_batch([
+                  { num: candycane1, slot: "mainhand" },
+                  { num: candycane2, slot: "offhand" },
                 ]),
               );
             }, 150);

--- a/basic_warrior.9.js
+++ b/basic_warrior.9.js
@@ -124,6 +124,7 @@ async function fight(target) {
     // Offhand swap logic: Use Candy Canes for farming
     const shouldUseCandyCanes =
       character.ping < 1000 &&
+      !isCleaving &&
       !character.s.sugarrush &&
       (character.slots.offhand?.name === "fireblade" ||
         character.slots.mainhand?.name === "fireblade") &&

--- a/basic_warrior.9.js
+++ b/basic_warrior.9.js
@@ -149,14 +149,26 @@ async function fight(target) {
 
           // Delayed re-equip
           new Promise((resolve) => {
-            setTimeout(() => {
-              resolve(
-                equip_batch([
-                  { num: candycane1, slot: "mainhand" },
-                  { num: candycane2, slot: "offhand" },
-                ]),
-              );
-            }, 150);
+            setTimeout(
+              () => {
+                const warriorItems = calculateWarriorItems();
+                const mainhandSlot = findMaxLevelItem(warriorItems.mainhand);
+                const offhandSlot = findMaxLevelItem(warriorItems.offhand);
+                resolve(
+                  equip_batch([
+                    {
+                      num: mainhandSlot === -1 ? candycane1 : mainhandSlot,
+                      slot: "mainhand",
+                    },
+                    {
+                      num: offhandSlot === -1 ? candycane2 : offhandSlot,
+                      slot: "offhand",
+                    },
+                  ]),
+                );
+              },
+              Math.min(character.ping, 100),
+            );
           }),
         ]).finally(() => {
           isEquipingItems = false;

--- a/basic_warrior.9.js
+++ b/basic_warrior.9.js
@@ -296,7 +296,7 @@ async function cleaveLoop() {
       distance(character, get_targeted_monster()) >
         character.range + character.xrange * 1.1;
 
-    if (shouldCleave) {
+    if (shouldCleave && character.mp > 1720) {
       await withTimeout(
         warriorCleave(
           currentStrategy === usePullStrategies ? "pull" : "normal",

--- a/basic_warrior.9.js
+++ b/basic_warrior.9.js
@@ -107,11 +107,14 @@ async function fight(target) {
     ms_to_next_skill("attack") === 0 && !character.s.penalty_cd;
 
   if (isAttackReady && inRange(target) && shouldAttack()) {
+    promisesToAwait.push(currentStrategy(target));
+  }
+
+  if (isAttackReady && inRange(target) && shouldAttack()) {
     set_message("Attacking");
 
     // Main attack execution
     promisesToAwait.push(
-      currentStrategy(target),
       attack(target)
         .then(() => {
           // attackSpeedCompensate(attackFrequencyBeforeComponsate);
@@ -269,7 +272,7 @@ async function fight(target) {
 
   // --- Await and Error Handling ---
   try {
-    await withTimeout(Promise.allSettled(promisesToAwait), 1000);
+    await withTimeout(Promise.all(promisesToAwait), 1000);
   } catch (e) {
     console.error("Error while attacking", e);
   }

--- a/basic_warrior.9.js
+++ b/basic_warrior.9.js
@@ -116,6 +116,7 @@ async function fight(target) {
         .then(() => reduceCd("attack")) // <-- Use reduceCd()
         .catch((e) => attackErrorHandler(e)),
     );
+    reduce_cooldown("attack", -1000 / character.frequency);
 
     // Offhand swap logic: Use Candy Canes for farming
     const shouldUseCandyCanes =
@@ -135,18 +136,34 @@ async function fight(target) {
         isEquipingItems = true;
         const equipPromise = Promise.all([
           // Immediate equip
-          Promise.all([
-            equip(candycane1, "mainhand"),
-            equip(candycane2, "offhand"),
+          equip_batch([
+            {
+              num: candycane1,
+              slot: "mainhand",
+            },
+            {
+              num: candycane2,
+              slot: "offhand",
+            },
           ]),
+          // Promise.all([
+          //   equip(candycane1, "mainhand"),
+          //   equip(candycane2, "offhand"),
+          // ]),
 
           // Delayed re-equip
           new Promise((resolve) => {
             setTimeout(() => {
               resolve(
-                Promise.all([
-                  equip(candycane1, "mainhand"),
-                  equip(candycane2, "offhand"),
+                equip_batch([
+                  {
+                    num: candycane1,
+                    slot: "mainhand",
+                  },
+                  {
+                    num: candycane2,
+                    slot: "offhand",
+                  },
                 ]),
               );
             }, 150);
@@ -276,7 +293,7 @@ async function cleaveLoop() {
   try {
     const shouldCleave =
       smart.moving ||
-      ms_to_next_skill("attack") > 50 ||
+      ms_to_next_skill("attack") > 360 ||
       distance(character, get_targeted_monster()) >
         character.range + character.xrange * 1.1;
 

--- a/basic_warrior.9.js
+++ b/basic_warrior.9.js
@@ -115,7 +115,7 @@ async function fight(target) {
       currentStrategy(target),
       attack(target)
         .then(() => {
-          attackSpeedCompensate(attackFrequencyBeforeComponsate);
+          // attackSpeedCompensate(attackFrequencyBeforeComponsate);
           reduceCd("attack");
         })
         .catch((e) => attackErrorHandler(e)),

--- a/basic_warrior.9.js
+++ b/basic_warrior.9.js
@@ -136,34 +136,29 @@ async function fight(target) {
 
       if (candycane1 !== -1 && candycane2 !== -1) {
         isEquipingItems = true;
-        const candySwap = equipBatch(
-          {
-            mainhand: "candycanesword",
-            offhand: "candycanesword",
-          },
-          true,
-        );
+        const equipPromise = Promise.all([
+          // Immediate equip
+          Promise.all([
+            equip(candycane1, "mainhand"),
+            equip(candycane2, "offhand"),
+          ]),
 
-        const backSwap =
-          character.ping < 300
-            ? candySwap.then(() => equipBatch(calculateWarriorItems(), true))
-            : new Promise((resolve) => {
-                setTimeout(() => {
-                  resolve(
-                    equip_batch([
-                      { num: candycane1, slot: "mainhand" },
-                      { num: candycane2, slot: "offhand" },
-                    ]),
-                  );
-                }, 150);
-              });
+          // Delayed re-equip
+          new Promise((resolve) => {
+            setTimeout(() => {
+              resolve(
+                Promise.all([
+                  equip(candycane1, "mainhand"),
+                  equip(candycane2, "offhand"),
+                ]),
+              );
+            }, 150);
+          }),
+        ]).finally(() => {
+          isEquipingItems = false;
+        });
 
-        const fireGlitchSwap = Promise.all([candySwap, backSwap]).finally(
-          () => {
-            isEquipingItems = false;
-          },
-        );
-        promisesToAwait.push(fireGlitchSwap);
+        promisesToAwait.push(equipPromise);
       }
     }
 

--- a/basic_warrior.9.js
+++ b/basic_warrior.9.js
@@ -139,46 +139,46 @@ async function fight(target) {
       const candycane2 = findMaxLevelItem("candycanesword", 1);
 
       if (candycane1 !== -1 && candycane2 !== -1) {
-        isEquipingItems = true;
+        // isEquipingItems = true;
         const equipPromise =
           // Promise.all([
           // Immediate equip
           equip_batch([
             { num: candycane1, slot: "mainhand" },
             { num: candycane2, slot: "offhand" },
-          ])
-            // ,
+          ]);
+        // ,
 
-            // Delayed re-equip
-            // new Promise((resolve) => {
-            //   setTimeout(
-            //     () => {
-            //       const warriorItems = calculateWarriorItems();
-            //       const mainhandSlot = findMaxLevelItem(warriorItems.mainhand);
-            //       const offhandSlot = findMaxLevelItem(
-            //         warriorItems.offhand,
-            //         warriorItems.mainhand === warriorItems.offhand,
-            //       );
-            //       resolve(
-            //         equip_batch([
-            //           {
-            //             num: mainhandSlot === -1 ? candycane1 : mainhandSlot,
-            //             slot: "mainhand",
-            //           },
-            //           {
-            //             num: offhandSlot === -1 ? candycane2 : offhandSlot,
-            //             slot: "offhand",
-            //           },
-            //         ]),
-            //       );
-            //     },
-            //     Math.min(character.ping, 100),
-            //   );
-            // }),
-            // ])
-            .finally(() => {
-              isEquipingItems = false;
-            });
+        // Delayed re-equip
+        // new Promise((resolve) => {
+        //   setTimeout(
+        //     () => {
+        //       const warriorItems = calculateWarriorItems();
+        //       const mainhandSlot = findMaxLevelItem(warriorItems.mainhand);
+        //       const offhandSlot = findMaxLevelItem(
+        //         warriorItems.offhand,
+        //         warriorItems.mainhand === warriorItems.offhand,
+        //       );
+        //       resolve(
+        //         equip_batch([
+        //           {
+        //             num: mainhandSlot === -1 ? candycane1 : mainhandSlot,
+        //             slot: "mainhand",
+        //           },
+        //           {
+        //             num: offhandSlot === -1 ? candycane2 : offhandSlot,
+        //             slot: "offhand",
+        //           },
+        //         ]),
+        //       );
+        //     },
+        //     Math.min(character.ping, 100),
+        //   );
+        // }),
+        // ])
+        // .finally(() => {
+        //   isEquipingItems = false;
+        // });
 
         promisesToAwait.push(equipPromise);
       }

--- a/basic_warrior.9.js
+++ b/basic_warrior.9.js
@@ -149,23 +149,20 @@ async function fight(target) {
 
           // Delayed re-equip
           new Promise((resolve) => {
-            setTimeout(
-              () => {
-                resolve(
-                  equip_batch([
-                    {
-                      num: candycane1,
-                      slot: "mainhand",
-                    },
-                    {
-                      num: candycane2,
-                      slot: "offhand",
-                    },
-                  ]),
-                );
-              },
-              Math.min(character.ping, 125),
-            );
+            setTimeout(() => {
+              resolve(
+                equip_batch([
+                  {
+                    num: candycane1,
+                    slot: "mainhand",
+                  },
+                  {
+                    num: candycane2,
+                    slot: "offhand",
+                  },
+                ]),
+              );
+            }, 150);
           }),
         ]).finally(() => {
           isEquipingItems = false;

--- a/basic_warrior.9.js
+++ b/basic_warrior.9.js
@@ -125,7 +125,6 @@ async function fight(target) {
     const shouldUseCandyCanes =
       character.ping < 1000 &&
       !character.s.sugarrush &&
-      !isEquipingItems &&
       (character.slots.offhand?.name === "fireblade" ||
         character.slots.mainhand?.name === "fireblade") &&
       character.slots.offhand?.name !== "mshield" &&

--- a/basic_warrior.9.js
+++ b/basic_warrior.9.js
@@ -153,7 +153,10 @@ async function fight(target) {
               () => {
                 const warriorItems = calculateWarriorItems();
                 const mainhandSlot = findMaxLevelItem(warriorItems.mainhand);
-                const offhandSlot = findMaxLevelItem(warriorItems.offhand);
+                const offhandSlot = findMaxLevelItem(
+                  warriorItems.offhand,
+                  warriorItems.mainhand === warriorItems.offhand,
+                );
                 resolve(
                   equip_batch([
                     {

--- a/merchant_crafting.10.js
+++ b/merchant_crafting.10.js
@@ -482,7 +482,7 @@ setInterval(async () => {
   ) {
     onDuty = true;
     close_stand();
-    await smart_move(bankPosition);
+    await smartMove(bankPosition);
     BANK_CACHE = character.bank;
     const promises = [];
     character.items.forEach((item, index) => {

--- a/merchant_crafting.10.js
+++ b/merchant_crafting.10.js
@@ -177,7 +177,7 @@ function retrievedBankItemToUpgrade() {
   if (!desiredItemId) return;
 
   RETRIEVE_HISTORY.push(desiredItemId);
-  if (RETRIEVE_HISTORY.length >= Object.keys(ITEMS_HIGHEST_LEVEL).length - 1) {
+  if (RETRIEVE_HISTORY.length >= Object.keys(ITEMS_HIGHEST_LEVEL).length / 2) {
     RETRIEVE_HISTORY.shift();
   }
 

--- a/merchant_crafting.10.js
+++ b/merchant_crafting.10.js
@@ -508,12 +508,6 @@ setInterval(async () => {
     retrieveMaxItemsLevel();
     await retrievedBankItemToUpgrade();
 
-    if (parent.S.egghunt) {
-      for (let index = 0; index < 9; index++) {
-        retrieveBankItem(`egg${index}`);
-      }
-    }
-
     retrieveBankItem("gemfragment");
 
     onDuty = false;

--- a/merchant_crafting.10.js
+++ b/merchant_crafting.10.js
@@ -23,7 +23,7 @@ const KEEP_THRESHOLD = {
   // Class based
   weapon: 2,
   orb: 2,
-  shield: 3, // warrior, 0 if unneccessary
+  shield: 2, // warrior, 0 if unneccessary
   source: 2, // priest and mage
   staff: 2,
 
@@ -177,7 +177,7 @@ function retrievedBankItemToUpgrade() {
   if (!desiredItemId) return;
 
   RETRIEVE_HISTORY.push(desiredItemId);
-  if (RETRIEVE_HISTORY.length >= Object.keys(ITEMS_HIGHEST_LEVEL).length / 2) {
+  if (RETRIEVE_HISTORY.length >= Object.keys(ITEMS_HIGHEST_LEVEL).length - 1) {
     RETRIEVE_HISTORY.shift();
   }
 
@@ -400,7 +400,7 @@ async function upgradeInv() {
       if (
         character.mp > 200 &&
         !is_on_cooldown("massproductionpp") &&
-        character.items[i]?.level >= 3 &&
+        character.items[i]?.level >= 1 &&
         !character.s.massproductionpp
       ) {
         if (character.mp < 1000 && locate_item("mpot1") === -1) {

--- a/merchant_crafting.10.js
+++ b/merchant_crafting.10.js
@@ -8,7 +8,7 @@ if (parent.caracAL) {
 
 var BANK_CACHE = undefined;
 const bankPosition = { map: "bank", x: 0, y: -280 };
-
+const IGNORE_BANK_SLOTS = ["gold", "items8", "items9"];
 const IGNORE_RARE_GOLD_THRESHOLD = 40e8;
 
 const KEEP_THRESHOLD = {
@@ -25,7 +25,7 @@ const KEEP_THRESHOLD = {
   orb: 2,
   shield: 3, // warrior, 0 if unneccessary
   source: 2, // priest and mage
-  staff: 4,
+  staff: 2,
 
   // Class attribute based
   earring: 4,
@@ -47,7 +47,7 @@ async function retrieveBankItem(searchId, level = 0) {
   }
 
   for (const [bankPack, items] of Object.entries(character.bank).filter(
-    ([key, value]) => !["gold", "items9"].includes(key),
+    ([key, value]) => !IGNORE_BANK_SLOTS.includes(key),
   )) {
     const slot = items.findIndex(
       (item) =>
@@ -61,72 +61,56 @@ async function retrieveBankItem(searchId, level = 0) {
   }
 }
 
-async function retrieveMaxItemsLevel() {
+function retrieveMaxItemsLevel() {
   if (character.map !== "bank") return;
 
-  // Reset counter;
-  Object.keys(ITEMS_HIGHEST_LEVEL).forEach(
-    (key) => delete ITEMS_HIGHEST_LEVEL[key],
-  );
+  // Reset cache
+  for (const key in ITEMS_HIGHEST_LEVEL) {
+    delete ITEMS_HIGHEST_LEVEL[key];
+  }
 
   BANK_CACHE = character.bank;
 
-  character.items
-    .filter((item) => item && !item.q && !IGNORE.includes(item.name))
-    .forEach((item) => {
-      if (item.q) return;
+  const processItem = (item) => {
+    if (!item || item.q || IGNORE.includes(item.name)) return;
 
-      if (!ITEMS_HIGHEST_LEVEL[item.name]) {
-        ITEMS_HIGHEST_LEVEL[item.name] = {
-          level: item.level,
-          quantity: 1,
-          count: 1,
-          ...item_info(item),
-        };
-      } else {
-        if (item.level > ITEMS_HIGHEST_LEVEL[item.name].level) {
-          ITEMS_HIGHEST_LEVEL[item.name].level = item.level;
-          ITEMS_HIGHEST_LEVEL[item.name].quantity = 1;
-        } else if (item.level === ITEMS_HIGHEST_LEVEL[item.name].level)
-          ITEMS_HIGHEST_LEVEL[item.name].quantity++;
+    const existing = ITEMS_HIGHEST_LEVEL[item.name];
 
-        ITEMS_HIGHEST_LEVEL[item.name].count++;
-      }
-    });
+    if (!existing) {
+      ITEMS_HIGHEST_LEVEL[item.name] = {
+        level: item.level,
+        quantity: 1,
+        count: 1,
+        ...item_info(item),
+      };
+      return;
+    }
 
-  for (slot in character.bank) {
-    if (slot === "gold") continue;
+    if (item.level > existing.level) {
+      existing.level = item.level;
+      existing.quantity = 1;
+    } else if (item.level === existing.level) {
+      existing.quantity++;
+    }
 
-    character.bank[slot]
-      .filter((item) => item && !item.q && !IGNORE.includes(item.name))
-      .forEach((item) => {
-        if (item.q) return;
+    existing.count++;
+  };
 
-        if (!ITEMS_HIGHEST_LEVEL[item.name]) {
-          ITEMS_HIGHEST_LEVEL[item.name] = {
-            level: item.level,
-            quantity: 1,
-            count: 1,
-            ...item_info(item),
-          };
-        } else {
-          if (item.level > ITEMS_HIGHEST_LEVEL[item.name].level) {
-            ITEMS_HIGHEST_LEVEL[item.name].level = item.level;
-            ITEMS_HIGHEST_LEVEL[item.name].quantity = 1;
-          } else if (item.level === ITEMS_HIGHEST_LEVEL[item.name].level)
-            ITEMS_HIGHEST_LEVEL[item.name].quantity++;
+  // Inventory
+  character.items.forEach(processItem);
 
-          ITEMS_HIGHEST_LEVEL[item.name].count++;
-        }
-      });
+  // Bank
+  for (const slot in character.bank ?? BANK_CACHE) {
+    if (IGNORE_BANK_SLOTS.includes(slot)) continue;
+    character.bank[slot].forEach(processItem);
   }
 }
 
 function getItemBankSlots(itemId) {
   if (!BANK_CACHE) return [];
   const result = [];
-  for (id in BANK_CACHE) {
-    if (id === "gold") continue;
+  for (const id in BANK_CACHE) {
+    if (IGNORE_BANK_SLOTS.includes(id)) continue;
     BANK_CACHE[id].forEach((item, index) => {
       if (!item) return;
       if (item.name === itemId)
@@ -137,6 +121,7 @@ function getItemBankSlots(itemId) {
         });
     });
   }
+
   if (character.gold < IGNORE_RARE_GOLD_THRESHOLD)
     return result
       .filter((item) => item_grade(item) < 2)
@@ -145,10 +130,41 @@ function getItemBankSlots(itemId) {
   return result.sort((lhs, rhs) => lhs.level - rhs.level);
 }
 
+function groupItemsByLevel(items) {
+  return items.reduce((acc, item) => {
+    (acc[item.level] ??= []).push(item);
+    return acc;
+  }, {});
+}
+
+function filterCompoundableSets(items, inventoryEmptySlots) {
+  const byLevel = groupItemsByLevel(items);
+  const result = [];
+
+  for (const level in byLevel) {
+    const group = byLevel[level];
+    const setCount = Math.floor(group.length / 3);
+
+    if (setCount > 0) {
+      result.push(...group.slice(0, setCount * 3));
+    }
+  }
+
+  const maxTake = Math.floor(inventoryEmptySlots / 3) * 3;
+
+  return result.slice(0, maxTake);
+}
+
 function retrievedBankItemToUpgrade() {
-  let desiredItemId = undefined;
+  let desiredItemId;
   let maxItemCount = 0;
-  for (id in ITEMS_HIGHEST_LEVEL) {
+  let inventoryEmptySlots = character.esize - 4;
+
+  for (const id in ITEMS_HIGHEST_LEVEL) {
+    const info = item_info({ name: id });
+    if (!info) continue;
+    if (info.compound && inventoryEmptySlots < 3) continue;
+
     if (
       ITEMS_HIGHEST_LEVEL[id].count > maxItemCount &&
       !RETRIEVE_HISTORY.includes(id)
@@ -158,25 +174,33 @@ function retrievedBankItemToUpgrade() {
     }
   }
 
+  if (!desiredItemId) return;
+
   RETRIEVE_HISTORY.push(desiredItemId);
-  if (RETRIEVE_HISTORY.length >= Object.keys(ITEMS_HIGHEST_LEVEL).length - 1)
+  if (RETRIEVE_HISTORY.length >= Object.keys(ITEMS_HIGHEST_LEVEL).length / 2) {
     RETRIEVE_HISTORY.shift();
+  }
 
   let desiredItems = getItemBankSlots(desiredItemId);
-  desiredItems = desiredItems.splice(
-    0,
-    desiredItems.length -
-      (KEEP_THRESHOLD[ITEMS_HIGHEST_LEVEL[desiredItemId].type] ?? 2),
-  );
 
-  let inventoryEmptySlots = character.items.filter((item) => !item).length - 4;
+  // Respect keep threshold
+  const keep = KEEP_THRESHOLD[ITEMS_HIGHEST_LEVEL[desiredItemId].type] ?? 2;
+  desiredItems = desiredItems.slice(0, desiredItems.length - keep);
 
+  const info = item_info({ name: desiredItemId });
+  if (info.compound) {
+    desiredItems = filterCompoundableSets(desiredItems, inventoryEmptySlots);
+  }
+
+  const promises = [];
   for (const itemSlot of desiredItems) {
     if (inventoryEmptySlots <= 0) break;
-    else inventoryEmptySlots--;
+    inventoryEmptySlots--;
 
-    bank_retrieve(itemSlot.pack, itemSlot.slot);
+    promises.push(bank_retrieve(itemSlot.pack, itemSlot.slot));
   }
+
+  return withTimeout(Promise.allSettled(promises), 2500);
 }
 
 async function compoundInv() {
@@ -263,7 +287,6 @@ async function compoundInv() {
       if (
         character.mp > 200 &&
         !is_on_cooldown("massproductionpp") &&
-        character.items[i]?.level >= 4 &&
         !character.s.massproductionpp
       )
         use_skill("massproductionpp");
@@ -461,6 +484,7 @@ setInterval(async () => {
     close_stand();
     await smart_move(bankPosition);
     BANK_CACHE = character.bank;
+    const promises = [];
     character.items.forEach((item, index) => {
       if (!item) return;
       const isRareItem = item_grade(item) >= 2;
@@ -476,13 +500,13 @@ setInterval(async () => {
         ((!shouldItemBeIgnore &&
           (isRareItem || (isEquipable && isHighLevelItem))) ||
           isStoreable ||
-          RETRIEVE_HISTORY.includes(item.name) ||
-          Object.keys(ITEMS_HIGHEST_LEVEL).includes(item.name))
+          RETRIEVE_HISTORY.includes(item.name))
       )
-        bank_store(index);
+        promises.push(bank_store(index));
     });
+    await withTimeout(Promise.allSettled(promises), 2500);
     retrieveMaxItemsLevel();
-    retrievedBankItemToUpgrade();
+    await retrievedBankItemToUpgrade();
 
     if (parent.S.egghunt) {
       for (let index = 0; index < 9; index++) {

--- a/merchant_crafting.10.js
+++ b/merchant_crafting.10.js
@@ -47,7 +47,7 @@ async function retrieveBankItem(searchId, level = 0) {
   }
 
   for (const [bankPack, items] of Object.entries(character.bank).filter(
-    ([key, value]) => key !== "gold",
+    ([key, value]) => !["gold", "items9"].includes(key),
   )) {
     const slot = items.findIndex(
       (item) =>
@@ -465,7 +465,7 @@ setInterval(async () => {
       if (!item) return;
       const isRareItem = item_grade(item) >= 2;
       const isHighLevelItem =
-        item?.level >= (ITEMS_HIGHEST_LEVEL[item.name]?.level ?? 1) - 1;
+        item.level >= (ITEMS_HIGHEST_LEVEL[item.name]?.level ?? 1) - 1;
 
       const isStoreable = STORE_ABLE.includes(item.name);
       const isEquipable = item_info(item).compound || item_info(item).upgrade;
@@ -476,7 +476,8 @@ setInterval(async () => {
         ((!shouldItemBeIgnore &&
           (isRareItem || (isEquipable && isHighLevelItem))) ||
           isStoreable ||
-          RETRIEVE_HISTORY?.[RETRIEVE_HISTORY.length - 1] === item?.name)
+          RETRIEVE_HISTORY.includes(item.name) ||
+          Object.keys(ITEMS_HIGHEST_LEVEL).includes(item.name))
       )
         bank_store(index);
     });

--- a/merchant_service.19.js
+++ b/merchant_service.19.js
@@ -209,3 +209,7 @@ async function lureMechaGnome() {
     setTimeout(lureMechaGnome, success ? 4 * 60 * 1000 : 50);
   }
 }
+
+if (!parent.caracAL) {
+  lureMechaGnome();
+}

--- a/merchant_service.19.js
+++ b/merchant_service.19.js
@@ -161,9 +161,11 @@ async function lureMechaGnome() {
     isLuringMobs ||
     onDuty ||
     serverCurrentlyHasLiveEvent() ||
-    !parent.party_list ||
-    (!trustedPartners.some((name) => parent.party_list.includes(name)) &&
-      !parent.party_list.includes(PRIEST))
+    (!(
+      parent.party_list &&
+      trustedPartners.some((name) => parent.party_list.includes(name))
+    ) &&
+      !parent.caracAL.siblings.includes(PRIEST))
   ) {
     return setTimeout(lureMechaGnome, 500);
   }
@@ -183,6 +185,7 @@ async function lureMechaGnome() {
       (entity) =>
         entity && entity.type === "monster" && entity.mtype === "mechagnome",
     );
+
     if (!gnomesNearby.length) {
       nextDelay = 45_000;
       throw new Error("No mechagnome found");
@@ -193,7 +196,8 @@ async function lureMechaGnome() {
       if (!mageInfo) return false;
       return (
         mageInfo.mp >= G.skills["magiport"].mp + 100 &&
-        Date.now() - mageInfo.time < 15_000
+        Date.now() - mageInfo.time < 15_000 &&
+        distance(mageInfo, { map: map, x: mapX, y: mapY }) < 300
       );
     }, 10_000);
 

--- a/merchant_service.19.js
+++ b/merchant_service.19.js
@@ -157,11 +157,10 @@ var isLuringMobs = false;
 const trustedPartners = ["earthPriest", "earthWar"];
 
 async function lureMechaGnome() {
-  if (isLuringMobs || onDuty) {
-    return setTimeout(lureMechaGnome, 500);
-  }
-
   if (
+    isLuringMobs ||
+    onDuty ||
+    serverCurrentlyHasLiveEvent() ||
     !parent.party_list ||
     (!trustedPartners.some((name) => parent.party_list.includes(name)) &&
       !parent.party_list.includes(PRIEST))
@@ -185,9 +184,9 @@ async function lureMechaGnome() {
         entity && entity.type === "monster" && entity.mtype === "mechagnome",
     );
     if (!gnomesNearby.length) {
-      nextDelay = 45000;
+      nextDelay = 45_000;
       throw new Error("No mechagnome found");
-    } else nextDelay = 150000;
+    } else nextDelay = 150_000;
 
     const mageResponse = await waitUntil(() => {
       const mageInfo = get("mageLocation");
@@ -199,7 +198,7 @@ async function lureMechaGnome() {
     }, 10_000);
 
     if (!mageResponse) {
-      nextDelay = 15000;
+      nextDelay = 15_000;
       throw new Error("Mage did not have mana / not online");
     }
 

--- a/merchant_service.19.js
+++ b/merchant_service.19.js
@@ -158,7 +158,7 @@ const trustedPartners = ["earthPriest", "earthWar"];
 
 async function lureMechaGnome() {
   if (isLuringMobs || onDuty) {
-    return setTimeout(lureMechaGnome, 50);
+    return setTimeout(lureMechaGnome, 500);
   }
 
   if (
@@ -166,25 +166,28 @@ async function lureMechaGnome() {
     (!trustedPartners.some((name) => parent.party_list.includes(name)) &&
       !parent.party_list.includes(PRIEST))
   ) {
-    return setTimeout(lureMechaGnome, 50);
+    return setTimeout(lureMechaGnome, 500);
   }
 
   // Global flags to prevent other tasks from interrupting
   onDuty = true;
   isLuringMobs = true; // Prevent scareAwayMobs
 
-  let success = false;
+  let nextDelay = 500;
 
   try {
     close_stand();
     await smartMove({ map: "cyberland" });
     await sleep(character.ping);
 
-    if (!get_nearest_monster({ type: "mechagnome" })) {
+    const gnomesNearby = Object.values(parent.entities).filter(
+      (entity) =>
+        entity && entity.type === "monster" && entity.mtype === "mechagnome",
+    );
+    if (!gnomesNearby.length) {
+      nextDelay = 45000;
       throw new Error("No mechagnome found");
-    }
-
-    parent.socket.emit("eval", { command: "mooooooh" });
+    } else nextDelay = 150000;
 
     const mageResponse = await waitUntil(() => {
       const mageInfo = get("mageLocation");
@@ -196,17 +199,18 @@ async function lureMechaGnome() {
     }, 10_000);
 
     if (!mageResponse) {
+      nextDelay = 15000;
       throw new Error("Mage did not have mana / not online");
     }
 
+    parent.socket.emit("eval", { command: "mooooooh" });
     await advanceSmartMove(get("mageLocation"), { useScare: false });
-    success = true;
   } catch (e) {
     console.error(e);
   } finally {
     isLuringMobs = false;
     onDuty = false;
-    setTimeout(lureMechaGnome, success ? 4 * 60 * 1000 : 50);
+    setTimeout(lureMechaGnome, nextDelay);
   }
 }
 

--- a/merchant_service.19.js
+++ b/merchant_service.19.js
@@ -199,7 +199,7 @@ async function lureMechaGnome() {
       throw new Error("Mage did not have mana / not online");
     }
 
-    advanceSmartMove(get("mageLocation"), { useScare: false });
+    await advanceSmartMove(get("mageLocation"), { useScare: false });
     success = true;
   } catch (e) {
     console.error(e);

--- a/merchant_service.19.js
+++ b/merchant_service.19.js
@@ -14,7 +14,6 @@ character.on("cm", async function ({ name, message }) {
   } else return;
 
   equipBroom();
-  // const sender = get_characters().find(character => character.name === name);
 
   switch (message.msg) {
     case "inv_full":
@@ -152,4 +151,61 @@ async function openCryptInstance() {
 
   onDuty = false;
   return;
+}
+
+var isLuringMobs = false;
+const trustedPartners = ["earthPriest", "earthWar"];
+
+async function lureMechaGnome() {
+  if (isLuringMobs || onDuty) {
+    return setTimeout(lureMechaGnome, 50);
+  }
+
+  if (
+    !parent.party_list ||
+    (!trustedPartners.some((name) => parent.party_list.includes(name)) &&
+      !parent.party_list.includes(PRIEST))
+  ) {
+    return setTimeout(lureMechaGnome, 50);
+  }
+
+  // Global flags to prevent other tasks from interrupting
+  onDuty = true;
+  isLuringMobs = true; // Prevent scareAwayMobs
+
+  let success = false;
+
+  try {
+    close_stand();
+    await smartMove({ map: "cyberland" });
+    await sleep(character.ping);
+
+    if (!get_nearest_monster({ type: "mechagnome" })) {
+      throw new Error("No mechagnome found");
+    }
+
+    parent.socket.emit("eval", { command: "mooooooh" });
+
+    const mageResponse = await waitUntil(() => {
+      const mageInfo = get("mageLocation");
+      if (!mageInfo) return false;
+      return (
+        mageInfo.mp >= G.skills["magiport"].mp + 100 &&
+        Date.now() - mageInfo.time < 15_000
+      );
+    }, 10_000);
+
+    if (!mageResponse) {
+      throw new Error("Mage did not have mana / not online");
+    }
+
+    advanceSmartMove(get("mageLocation"), { useScare: false });
+    success = true;
+  } catch (e) {
+    console.error(e);
+  } finally {
+    isLuringMobs = false;
+    onDuty = false;
+    setTimeout(lureMechaGnome, success ? 4 * 60 * 1000 : 50);
+  }
 }

--- a/normal_strategy.12.js
+++ b/normal_strategy.12.js
@@ -45,7 +45,7 @@ async function useNormalStrategy(target) {
           (slot) => character.slots[slot]?.name !== suggestedRangerItems[slot],
         )
       ) {
-        promises.push(equipBatch(suggestedRangerItems));
+        promises.push(equipBatch(suggestedRangerItems, character.slots.mainhand?.name === "cupid"));
       }
       break;
 

--- a/other_class_msg_listener.8.js
+++ b/other_class_msg_listener.8.js
@@ -1,7 +1,12 @@
 // Other class message listener;
 
 character.on("cm", async function ({ name, message }) {
-  if (!partyMems.includes(name) && name !== partyMerchant) return;
+  if (
+    !partyMems.includes(name) &&
+    name !== partyMerchant &&
+    message !== "magiport"
+  )
+    return;
   switch (message.msg || message) {
     case "inv_full_merchant_near":
       log("The merchant is nearby, sending compoundable");
@@ -28,7 +33,7 @@ character.on("cm", async function ({ name, message }) {
           )
             return;
           await send_item(partyMerchant, index, 1000);
-        })
+        }),
       );
       // const compoundables = filterCompoundableAndStackable();
       // const others = Array.from({ length: 42 }, (_, i) => i + 0).filter(
@@ -63,7 +68,7 @@ character.on("cm", async function ({ name, message }) {
     case "party_heal":
       log(`Remotely heal ${name}!`);
       use_skill("partyheal").then(() =>
-        reduce_cooldown("partyheal", character.ping * 0.95)
+        reduce_cooldown("partyheal", character.ping * 0.95),
       );
       break;
 

--- a/pull_strategy.13.js
+++ b/pull_strategy.13.js
@@ -37,11 +37,8 @@ async function usePullStrategies(target) {
         getMonstersToCBurst().length >= 1
       ) {
         promises.push(
-          withTimeout(
-            use_skill("cburst", getMonstersToCBurst()).then(() =>
-              reduce_cooldown("cburst", -2000),
-            ),
-            2500,
+          use_skill("cburst", getMonstersToCBurst()).then(() =>
+            reduce_cooldown("cburst", -2000),
           ),
         );
       }
@@ -130,7 +127,11 @@ async function usePullStrategies(target) {
         !is_on_cooldown("agitate") &&
         // numberOfMonsterInRange <= MAX_TARGET + 2 &&
         !listOfNoTargetMonsterInRange.some(
-          (mob) => mob.cooperative && !partyMems.includes(mob.target),
+          (mob) =>
+            (mob.cooperative && !partyMems.includes(mob.target)) ||
+            parent.party_list
+              .filter((id) => !partyMems.includes(id))
+              .includes(mob.target),
         ) &&
         listOfNoTargetMonsterInRange.length >= 2 &&
         !listOfNoTargetMonsterInRange.some(
@@ -151,7 +152,7 @@ async function usePullStrategies(target) {
           healReceivableAmount - partyDmgRecieved &&
         !isFearedAfterAgitating
       ) {
-        promises.push(withTimeout(use_skill("agitate"), 2500));
+        promises.push(use_skill("agitate"));
       }
       if (
         partyDmgRecieved < healReceivableAmount &&
@@ -179,11 +180,8 @@ async function usePullStrategies(target) {
 
         if (mobToPull)
           promises.push(
-            withTimeout(
-              use_skill("taunt", parent.entities[mobToPull]).then(() =>
-                reduce_cooldown("taunt", character.ping * 0.95),
-              ),
-              2500,
+            use_skill("taunt", parent.entities[mobToPull]).then(() =>
+              reduce_cooldown("taunt", character.ping * 0.95),
             ),
           );
       }

--- a/pull_strategy.13.js
+++ b/pull_strategy.13.js
@@ -74,14 +74,17 @@ async function usePullStrategies(target) {
           MELEE_IGNORE_LIST.includes(mob.mtype),
       );
 
+      // Check if the character is already targeting enough mobs
       const havePulledEnoughMobs =
         mobsList.filter((mob) => mob.target === character.name).length >=
         MAX_TARGET;
 
+      // Monsters that are in range of 'agitate' but *not* currently targeting the character
       const listOfNoTargetMonsterInRange = mobsList.filter(
         (mob) => is_in_range(mob, "agitate") && mob.target !== character.name,
       );
 
+      // Count mobs targeting self
       const magicalMobsTargetingSelf = mobsList.filter(
         (mob) => mob.damage_type === "magical" && mob.target === character.name,
       );
@@ -93,10 +96,12 @@ async function usePullStrategies(target) {
         (mob) => mob.damage_type === "pure" && mob.target === character.name,
       );
 
+      // Initialize counters
       let magicalMobsAfterAgitating = magicalMobsTargetingSelf.length;
       let physicalMobsAfterAgitating = physicalMobsTargetingSelf.length;
       let pureMobsAfterAgitating = pureMobsTargetingSelf.length;
 
+      // Add counts for mobs that *will* target self after 'agitate'
       for (const mob of listOfNoTargetMonsterInRange) {
         switch (mob.damage_type) {
           case "magical":
@@ -113,60 +118,82 @@ async function usePullStrategies(target) {
         }
       }
 
+      // Check if the character would be feared after the new mobs are pulled (based on courage stats)
       const isFearedAfterAgitating =
         magicalMobsAfterAgitating > character.mcourage ||
         physicalMobsAfterAgitating > character.courage ||
         pureMobsAfterAgitating > character.pcourage;
 
+      // Calculate average party damage taken
       const partyDmgRecieved = avgPartyDmgTaken(partyMems);
 
-      if (
+      // Basic Requirements
+      const canUseAgitate =
         !havePulledEnoughMobs &&
         !formidableMonsterAppeared &&
-        character.mp > G.skills["agitate"].mp &&
-        !is_on_cooldown("agitate") &&
-        // numberOfMonsterInRange <= MAX_TARGET + 2 &&
-        !listOfNoTargetMonsterInRange.some(
-          (mob) =>
-            (mob.cooperative && !partyMems.includes(mob.target)) ||
-            parent.party_list
-              .filter((id) => !partyMems.includes(id))
-              .includes(mob.target),
-        ) &&
-        listOfNoTargetMonsterInRange.length >= 2 &&
-        !listOfNoTargetMonsterInRange.some(
-          (mob) =>
-            MELEE_IGNORE_LIST.includes(mob.mtype) ||
-            WATCHOUT_ABILITIES.some((skill) =>
-              Object.keys(mob.abilities ?? {}).includes(skill),
-            ),
-        ) &&
-        Object.values(parent.entities)
-          .filter(
-            (entity) =>
-              entity.type === "monster" &&
-              is_in_range(entity, "agitate") &&
-              entity.target !== character,
-          )
-          .reduce((prev, curr) => prev + calculateDamage(curr, character), 0) <
-          healReceivableAmount - partyDmgRecieved &&
-        !isFearedAfterAgitating
+        character.mp >= G.skills["agitate"].mp &&
+        !is_on_cooldown("agitate");
+
+      // Mob Quantity Requirement
+      const sufficientNoTargetMobs = listOfNoTargetMonsterInRange.length >= 2;
+
+      // Mob Safety Check: No bad mobs in the list
+      const safeToAgitateMobs = !listOfNoTargetMonsterInRange.some(
+        (mob) =>
+          MELEE_IGNORE_LIST.includes(mob.mtype) ||
+          WATCHOUT_ABILITIES.some((skill) =>
+            Object.keys(mob.abilities ?? {}).includes(skill),
+          ),
+      );
+
+      // Mob Target Check: Agitate won't steal from others or cooperative mobs
+      const wontStealOrBreakCoop = !listOfNoTargetMonsterInRange.some(
+        (mob) =>
+          (mob.cooperative && // Cooperative mob
+            !mob["1hp"] && // Is not a 1HP cooperative mob (maybe ignored?)
+            !partyMems.includes(mob.target)) || // And its target is not one of my character
+          parent.party_list
+            .filter((id) => !partyMems.includes(id))
+            .includes(mob.target), // OR its target is other player in the party
+      );
+
+      // Fear Check
+      const willNotBeFeared = !isFearedAfterAgitating;
+
+      // Damage Check
+      const currentAggroDamage = Object.values(parent.entities)
+        .filter(
+          (entity) =>
+            entity.type === "monster" &&
+            is_in_range(entity, "agitate") &&
+            !partyMems.includes(entity.target),
+        )
+        .reduce((prev, curr) => prev + calculateDamage(curr, character), 0);
+
+      const damageIsAcceptable =
+        currentAggroDamage < healReceivableAmount - partyDmgRecieved;
+
+      if (
+        canUseAgitate &&
+        sufficientNoTargetMobs &&
+        safeToAgitateMobs &&
+        wontStealOrBreakCoop &&
+        willNotBeFeared &&
+        damageIsAcceptable
       ) {
         promises.push(use_skill("agitate"));
       }
+
       if (
         partyDmgRecieved < healReceivableAmount &&
         !havePulledEnoughMobs &&
         character.mp > G.skills["taunt"].mp &&
-        !is_on_cooldown("taunt")
+        !is_on_cooldown("taunt") && isAssignedAsTanker()
       ) {
         const mobToPull = mobsList.find(
           (mob) =>
             calculateDamage(mob, character) < 4000 &&
             is_in_range(mob, "taunt") &&
-            !WATCHOUT_ABILITIES.some((skill) =>
-              Object.keys(mob.abilities ?? {}).includes(skill),
-            ) &&
             (!mob.target ||
               partyMems
                 .filter((id) => id !== character.name)

--- a/pull_strategy.13.js
+++ b/pull_strategy.13.js
@@ -192,7 +192,10 @@ async function usePullStrategies(target) {
         isAssignedAsTanker()
       ) {
         const mobToPull = mobsList
-          .sort((lhs, rhs) => rhs.attack * rhs.frequency - lhs.attack * lhs.frequency)
+          .sort(
+            (lhs, rhs) =>
+              rhs.attack * rhs.frequency - lhs.attack * lhs.frequency,
+          )
           .find(
             (mob) =>
               calculateDamage(mob, character) + partyDmgRecieved <
@@ -231,7 +234,10 @@ async function usePullStrategies(target) {
       break;
 
     case "ranger":
-      const suggestedRangerItems = calculateRangerItems(target);
+      const suggestedRangerItems = calculateRangerItems(
+        target,
+        character.slots.mainhand?.name === "cupid",
+      );
 
       if (
         Object.keys(suggestedRangerItems).some(

--- a/pull_strategy.13.js
+++ b/pull_strategy.13.js
@@ -3,12 +3,11 @@ async function usePullStrategies(target) {
   const healerPower = partyHealer?.heal || partyHealer?.attack || 0;
   const healerFreq = partyHealer?.frequency || 1;
   const healReceivableAmount =
-    healerPower * 0.925 * healerFreq +
+    healerPower * healerFreq +
     (parent.entities["$Caroline"]?.focus &&
     distance(parent.entities["$Caroline"], character) < 250
       ? 1200
       : 0);
-  const partyTanker = get_entity(TANKER);
   const mobsList = Object.values(parent.entities).filter(
     (mob) => mob.type === "monster",
   );

--- a/pull_strategy.13.js
+++ b/pull_strategy.13.js
@@ -69,7 +69,7 @@ async function usePullStrategies(target) {
 
       const formidableMonsterAppeared = mobsList.find(
         (mob) =>
-          mob.attack * mob.frequency > MAX_MOB_DPS ||
+          calculateDamage(mob, character) > MAX_MOB_DPS ||
           MELEE_IGNORE_LIST.includes(mob.mtype),
       );
 
@@ -148,12 +148,12 @@ async function usePullStrategies(target) {
       // Mob Target Check: Agitate won't steal from others or cooperative mobs
       const wontStealOrBreakCoop = !listOfNoTargetMonsterInRange.some(
         (mob) =>
-          (mob.cooperative && // Cooperative mob
-            !mob["1hp"] && // Is not a 1HP cooperative mob (maybe ignored?)
-            !partyMems.includes(mob.target)) || // And its target is not one of my character
-          parent.party_list
-            .filter((id) => !partyMems.includes(id))
-            .includes(mob.target), // OR its target is other player in the party
+          mob.cooperative &&
+          !mob["1hp"] &&
+          (!partyMems.includes(mob.target) ||
+            parent.party_list
+              .filter((id) => !partyMems.includes(id))
+              .includes(mob.target)),
       );
 
       // Fear Check

--- a/pull_strategy.13.js
+++ b/pull_strategy.13.js
@@ -188,26 +188,30 @@ async function usePullStrategies(target) {
         partyDmgRecieved < healReceivableAmount &&
         !havePulledEnoughMobs &&
         character.mp > G.skills["taunt"].mp &&
-        !is_on_cooldown("taunt") && isAssignedAsTanker()
+        !is_on_cooldown("taunt") &&
+        isAssignedAsTanker()
       ) {
-        const mobToPull = mobsList.find(
-          (mob) =>
-            calculateDamage(mob, character) < 4000 &&
-            is_in_range(mob, "taunt") &&
-            (!mob.target ||
-              partyMems
-                .filter((id) => id !== character.name)
-                .includes(mob.target)) &&
-            (mob.damage_type === "physical"
-              ? physicalMobsTargetingSelf.length < character.courage
-              : mob.damage_type === "magical"
-              ? magicalMobsTargetingSelf.length < character.mcourage
-              : pureMobsTargetingSelf.length < character.pcourage),
-        );
+        const mobToPull = mobsList
+          .sort((lhs, rhs) => rhs.attack * rhs.frequency - lhs.attack * lhs.frequency)
+          .find(
+            (mob) =>
+              calculateDamage(mob, character) + partyDmgRecieved <
+                healReceivableAmount &&
+              is_in_range(mob, "taunt") &&
+              (!mob.target ||
+                partyMems
+                  .filter((id) => id !== character.name)
+                  .includes(mob.target)) &&
+              (mob.damage_type === "physical"
+                ? physicalMobsTargetingSelf.length < character.courage
+                : mob.damage_type === "magical"
+                ? magicalMobsTargetingSelf.length < character.mcourage
+                : pureMobsTargetingSelf.length < character.pcourage),
+          );
 
         if (mobToPull)
           promises.push(
-            use_skill("taunt", parent.entities[mobToPull]).then(() =>
+            use_skill("taunt", mobToPull).then(() =>
               reduce_cooldown("taunt", character.ping * 0.95),
             ),
           );

--- a/server_hop.14.js
+++ b/server_hop.14.js
@@ -3,8 +3,8 @@ const HOP_SERVERS = ["US", "ASIA", "EU"];
 const ignoreServer = [];
 
 const HOME_SERVER = {
-  serverRegion: "US",
-  serverIdentifier: "III",
+  serverRegion: "ASIA",
+  serverIdentifier: "I",
 };
 
 const tankableBoss = ["snowman", "pinkgoo"];

--- a/server_hop.14.js
+++ b/server_hop.14.js
@@ -4,13 +4,13 @@ const ignoreServer = [];
 
 const HOME_SERVER = {
   serverRegion: "US",
-  serverIdentifier: "II",
+  serverIdentifier: "III",
 };
 
 const tankableBoss = ["snowman", "pinkgoo"];
 
 const bosses = {
-  grinch: { type: "grinch", threshold: 0.425, hoppable: 1 },
+  grinch: { type: "grinch", threshold: 0.7, hoppable: 1 },
   icegolem: { type: "icegolem", threshold: 0.7, hoppable: 0.999 },
   franky: { type: "franky", threshold: 0.7, hoppable: 0.965 },
   mrpumpkin: { type: "mrpumpkin", threshold: 0.3, hoppable: 0.9999 },

--- a/server_hop.14.js
+++ b/server_hop.14.js
@@ -3,13 +3,14 @@ const HOP_SERVERS = ["US", "ASIA", "EU"];
 const ignoreServer = [];
 
 const HOME_SERVER = {
-  serverRegion: "EU",
+  serverRegion: "US",
   serverIdentifier: "II",
 };
 
 const tankableBoss = ["snowman", "pinkgoo"];
 
 const bosses = {
+  grinch: { type: "grinch", threshold: 0.425, hoppable: 1 },
   icegolem: { type: "icegolem", threshold: 0.7, hoppable: 0.999 },
   franky: { type: "franky", threshold: 0.7, hoppable: 0.965 },
   mrpumpkin: { type: "mrpumpkin", threshold: 0.3, hoppable: 0.9999 },
@@ -53,7 +54,7 @@ setInterval(async () => {
     Object.keys(bosses).some(
       (boss) =>
         parent.S[boss] &&
-        parent.S[boss].target &&
+        (parent.S[boss].target || bosses[boss].hoppable === 1) &&
         parent.S[boss].hp <
           (bosses[boss]?.threshold ?? 0.93) * parent.S[boss].max_hp,
     ) ||
@@ -79,6 +80,16 @@ setInterval(async () => {
 
     const data = await response.json();
 
+    if (parent.S.grinch?.live && data.constructor === Array) {
+      data.push({
+        ...parent.S.grinch,
+        id: 1,
+        type: "grinch",
+        serverIdentifier: server.id,
+        serverRegion: server.region,
+      });
+    }
+
     if (!data) return;
 
     const hopAbleServers = data
@@ -100,7 +111,13 @@ setInterval(async () => {
         );
       })
       .sort((lhs, rhs) => {
-        // const bossPriority = [...tankableBoss, ...Object.keys(bosses)];
+        const lhsIsTankable = tankableBoss.includes(lhs.type);
+        const rhsIsTankable = tankableBoss.includes(rhs.type);
+
+        if (lhsIsTankable !== rhsIsTankable) {
+          return rhsIsTankable - lhsIsTankable;
+        }
+
         return (
           lhs.hp / G.monsters[lhs.type].hp - rhs.hp / G.monsters[rhs.type].hp
         );
@@ -113,11 +130,18 @@ setInterval(async () => {
       });
 
     if (hopAbleServers && hopAbleServers.length) {
+      console.log(
+        hopAbleServers.map(
+          (server) =>
+            `${server.serverRegion}${server.serverIdentifier} ${server.type} ${server.hp}`,
+        ),
+      );
       const toServer = hopAbleServers.shift();
       if (
         `${toServer.serverRegion}${toServer.serverIdentifier}` !== currentServer
       ) {
         log(`Hopping to ${toServer.serverRegion}${toServer.serverIdentifier}`);
+        set("currentParty", undefined);
         await hopToServer(toServer.serverRegion, toServer.serverIdentifier);
       }
       return true;
@@ -125,6 +149,7 @@ setInterval(async () => {
 
     if (currentServer !== getHomeServer()) {
       log("Hopping back home server!");
+      set("currentParty", undefined);
       await hopToServer(HOME_SERVER.serverRegion, HOME_SERVER.serverIdentifier);
     }
 

--- a/server_hop.14.js
+++ b/server_hop.14.js
@@ -85,11 +85,22 @@ setInterval(async () => {
 
     const data = await response.json();
 
+    // Way around to add bosses that are flickering and bugged in the API
     if (parent.S.grinch?.live && data.constructor === Array) {
       data.push({
         ...parent.S.grinch,
         id: 1,
         type: "grinch",
+        serverIdentifier: server.id,
+        serverRegion: server.region,
+      });
+    }
+
+    if (parent.S.pinkgoo?.live && data.constructor === Array) {
+      data.push({
+        ...parent.S.pinkgoo,
+        id: 1,
+        type: "pinkgoo",
         serverIdentifier: server.id,
         serverRegion: server.region,
       });

--- a/server_hop.14.js
+++ b/server_hop.14.js
@@ -16,8 +16,8 @@ const bosses = {
   mrpumpkin: { type: "mrpumpkin", threshold: 0.3, hoppable: 0.9999 },
   mrgreen: { type: "mrgreen", threshold: 0.3, hoppable: 0.9999 },
   crabxx: { type: "crabxx", threshold: 0.95, hoppable: 0.9999 },
-  dragold: { type: "dragold", threshold: 0.5, hoppable: 1 },
-  pinkgoo: { type: "pinkgoo", threshold: 0.5, hoppable: 0.99 },
+  dragold: { type: "dragold", threshold: 0.85, hoppable: 1 },
+  pinkgoo: { type: "pinkgoo", threshold: 0.65, hoppable: 0.99 },
 };
 const waitForEvent = ["wabbit"];
 

--- a/server_hop.14.js
+++ b/server_hop.14.js
@@ -11,7 +11,7 @@ const tankableBoss = ["snowman"];
 
 const bosses = {
   grinch: { type: "grinch", threshold: 0.7, hoppable: 1 },
-  icegolem: { type: "icegolem", threshold: 0.7, hoppable: 0.999 },
+  icegolem: { type: "icegolem", threshold: 0.7, hoppable: 1 },
   franky: { type: "franky", threshold: 0.7, hoppable: 0.965 },
   mrpumpkin: { type: "mrpumpkin", threshold: 0.3, hoppable: 0.9999 },
   mrgreen: { type: "mrgreen", threshold: 0.3, hoppable: 0.9999 },

--- a/server_hop.14.js
+++ b/server_hop.14.js
@@ -17,7 +17,7 @@ const bosses = {
   mrgreen: { type: "mrgreen", threshold: 0.3, hoppable: 0.9999 },
   crabxx: { type: "crabxx", threshold: 0.95, hoppable: 0.9999 },
   dragold: { type: "dragold", threshold: 0.85, hoppable: 1 },
-  pinkgoo: { type: "pinkgoo", threshold: 0.65, hoppable: 0.99 },
+  pinkgoo: { type: "pinkgoo", threshold: 0.65, hoppable: 1 },
 };
 const waitForEvent = ["wabbit"];
 

--- a/server_hop.14.js
+++ b/server_hop.14.js
@@ -3,8 +3,8 @@ const HOP_SERVERS = ["US", "ASIA", "EU"];
 const ignoreServer = [];
 
 const HOME_SERVER = {
-  serverRegion: "ASIA",
-  serverIdentifier: "I",
+  serverRegion: "US",
+  serverIdentifier: "III",
 };
 
 const tankableBoss = ["snowman", "pinkgoo"];

--- a/server_hop.14.js
+++ b/server_hop.14.js
@@ -7,7 +7,7 @@ const HOME_SERVER = {
   serverIdentifier: "II",
 };
 
-const tankableBoss = ["snowman", "pinkgoo"];
+const tankableBoss = ["snowman"];
 
 const bosses = {
   grinch: { type: "grinch", threshold: 0.7, hoppable: 1 },
@@ -17,6 +17,7 @@ const bosses = {
   mrgreen: { type: "mrgreen", threshold: 0.3, hoppable: 0.9999 },
   crabxx: { type: "crabxx", threshold: 0.95, hoppable: 0.9999 },
   dragold: { type: "dragold", threshold: 0.5, hoppable: 1 },
+  pinkgoo: { type: "pinkgoo", threshold: 0.5, hoppable: 0.99 },
 };
 const waitForEvent = ["wabbit"];
 

--- a/server_hop.14.js
+++ b/server_hop.14.js
@@ -57,7 +57,9 @@ setInterval(async () => {
     Object.keys(bosses).some(
       (boss) =>
         parent.S[boss] &&
-        (parent.S[boss].target || bosses[boss].hoppable === 1) &&
+        (parent.S[boss].target ||
+          bosses[boss].hoppable === 1 ||
+          ["pinkgoo"].includes(bosses[boss].type)) &&
         parent.S[boss].hp <
           (bosses[boss]?.threshold ?? 0.93) * parent.S[boss].max_hp,
     ) ||

--- a/server_hop.14.js
+++ b/server_hop.14.js
@@ -4,7 +4,7 @@ const ignoreServer = [];
 
 const HOME_SERVER = {
   serverRegion: "US",
-  serverIdentifier: "III",
+  serverIdentifier: "II",
 };
 
 const tankableBoss = ["snowman", "pinkgoo"];

--- a/server_hop.14.js
+++ b/server_hop.14.js
@@ -16,7 +16,7 @@ const bosses = {
   mrpumpkin: { type: "mrpumpkin", threshold: 0.3, hoppable: 0.9999 },
   mrgreen: { type: "mrgreen", threshold: 0.3, hoppable: 0.9999 },
   crabxx: { type: "crabxx", threshold: 0.95, hoppable: 0.9999 },
-  dragold: { type: "dragold", threshold: 0.99, hoppable: 1 },
+  dragold: { type: "dragold", threshold: 0.5, hoppable: 1 },
 };
 const waitForEvent = ["wabbit"];
 

--- a/server_hop.14.js
+++ b/server_hop.14.js
@@ -15,7 +15,7 @@ const bosses = {
   franky: { type: "franky", threshold: 0.7, hoppable: 0.965 },
   mrpumpkin: { type: "mrpumpkin", threshold: 0.3, hoppable: 0.9999 },
   mrgreen: { type: "mrgreen", threshold: 0.3, hoppable: 0.9999 },
-  crabxx: { type: "crabxx", threshold: 0.95, hoppable: 0.9999 },
+  crabxx: { type: "crabxx", threshold: 0.95, hoppable: 1 },
   dragold: { type: "dragold", threshold: 0.85, hoppable: 1 },
   pinkgoo: { type: "pinkgoo", threshold: 0.65, hoppable: 1 },
 };

--- a/server_hop.14.js
+++ b/server_hop.14.js
@@ -29,6 +29,8 @@ const currentServer = `${server.region}${server.id}`;
 const getHomeServer = () =>
   `${HOME_SERVER.serverRegion}${HOME_SERVER.serverIdentifier}`;
 
+const isAtHomeServer = () => currentServer === getHomeServer();
+
 async function hopToServer(serverRegion, serverIdentifier) {
   if (parent.caracAL) {
     parent.caracAL.siblings.forEach((id) => send_cm(id, "loot-before-hopping"));
@@ -147,7 +149,7 @@ setInterval(async () => {
       return true;
     }
 
-    if (currentServer !== getHomeServer()) {
+    if (!isAtHomeServer()) {
       log("Hopping back home server!");
       set("currentParty", undefined);
       await hopToServer(HOME_SERVER.serverRegion, HOME_SERVER.serverIdentifier);

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -1010,6 +1010,6 @@ async function useTemporalSurge() {
 }
 
 // Surge loop
-setInterval(() => {
-  useTemporalSurge();
+setInterval(async () => {
+  await useTemporalSurge();
 }, 1000);

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -118,8 +118,10 @@ function calculateWarriorItems() {
   const shouldUseBlaster =
     numberOfMonsterAroundTarget(currentTarget) >= 2 && !currentTarget["1hp"];
 
-  const haveLowHpMobsNearby = shouldWearLuckGear();
-  const isTanker = isAssignedAsTanker();
+  const feelingLucky = shouldWearLuckGear();
+  const feelingWise = shouldWearExpGear();
+  const isTanker =
+    isAssignedAsTanker() && avgDmgTaken(character, "physical") > 300;
 
   if (
     currentTarget &&
@@ -135,7 +137,7 @@ function calculateWarriorItems() {
     };
 
   return {
-    helmet: haveLowHpMobsNearby
+    helmet: feelingLucky
       ? "oxhelmet"
       : character.map === "crypt"
       ? "xhelmet"
@@ -151,12 +153,12 @@ function calculateWarriorItems() {
         Object.values(parent.entities).some(
           (mob) => mob.target === character.name && mob.mtype === "a2",
         )) ||
-      haveLowHpMobsNearby
+      feelingLucky
         ? "mshield"
         : currentStrategy === usePullStrategies && shouldUseBlaster
         ? "ololipop"
         : "fireblade",
-    amulet: haveLowHpMobsNearby
+    amulet: feelingLucky
       ? "spookyamulet"
       : (isTanker &&
           Object.values(parent.entities)
@@ -165,8 +167,12 @@ function calculateWarriorItems() {
         character.map === "crypt"
       ? "snring"
       : "stramulet",
-    orb: haveLowHpMobsNearby ? "rabbitsfoot" : "orbofstr",
-    chest: haveLowHpMobsNearby
+    orb: feelingLucky
+      ? "rabbitsfoot"
+      : feelingWise
+      ? "talkingskull"
+      : "orbofstr",
+    chest: feelingLucky
       ? "cdragon"
       : character.map === "crypt"
       ? "xarmor"
@@ -185,7 +191,8 @@ const RANGER_INV_ITEMS = {
 function calculateRangerItems(target) {
   // Sanitize input
   const targets = !target ? [] : Array.isArray(target) ? target : [target];
-  const haveLowHpMobsNearby = shouldWearLuckGear();
+  const feelingLucky = shouldWearLuckGear();
+  const feelingWise = shouldWearExpGear();
   const someTargetCooperative = targets.some((mob) => mob.cooperative);
 
   // Start with current mainhand
@@ -200,10 +207,11 @@ function calculateRangerItems(target) {
       currentStrategy === usePullStrategies &&
       targets.some(
         (mob) =>
-          numberOfMonsterAroundTarget(
-            mob,
-            character.explosion / 3.6 ?? BLAST_RADIUS,
-          ) > 1,
+          (mob.cluster_count ??
+            numberOfMonsterAroundTarget(
+              mob,
+              character.explosion / 3.6 || BLAST_RADIUS,
+            )) > 1,
       )
     ) {
       mainhand = RANGER_INV_ITEMS.poucher;
@@ -279,10 +287,14 @@ function calculateRangerItems(target) {
   return {
     helmet: "wcap",
     mainhand,
-    orb: haveLowHpMobsNearby ? "rabbitsfoot" : "orbofdex",
-    amulet: haveLowHpMobsNearby ? "spookyamulet" : "dexamulet",
-    shoes: haveLowHpMobsNearby ? "wshoes" : "wingedboots",
-    gloves: haveLowHpMobsNearby ? "wgloves" : "mittens",
+    orb: feelingLucky
+      ? "rabbitsfoot"
+      : feelingWise
+      ? "talkingskull"
+      : "orbofdex",
+    amulet: feelingWise ? "spookyamulet" : "dexamulet",
+    shoes: feelingLucky ? "wshoes" : "wingedboots",
+    gloves: feelingLucky ? "wgloves" : "mittens",
   };
 }
 
@@ -460,19 +472,28 @@ function findMaxLevelItem(id, offset = 0) {
 
 var isEquipingItems = false;
 async function equipBatch(suggestedItems, forced = false) {
-  if ((character.cc > 130 || isEquipingItems) && !forced) return;
+  if (
+    (character.cc > 130 ||
+      isEquipingItems ||
+      character.s.penalty_cd ||
+      isLooting) &&
+    !forced
+  )
+    return false;
 
   isEquipingItems = true;
 
   const promises = [];
-
   const currentBooster = findInvBooster();
 
-  if (!isLooting && currentBooster) {
-    if (
-      (get_targeted_monster()?.cooperative &&
-        currentBooster !== "luckbooster") ||
-      TANKER === character.name
+  if ((!isLooting && currentBooster) || forced) {
+    if (suggestedItems.booster && currentBooster !== suggestedItems.booster) {
+      promises.push(shift(locate_item(currentBooster), suggestedItems.booster));
+      delete suggestedItems.booster;
+    } else if (
+      currentBooster !== "luckbooster" &&
+      (get_target()?.cooperative ||
+        (isAssignedAsTanker() && avgDmgTaken(character) > 300))
     ) {
       promises.push(shift(locate_item(currentBooster), "luckbooster"));
     } else if (currentBooster !== "xpbooster") {

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -225,7 +225,8 @@ const STUN_FOCUS_LIST = ["crabxx", "grinch"];
 function calculateWarriorItems() {
   const currentTarget = get_target();
   const shouldUseBlaster =
-    numberOfMonsterAroundTarget(currentTarget) >= TARGET_TO_SWITCH_TO_BLASTER_WEAPON && !currentTarget["1hp"];
+    numberOfMonsterAroundTarget(currentTarget) >=
+      TARGET_TO_SWITCH_TO_BLASTER_WEAPON && !currentTarget["1hp"];
 
   const feelingLucky = shouldWearLuckGear();
   const feelingWise = shouldWearExpGear();
@@ -652,13 +653,18 @@ async function equipBatch(suggestedItems, forced = false) {
     itemSlots.splice(maxItemsToEquip);
   }
 
-  if (itemSlots.length)
+  if (itemSlots.length) {
     if (itemSlots.length <= 1)
       for (const item of itemSlots) promises.push(equip(item.num, item.slot));
     else promises.push(equip_batch(itemSlots));
-  return Promise.all(promises).finally(() => {
+    return Promise.all(promises).finally(() => {
+      isEquipingItems = false;
+    });
+  }
+  else {
     isEquipingItems = false;
-  });
+    return false;
+  }
 }
 
 // Utilities

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -141,7 +141,7 @@ function shouldWearLuckGear() {
       !mob.dead &&
       mob.hp > 0 &&
       (mob.target === character.name || mob.cooperative) &&
-      mob.hp <= Math.min(mob.max_hp * 0.15, 300000),
+      (mob.hp <= Math.min(mob.max_hp * 0.15, 300000) || mob.max_hp < calculateDamage(character, mob, false) * 2),
   );
 }
 
@@ -153,7 +153,7 @@ function shouldWearExpGear() {
       !mob.dead &&
       mob.hp > 0 &&
       (parent.party_list.includes(mob.target) || mob.cooperative) &&
-      mob.hp <= Math.min(mob.max_hp * 0.1, 300000),
+      mob.hp <= Math.min(mob.max_hp * 0.1, 300000) && mob.max_hp > calculateDamage(character, mob, false) * 2,
   );
 }
 

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -648,7 +648,9 @@ async function equipBatch(suggestedItems, forced = false) {
   if (
     (character.cc > 130 ||
       isEquipingItems ||
-      // character.s.penalty_cd ||
+      (character.s.penalty_cd &&
+        character.s.penalty_cd.ms >
+          (ms_to_next_skill("attack") ?? 1000 / character.frequency)) ||
       isLooting) &&
     !forced
   )

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -601,11 +601,7 @@ async function equipBatch(suggestedItems, forced = false) {
     if (suggestedItems.booster && currentBooster !== suggestedItems.booster) {
       promises.push(shift(locate_item(currentBooster), suggestedItems.booster));
       delete suggestedItems.booster;
-    } else if (
-      currentBooster !== "luckbooster" &&
-      (get_target()?.cooperative ||
-        (isAssignedAsTanker() && avgDmgTaken(character) > 300))
-    ) {
+    } else if (currentBooster !== "luckbooster" && shouldWearLuckGear()) {
       promises.push(shift(locate_item(currentBooster), "luckbooster"));
     } else if (currentBooster !== "xpbooster") {
       promises.push(shift(locate_item(currentBooster), "xpbooster"));

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -950,6 +950,7 @@ function shouldAttack(target = get_target()) {
 }
 
 // New Temporal Surge Logic
+// New Temporal Surge Logic
 async function useTemporalSurge() {
   if (
     is_on_cooldown("temporalsurge") ||
@@ -965,7 +966,7 @@ async function useTemporalSurge() {
   }
 
   const currentMap = character.map;
-  const temporalsurgeRange = G.skills["temporalsurge"].range;
+  const temporalsurgeRange = 160;
 
   const isSpawnInRange = (boundary) => {
     let map, x1, y1, x2, y2;
@@ -976,6 +977,18 @@ async function useTemporalSurge() {
     } else {
       [x1, y1, x2, y2] = boundary;
     }
+
+    console.log(
+      "Distance with spawn boundary:",
+      { x1, y1, x2, y2 },
+      distance(character, {
+        map: currentMap,
+        x: (x1 + x2) / 2,
+        y: (y1 + y2) / 2,
+        awidth: Math.abs(x2 - x1),
+        aheight: Math.abs(y2 - y1),
+      }),
+    );
 
     return (
       distance(character, {
@@ -989,9 +1002,11 @@ async function useTemporalSurge() {
   };
 
   const nearbySpawn = parent.G.maps[currentMap].monsters.filter((spawn) => {
-    if (spawn.boundaries) {
+    if (Array.isArray(spawn.boundaries) && spawn.boundaries.length > 0) {
       return spawn.boundaries.some((boundary) => isSpawnInRange(boundary));
-    } else {
+    }
+
+    if (spawn.boundary) {
       return isSpawnInRange(spawn.boundary);
     }
   });
@@ -1001,7 +1016,7 @@ async function useTemporalSurge() {
   );
 
   const promises = [];
-
+  console.log(nearbySpawn.length, nearbySpawnWithSpawnMechanic.length);
   if (nearbySpawn.length && nearbySpawnWithSpawnMechanic.length === 0) {
     if (character.slots.orb?.name !== "orboftemporal") {
       promises.push(equipBatch({ orb: "orboftemporal" }, true));

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -859,11 +859,11 @@ function rotateLeader(partyList, newLeaderId) {
 function assignRoles() {
   if (partyMems.includes(WARRIOR) && partyMems.includes(HEALER)) {
     const partyDmgTaken = avgPartyDmgTaken(partyMems);
-    const partyMagicalDmgTaken = avgPartyDmgTaken(partyMems, "magical");
+    const partyMagicalDmgTaken = avgPartyDmgTaken(partyMems, "physical");
 
     // If more than half of taken DMG is magical, set our HEALER to be TANKER
-    const magicDmgRatio = partyMagicalDmgTaken / partyDmgTaken;
-    TANKER = magicDmgRatio > 0.5 ? HEALER : WARRIOR;
+    const physicalDmgRatio = partyMagicalDmgTaken / partyDmgTaken;
+    TANKER = physicalDmgRatio <= 0.5 ? HEALER : WARRIOR;
     partyMems = rotateLeader(partyMems, TANKER);
   }
 }

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -338,7 +338,6 @@ function chooseFireOrPouchForSplashing(targets) {
       ? item_info(character.items[pouchbowSlot])
       : undefined;
 
-  console.warn(fireInfo.explosion_delta, pouchInfo.explosion_delta);
   if (!pouchInfo) return RANGER_INV_ITEMS.fireBow;
   if (!fireInfo) return RANGER_INV_ITEMS.poucher;
 
@@ -352,6 +351,8 @@ function chooseFireOrPouchForSplashing(targets) {
 
   const fireScore = explosionScore(fireInfo, targets);
   const pouchScore = explosionScore(pouchInfo, targets);
+  console.warn(pouchInfo.explosion_delta, fireInfo.explosion_delta);
+  console.warn(`Pouch Score: ${pouchScore}, Fire Score: ${fireScore}`);
 
   return pouchScore > fireScore
     ? RANGER_INV_ITEMS.poucher

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -352,8 +352,6 @@ function chooseFireOrPouchForSplashing(targets) {
 
   const fireScore = explosionScore(fireInfo, targets);
   const pouchScore = explosionScore(pouchInfo, targets);
-  console.warn(pouchInfo.explosion_delta, fireInfo.explosion_delta);
-  console.warn(`Pouch Score: ${pouchScore}, Fire Score: ${fireScore}`);
 
   return pouchScore > fireScore
     ? RANGER_INV_ITEMS.poucher

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -639,6 +639,19 @@ async function equipBatch(suggestedItems, forced = false) {
       return { slot, num };
     })
     .filter((equipInfo) => equipInfo.num >= 0);
+
+  // Slice items to fit with penalty_cd & frequency
+  const msToNextAttack = ms_to_next_skill("attack");
+  const timeToNextAttack =
+    msToNextAttack === 0 ? 1000 / character.frequency : msToNextAttack;
+  const maxItemsToEquip = Math.max(
+    0,
+    Math.floor((timeToNextAttack - (character.s.penalty_cd?.ms ?? 0)) / 120),
+  );
+  if (itemSlots.length > maxItemsToEquip && !forced) {
+    itemSlots.splice(maxItemsToEquip);
+  }
+
   if (itemSlots.length)
     if (itemSlots.length <= 1)
       for (const item of itemSlots) promises.push(equip(item.num, item.slot));

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -353,6 +353,7 @@ function calculateRangerItems(target) {
             name: item.name,
             info,
             attackDelta: info.attack - currentInfo.attack,
+            rangeDelta: info.range - (currentInfo.range || 0),
           };
         })
         .filter(Boolean);
@@ -368,16 +369,19 @@ function calculateRangerItems(target) {
             name: current.name,
             info,
             attackDelta: 0,
+            rangeDelta: 0,
           });
         }
       }
 
-      // Sort by smallest upgrade first (asc)
       rangedWeapons.sort((lhs, rhs) => {
         if (lhs.info.wtype !== rhs.info.wtype) {
           return lhs.info.wtype === "crossbow" ? 1 : -1;
         }
-        return lhs.attackDelta - rhs.attackDelta;
+
+        return (
+          rhs.rangeDelta - lhs.rangeDelta || lhs.attackDelta - rhs.attackDelta
+        );
       });
 
       const oneShotWeapon = rangedWeapons.find((weapon) =>

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -50,6 +50,14 @@ function getMobDefense(mob) {
   return 0;
 }
 
+function rawAttackMultiplier() {
+  const mainStat = G.classes[character.ctype].main_stat;
+
+  if (character.ctype === "paladin")
+    return character.str / 20 + character.int / 40;
+  else return mainStat / 20;
+}
+
 function canOneShotWithWeapon(weaponInfo, targets) {
   const classData = G.classes[character.ctype];
   const damageType = classData.damage_type;
@@ -59,7 +67,8 @@ function canOneShotWithWeapon(weaponInfo, targets) {
     : { attack: 0, name: null, wtype: null };
 
   const effectiveAttack =
-    character.attack + (weaponInfo.attack - currentInfo.attack);
+    character.attack +
+    (weaponInfo.attack - currentInfo.attack) * rawAttackMultiplier();
 
   let effectivePiercing =
     damageType === "physical" ? character.apiercing : character.rpiercing;
@@ -329,6 +338,21 @@ function calculateRangerItems(target) {
           };
         })
         .filter(Boolean);
+
+      if (current) {
+        const info = item_info(current);
+        if (
+          ["bow", "crossbow"].includes(info.wtype) &&
+          current.name !== "cupid"
+        ) {
+          rangedWeapons.push({
+            slot: "mainhand",
+            name: current.name,
+            info,
+            attackDelta: 0,
+          });
+        }
+      }
 
       // Sort by smallest upgrade first (asc)
       rangedWeapons.sort((lhs, rhs) => lhs.attackDelta - rhs.attackDelta);

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -641,10 +641,11 @@ function calculateDamage(target, characterEntity, recursion = true) {
                 : 0),
           ) *
           target.frequency +
-        (target.dreturn && recursion
-          ? characterEntity.range < 100
+        (target.reflection && recursion
+          ? characterEntity.range > 100 &&
+            G.classes[characterEntity.ctype].damage_type === "magical"
             ? (calculateDamage(characterEntity, target, false) *
-                (target.dreturn ?? 0)) /
+                (target.reflection ?? 0)) /
               100
             : 0
           : 0)
@@ -664,7 +665,7 @@ function calculateDamage(target, characterEntity, recursion = true) {
           ) *
           target.frequency +
         (target.dreturn && recursion
-          ? characterEntity.range < 100
+          ? characterEntity.range < 100 && G.classes[characterEntity.ctype].damage_type === "physical"
             ? (calculateDamage(characterEntity, target, false) *
                 (target.dreturn ?? 0)) /
               100
@@ -738,8 +739,8 @@ function avgDmgTaken(characterEntity, dmgType = null) {
   );
 }
 
-function avgPartyDmgTaken(partyMems, dmgType = null) {
-  return partyMems.reduce(
+function avgPartyDmgTaken(partyList = partyMems, dmgType = null) {
+  return partyList.reduce(
     (accumulator, current) =>
       accumulator + avgDmgTaken(get_player(current), dmgType),
     0,

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -357,16 +357,14 @@ function calculateRangerItems(target) {
       // Sort by smallest upgrade first (asc)
       rangedWeapons.sort((lhs, rhs) => lhs.attackDelta - rhs.attackDelta);
 
-      const winningWeapon = rangedWeapons.find((weapon) =>
+      const oneShotWeapon = rangedWeapons.find((weapon) =>
         canOneShotWithWeapon(weapon.info, targets),
       );
 
-      if (winningWeapon) {
-        mainhand = winningWeapon.name;
+      if (oneShotWeapon) {
+        mainhand = oneShotWeapon.name;
       } else {
-        // fallback: strongest ranged weapon
-        const strongest = rangedWeapons.at(-1);
-        mainhand = strongest?.name ?? character.slots.mainhand?.name ?? "bow";
+        mainhand = RANGER_INV_ITEMS.fireBow;
       }
     }
 

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -484,31 +484,15 @@ function calculatePriestItems(target) {
 
   return {
     mainhand:
-      target &&
-      target.type !== "monster" &&
-      ![
-        // "firestaff", // only enable these when oozingterror is main designated weapon (currently: harbringer)
-        // "oozingterror",
-        // "pmace",
-        ...(!character.s.burned ? ["lmace"] : []),
-      ].includes(character.slots.mainhand?.name)
-        ? "harbringer"
-        : // : ["pinkgoo", "snowman", "wabbit", "crab"].includes(
-        //     get_targeted_monster()?.mtype,
-        //   )
-        // ? "pinkie"
-        character.map === "crypt"
+      target && target.type !== "monster"
+        ? "lmace"
+        : character.map === "crypt"
         ? currentTarget && currentTarget.s["frozen"]
-          ? "harbringer"
+          ? "lmace"
           : "froststaff"
         : feelingLucky
         ? "lmace"
-        : currentTarget &&
-          (currentTarget.cooperative ||
-            currentTarget["1hp"] ||
-            currentTarget["avoidance"] > 90)
-        ? "firestaff"
-        : "harbringer",
+        : "firestaff",
     offhand:
       character.map === "crypt"
         ? "wbook1"

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -307,9 +307,10 @@ function explosionScore(itemInfo, targets) {
     (character.explosion ?? 0) + (itemInfo.explosion_delta ?? 0);
 
   return targets.reduce((sum, mob) => {
-    const cluster =
-      mob.cluster_count ??
-      numberOfMonsterAroundTarget(mob, explosion / 3.6 || BLAST_RADIUS);
+    const cluster = numberOfMonsterAroundTarget(
+      mob,
+      explosion / 3.6 || BLAST_RADIUS,
+    );
 
     return sum + attack + attack * explosion * Math.max(0, cluster - 1);
   }, 0);
@@ -371,30 +372,25 @@ function calculateRangerItems(target) {
 
   const poucherAvailable = findMaxLevelItem(RANGER_INV_ITEMS.poucher) !== -1;
 
-  // --- Poucher priority for pull strategy ---
+  // Splashing equipment choice
   if (targets.length)
     if (
-      // (poucherAvailable || mainhand === RANGER_INV_ITEMS.poucher) &&
-      currentStrategy === usePullStrategies
-      // targets.some(
-      //   (mob) =>
-      //     (mob.cluster_count ??
-      //       numberOfMonsterAroundTarget(
-      //         mob,
-      //         character.explosion / 3.6 || BLAST_RADIUS,
-      //       )) >= TARGET_TO_SWITCH_TO_BLASTER_WEAPON,
-      // )
+      (poucherAvailable || mainhand === RANGER_INV_ITEMS.poucher) &&
+      currentStrategy === usePullStrategies &&
+      targets.some(
+        (mob) =>
+          (mob.cluster_count ??
+            numberOfMonsterAroundTarget(
+              mob,
+              character.explosion / 3.6 || BLAST_RADIUS,
+            )) >= TARGET_TO_SWITCH_TO_BLASTER_WEAPON,
+      )
     ) {
       mainhand = chooseFireOrPouchForSplashing(targets);
-    }
-    // --- Cooperative ---
-    else if (
-      someTargetCooperative
-      // || targets.every((mob) => mob.target)
-    ) {
+    } else if (someTargetCooperative) {
       mainhand = RANGER_INV_ITEMS.fireBow;
     }
-    // --- Calculate oneshot with crossbow ---
+    // Check for one-shot possibility with other bows
     else {
       const current = character.slots.mainhand;
       const currentInfo = current ? item_info(current) : { attack: 0 };

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -538,7 +538,7 @@ function calculatePriestItems(target) {
     gloves: "supermittens",
     amulet: isTanking ? "t2stramulet" : "intamulet",
     ring1: feelingLucky ? "ringhs" : "cring",
-    ring2: "zapper",
+    ring2: feelingLucky ? "ringhs" : "zapper",
     cape: "angelwings",
   };
 }

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -704,12 +704,7 @@ async function equipBatch(suggestedItems, forced = false) {
     msToNextAttack === 0 ? 1000 / character.frequency : msToNextAttack;
   const maxItemsToEquip = Math.max(
     0,
-    Math.floor(
-      (timeToNextAttack -
-        (character.s.penalty_cd?.ms ?? 0) -
-        character.ping / 2) /
-        120,
-    ),
+    Math.floor((timeToNextAttack - (character.s.penalty_cd?.ms ?? 0)) / 120),
   );
   if (itemSlots.length > maxItemsToEquip && !forced) {
     itemSlots.splice(maxItemsToEquip);

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -704,7 +704,12 @@ async function equipBatch(suggestedItems, forced = false) {
     msToNextAttack === 0 ? 1000 / character.frequency : msToNextAttack;
   const maxItemsToEquip = Math.max(
     0,
-    Math.floor((timeToNextAttack - (character.s.penalty_cd?.ms ?? 0)) / 120),
+    Math.floor(
+      (timeToNextAttack -
+        (character.s.penalty_cd?.ms ?? 0) -
+        character.ping / 2) /
+        120,
+    ),
   );
   if (itemSlots.length > maxItemsToEquip && !forced) {
     itemSlots.splice(maxItemsToEquip);

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -1352,6 +1352,10 @@ class ProjectileManagement {
   }
 }
 
-if (!PROJECTILE_MANAGER && parent.socket && character.ctype === "priest") {
+if (
+  !PROJECTILE_MANAGER &&
+  parent.socket &&
+  ["priest", "ranger"].includes(character.ctype)
+) {
   var PROJECTILE_MANAGER = new ProjectileManagement(parent.socket);
 }

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -157,6 +157,27 @@ function shouldWearExpGear() {
   );
 }
 
+// Ping compensation for normal attack
+function attackPingCompensate(
+  startTime,
+  attackFrequencyBeforeComponsate = character.frequency,
+) {
+  const elapsed = Date.now() - startTime;
+  const remaining = ms_to_next_skill("attack");
+
+  // compensate RTT
+  const effectiveRemaining = remaining + elapsed + Math.min(...parent.pings);
+
+  const expected = 1000 / attackFrequencyBeforeComponsate;
+
+  console.log(effectiveRemaining, expected);
+
+  if (effectiveRemaining > expected) {
+    const diff = effectiveRemaining - expected;
+    reduce_cooldown("attack", diff);
+  }
+}
+
 // Class Items logic
 function calculateMageItems() {
   const currentTarget = get_target();
@@ -989,7 +1010,6 @@ async function warriorStomp() {
 
   isStomping = true;
   const promises = [];
-
   const warriorItems = calculateWarriorItems();
   promises.push(
     equipBatch({ mainhand: "basher", offhand: undefined }, true),

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -978,18 +978,6 @@ async function useTemporalSurge() {
       [x1, y1, x2, y2] = boundary;
     }
 
-    console.log(
-      "Distance with spawn boundary:",
-      { x1, y1, x2, y2 },
-      distance(character, {
-        map: currentMap,
-        x: (x1 + x2) / 2,
-        y: (y1 + y2) / 2,
-        awidth: Math.abs(x2 - x1),
-        aheight: Math.abs(y2 - y1),
-      }),
-    );
-
     return (
       distance(character, {
         map: currentMap,
@@ -1016,7 +1004,6 @@ async function useTemporalSurge() {
   );
 
   const promises = [];
-  console.log(nearbySpawn.length, nearbySpawnWithSpawnMechanic.length);
   if (nearbySpawn.length && nearbySpawnWithSpawnMechanic.length === 0) {
     if (character.slots.orb?.name !== "orboftemporal") {
       promises.push(equipBatch({ orb: "orboftemporal" }, true));

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -1097,12 +1097,15 @@ async function useTemporalSurge() {
     }
   });
 
-  const nearbySpawnWithSpawnMechanic = nearbySpawn.filter(
-    (spawn) => G.monsters[spawn.type].spawns,
-  );
+  // const nearbySpawnWithSpawnMechanic = nearbySpawn.filter(
+  //   (spawn) => G.monsters[spawn.type].spawns,
+  // );
 
   const promises = [];
-  if (nearbySpawn.length && nearbySpawnWithSpawnMechanic.length === 0) {
+  if (
+    nearbySpawn.length
+    // && nearbySpawnWithSpawnMechanic.length === 0
+  ) {
     if (character.slots.orb?.name !== "orboftemporal") {
       promises.push(equipBatch({ orb: "orboftemporal" }, true));
     }

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -355,7 +355,12 @@ function calculateRangerItems(target) {
       }
 
       // Sort by smallest upgrade first (asc)
-      rangedWeapons.sort((lhs, rhs) => lhs.attackDelta - rhs.attackDelta);
+      rangedWeapons.sort((lhs, rhs) => {
+        if (lhs.info.wtype !== rhs.info.wtype) {
+          return lhs.info.wtype === "crossbow" ? 1 : -1;
+        }
+        return lhs.attackDelta - rhs.attackDelta;
+      });
 
       const oneShotWeapon = rangedWeapons.find((weapon) =>
         canOneShotWithWeapon(weapon.info, targets),

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -133,10 +133,12 @@ function haveFormidableMonsterAroundTarget(target, blastRadius = BLAST_RADIUS) {
   );
 }
 
+const EQUIP_IGNORE_MOBS = ["nerfedmummy"];
 function shouldWearLuckGear() {
   return Object.values(parent.entities).some(
     (mob) =>
       mob.type === "monster" &&
+      !EQUIP_IGNORE_MOBS.includes(mob.mtype) &&
       !mob.rip &&
       !mob.dead &&
       mob.hp > 0 &&
@@ -150,6 +152,7 @@ function shouldWearExpGear() {
   return Object.values(parent.entities).some(
     (mob) =>
       mob.type === "monster" &&
+      !EQUIP_IGNORE_MOBS.includes(mob.mtype) &&
       !mob.rip &&
       !mob.dead &&
       mob.hp > 0 &&
@@ -1099,15 +1102,12 @@ async function useTemporalSurge() {
     }
   });
 
-  // const nearbySpawnWithSpawnMechanic = nearbySpawn.filter(
-  //   (spawn) => G.monsters[spawn.type].spawns,
-  // );
+  const nearbySpawnWithSpawnMechanic = nearbySpawn.filter(
+    (spawn) => G.monsters[spawn.type].spawns,
+  );
 
   const promises = [];
-  if (
-    nearbySpawn.length
-    // && nearbySpawnWithSpawnMechanic.length === 0
-  ) {
+  if (nearbySpawn.length && nearbySpawnWithSpawnMechanic.length === 0) {
     if (character.slots.orb?.name !== "orboftemporal") {
       promises.push(equipBatch({ orb: "orboftemporal" }, true));
     }

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -158,23 +158,15 @@ function shouldWearExpGear() {
 }
 
 // Ping compensation for normal attack
-function attackPingCompensate(
-  startTime,
-  attackFrequencyBeforeComponsate = character.frequency,
+function attackSpeedCompensate(
+  attackFrequencyBeforeComponsate,
+  attackFrequencyAfterComponsate = character.frequency,
 ) {
-  const elapsed = Date.now() - startTime;
-  const remaining = ms_to_next_skill("attack");
-
-  // compensate RTT
-  const effectiveRemaining = remaining + elapsed + Math.min(...parent.pings);
-
-  const expected = 1000 / attackFrequencyBeforeComponsate;
-
-  console.log(effectiveRemaining, expected);
-
-  if (effectiveRemaining > expected) {
-    const diff = effectiveRemaining - expected;
-    reduce_cooldown("attack", diff);
+  if (attackFrequencyBeforeComponsate > attackFrequencyAfterComponsate) {
+    const compensateMs =
+      1000 / attackFrequencyAfterComponsate -
+      1000 / attackFrequencyBeforeComponsate;
+    reduce_cooldown("attack", compensateMs);
   }
 }
 
@@ -597,7 +589,7 @@ async function equipBatch(suggestedItems, forced = false) {
   const promises = [];
   const currentBooster = findInvBooster();
 
-  if ((!isLooting && currentBooster) || forced) {
+  if ((!isLooting || forced) && currentBooster) {
     if (suggestedItems.booster && currentBooster !== suggestedItems.booster) {
       promises.push(shift(locate_item(currentBooster), suggestedItems.booster));
       delete suggestedItems.booster;

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -68,7 +68,7 @@ function canOneShotWithWeapon(weaponInfo, targets) {
 
   const effectiveAttack =
     character.attack +
-    (weaponInfo.attack - currentInfo.attack) * rawAttackMultiplier();
+    (weaponInfo.attack - currentInfo.attack) * (rawAttackMultiplier() + 1);
 
   let effectivePiercing =
     damageType === "physical" ? character.apiercing : character.rpiercing;
@@ -298,6 +298,58 @@ const RANGER_INV_ITEMS = {
   fireBow: "firebow",
   crossBow: "crossbow",
 };
+
+function explosionScore(itemInfo, targets) {
+  if (!itemInfo || !targets?.length) return 0;
+
+  const attack = itemInfo.attack || 0;
+  const explosion = (character.explosion ?? 0) + itemInfo.explosion_delta || 0;
+
+  return targets.reduce((sum, mob) => {
+    const cluster =
+      mob.cluster_count ??
+      numberOfMonsterAroundTarget(mob, explosion / 3.6 || BLAST_RADIUS);
+
+    return sum + attack + attack * explosion * (cluster - 1);
+  }, 0);
+}
+
+function chooseFireOrPouchForSplashing(targets) {
+  const targetCount = estimateExplosionTargetCount(targets);
+
+  const currentBow = {
+    ...item_info(character.slots.mainhand),
+    explosion_delta: 0,
+  };
+
+  const fireInfo =
+    currentBow?.name === RANGER_INV_ITEMS.fireBow
+      ? currentBow
+      : item_info(findMaxLevelItem(RANGER_INV_ITEMS.fireBow));
+  const pouchInfo =
+    currentBow?.name === RANGER_INV_ITEMS.poucher
+      ? getBowInfo(RANGER_INV_ITEMS.poucher)
+      : item_info(findMaxLevelItem(RANGER_INV_ITEMS.poucher));
+
+  if (!pouchInfo) return RANGER_INV_ITEMS.fireBow;
+  if (!fireInfo) return RANGER_INV_ITEMS.poucher;
+
+  if (!pouchInfo.explosion_delta) {
+    pouchInfo.explosion_delta = pouchInfo.explosion - currentBow.explosion;
+  }
+
+  if (!fireInfo.explosion_delta) {
+    fireInfo.explosion_delta = fireInfo.explosion - currentBow.explosion;
+  }
+
+  const fireScore = explosionScore(fireInfo, targetCount);
+  const pouchScore = explosionScore(pouchInfo, targetCount);
+
+  return pouchScore > fireScore
+    ? RANGER_INV_ITEMS.poucher
+    : RANGER_INV_ITEMS.fireBow;
+}
+
 function calculateRangerItems(target) {
   // Sanitize input
   const targets = !target ? [] : Array.isArray(target) ? target : [target];
@@ -313,18 +365,18 @@ function calculateRangerItems(target) {
   // --- Poucher priority for pull strategy ---
   if (targets.length)
     if (
-      (poucherAvailable || mainhand === RANGER_INV_ITEMS.poucher) &&
-      currentStrategy === usePullStrategies &&
-      targets.some(
-        (mob) =>
-          (mob.cluster_count ??
-            numberOfMonsterAroundTarget(
-              mob,
-              character.explosion / 3.6 || BLAST_RADIUS,
-            )) >= TARGET_TO_SWITCH_TO_BLASTER_WEAPON,
-      )
+      // (poucherAvailable || mainhand === RANGER_INV_ITEMS.poucher) &&
+      currentStrategy === usePullStrategies
+      // targets.some(
+      //   (mob) =>
+      //     (mob.cluster_count ??
+      //       numberOfMonsterAroundTarget(
+      //         mob,
+      //         character.explosion / 3.6 || BLAST_RADIUS,
+      //       )) >= TARGET_TO_SWITCH_TO_BLASTER_WEAPON,
+      // )
     ) {
-      mainhand = RANGER_INV_ITEMS.poucher;
+      mainhand = chooseFireOrPouchForSplashing(targets);
     }
     // --- Cooperative ---
     else if (
@@ -660,8 +712,7 @@ async function equipBatch(suggestedItems, forced = false) {
     return Promise.all(promises).finally(() => {
       isEquipingItems = false;
     });
-  }
-  else {
+  } else {
     isEquipingItems = false;
     return false;
   }

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -628,52 +628,55 @@ async function equipBatch(suggestedItems, forced = false) {
 }
 
 // Utilities
-function calculateDamage(target, characterEntity, recursion = true) {
-  if (!target) return 0;
-  switch (target?.damage_type) {
+function calculateDamage(fromEntity, toEntity, recursion = true) {
+  if (!fromEntity) return 0;
+  switch (fromEntity?.damage_type) {
     case "magical":
       return (
-        target.attack *
+        fromEntity.attack *
           dps_multiplier(
-            characterEntity.resistance -
-              (target.type === "monster"
-                ? G.monsters[target.mtype].rpiercing ?? 0
+            toEntity.resistance -
+              (fromEntity.type === "monster"
+                ? G.monsters[fromEntity.mtype].rpiercing ?? 0
                 : 0),
           ) *
-          target.frequency +
-        (target.reflection && recursion
-          ? characterEntity.range > 100 &&
-            G.classes[characterEntity.ctype].damage_type === "magical"
-            ? (calculateDamage(characterEntity, target, false) *
-                (target.reflection ?? 0)) /
+          fromEntity.frequency +
+        (fromEntity.reflection && recursion
+          ? toEntity.range > 100 &&
+            (toEntity.type === "monster"
+              ? G.monsters[toEntity.mtype].damage_type
+              : G.classes[toEntity.ctype].damage_type) === "magical"
+            ? (calculateDamage(toEntity, fromEntity, false) *
+                (fromEntity.reflection ?? 0)) /
               100
             : 0
           : 0)
       );
     case "physical":
       return (
-        target.attack *
+        fromEntity.attack *
           dps_multiplier(
-            characterEntity.armor -
-              (characterEntity.s["hardshell"]
-                ? G.conditions.hardshell.armor
-                : 0) -
-              (target.type === "monster"
-                ? G.monsters[target.mtype].apiercing ?? 0
+            toEntity.armor -
+              (toEntity.s["hardshell"] ? G.conditions.hardshell.armor : 0) -
+              (fromEntity.type === "monster"
+                ? G.monsters[fromEntity.mtype].apiercing ?? 0
                 : 0) *
                 2,
           ) *
-          target.frequency +
-        (target.dreturn && recursion
-          ? characterEntity.range < 100 && G.classes[characterEntity.ctype].damage_type === "physical"
-            ? (calculateDamage(characterEntity, target, false) *
-                (target.dreturn ?? 0)) /
+          fromEntity.frequency +
+        (fromEntity.dreturn && recursion
+          ? toEntity.range < 100 &&
+            (toEntity.type === "monster"
+              ? G.monsters[toEntity.mtype].damage_type
+              : G.classes[toEntity.ctype].damage_type) === "physical"
+            ? (calculateDamage(toEntity, fromEntity, false) *
+                (fromEntity.dreturn ?? 0)) /
               100
             : 0
           : 0)
       );
     default:
-      return target.attack * target.frequency;
+      return fromEntity.attack * fromEntity.frequency;
   }
 }
 

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -322,6 +322,8 @@ function chooseFireOrPouchForSplashing(targets) {
   };
   const currentBowExplosion = currentBow.explosion ?? 0;
 
+  console.warn(currentBowExplosion, currentBow?.name);
+
   const firebowSlot = findMaxLevelItem(RANGER_INV_ITEMS.fireBow);
   const fireInfo =
     currentBow?.name === RANGER_INV_ITEMS.fireBow
@@ -338,6 +340,7 @@ function chooseFireOrPouchForSplashing(targets) {
       ? item_info(character.items[pouchbowSlot])
       : undefined;
 
+  console.warn(fireInfo.explosion_delta, pouchInfo.explosion_delta);
   if (!pouchInfo) return RANGER_INV_ITEMS.fireBow;
   if (!fireInfo) return RANGER_INV_ITEMS.poucher;
 
@@ -348,8 +351,6 @@ function chooseFireOrPouchForSplashing(targets) {
   if (fireInfo.explosion_delta == null) {
     fireInfo.explosion_delta = fireInfo.explosion - currentBowExplosion;
   }
-
-  console.warn (fireInfo.explosion_delta, pouchInfo.explosion_delta);
 
   const fireScore = explosionScore(fireInfo, targets);
   const pouchScore = explosionScore(pouchInfo, targets);

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -952,6 +952,7 @@ function shouldAttack(target = get_target()) {
 // New Temporal Surge Logic
 // New Temporal Surge Logic
 async function useTemporalSurge() {
+  if (isAdvanceSmartMoving || smart.moving) return false;
   if (
     is_on_cooldown("temporalsurge") ||
     character.mp < G.skills["temporalsurge"].mp + 400

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -699,7 +699,7 @@ async function equipBatch(suggestedItems, forced = false) {
     })
     .filter((equipInfo) => equipInfo.num >= 0);
 
-  // Slice items to fit with penalty_cd & frequency
+  // Slice items to prevent penalty_cd from affecting attack cooldown
   const msToNextAttack = ms_to_next_skill("attack");
   const timeToNextAttack =
     msToNextAttack === 0 ? 1000 / character.frequency : msToNextAttack;

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -312,7 +312,9 @@ function explosionScore(itemInfo, targets) {
       explosion / 3.6 || BLAST_RADIUS,
     );
 
-    return sum + attack + attack * explosion * Math.max(0, cluster - 1);
+    return (
+      sum + attack + ((attack * explosion) / 100) * Math.max(0, cluster - 1)
+    );
   }, 0);
 }
 

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -216,6 +216,7 @@ function calculateMageItems() {
     pants: "starkillers",
     shoes: "wingedboots",
     gloves: "supermittens",
+    cape: "ecape",
     orb: feelingLucky ? "rabbitsfoot" : feelingWise ? "talkingskull" : "jacko",
     amulet: feelingWise ? "spookyamulet" : "intamulet",
   };

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -636,7 +636,7 @@ async function equipBatch(suggestedItems, forced = false) {
     })
     .filter((equipInfo) => equipInfo.num >= 0);
   if (itemSlots.length)
-    if (itemSlots.length <= 2 && !character.s.penalty_cd)
+    if (itemSlots.length <= 1)
       for (const item of itemSlots) promises.push(equip(item.num, item.slot));
     else promises.push(equip_batch(itemSlots));
   return Promise.all(promises).finally(() => {

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -322,11 +322,9 @@ function chooseFireOrPouchForSplashing(targets) {
   };
   const currentBowExplosion = currentBow.explosion ?? 0;
 
-  console.warn(currentBowExplosion, currentBow?.name);
-
   const firebowSlot = findMaxLevelItem(RANGER_INV_ITEMS.fireBow);
   const fireInfo =
-    currentBow?.name === RANGER_INV_ITEMS.fireBow
+    currentBow?.id === RANGER_INV_ITEMS.fireBow
       ? currentBow
       : firebowSlot !== -1
       ? item_info(character.items[firebowSlot])
@@ -334,7 +332,7 @@ function chooseFireOrPouchForSplashing(targets) {
 
   const pouchbowSlot = findMaxLevelItem(RANGER_INV_ITEMS.poucher);
   const pouchInfo =
-    currentBow?.name === RANGER_INV_ITEMS.poucher
+    currentBow?.id === RANGER_INV_ITEMS.poucher
       ? currentBow
       : pouchbowSlot !== -1
       ? item_info(character.items[pouchbowSlot])

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -708,9 +708,36 @@ async function equipBatch(suggestedItems, forced = false) {
   }
 }
 
+function calculateHeal(fromEntity, toEntity) {
+  if (!fromEntity) return 0;
+  switch (fromEntity?.damage_type) {
+    case "magical":
+      return (
+        fromEntity.heal *
+        damage_multiplier(
+          toEntity.resistance -
+            (fromEntity.name === character.name
+              ? character.rpiercing / 2 ?? 0
+              : 0),
+        )
+      );
+    case "physical":
+      return (
+        fromEntity.attack *
+        damage_multiplier(
+          toEntity.armor -
+            (fromEntity.name === character.name
+              ? character.apiercing / 2 ?? 0
+              : 0),
+        )
+      );
+  }
+}
+
 // Utilities
 function calculateDamage(fromEntity, toEntity, recursion = true) {
   if (!fromEntity) return 0;
+
   switch (fromEntity?.damage_type) {
     case "magical":
       return (
@@ -1183,3 +1210,148 @@ async function useTemporalSurge() {
 setInterval(async () => {
   await useTemporalSurge();
 }, 1000);
+
+class ProjectileManagement {
+  constructor(socket) {
+    this.socket = socket;
+    this.projectilesByTarget = new Map(); // name/ID -> Map(pid -> projectile)
+    this.pidToTarget = new Map(); // pid -> target for O(1) removals
+
+    this.init();
+  }
+
+  _calculateSingleHitDamage(from, to) {
+    const clone = { ...from, frequency: 1 };
+    return calculateDamage(clone, to, false);
+  }
+
+  _onIncomingProjectile = (data) => {
+    if (!data?.pid || !data?.target) return;
+    if (data.source !== "attack" && data.source !== "heal") return;
+    if (data.instant) return;
+
+    // Only consider projectiles that have a damage or heal value
+    const rawValue = data.damage ?? data.heal;
+    if (typeof rawValue !== "number") return;
+
+    const projectileActor = parent.entities[data.attacker];
+    const projectileTarget = parent.entities[data.target];
+
+    const projectile = {
+      type: data.source, // "attack" | "heal"
+      attacker: data.attacker,
+      eta: data.eta,
+      arrival: performance.now() + data.eta,
+    };
+
+    // damage as negative and heal as positive
+    if (projectileActor && projectileTarget) {
+      projectile.value =
+        data.damage != null
+          ? -this._calculateSingleHitDamage(projectileActor, projectileTarget)
+          : calculateHeal(projectileActor, projectileTarget);
+    } else {
+      projectile.value = data.damage != null ? -rawValue : rawValue;
+    }
+
+    const { target, pid } = data;
+
+    // Init map for target if undefined
+    if (!this.projectilesByTarget.has(target)) {
+      this.projectilesByTarget.set(target, new Map());
+    }
+
+    // Store projectile under target -> pid
+    this.projectilesByTarget.get(target).set(pid, projectile);
+
+    // Optional but strongly recommended for O(1) removal later
+    this.pidToTarget.set(pid, target);
+  };
+
+  _onProjectileHit = (data) => {
+    if (!data?.pid) return;
+
+    const target = this.pidToTarget.get(data.pid);
+    if (!target) return;
+
+    const targetMap = this.projectilesByTarget.get(target);
+    if (targetMap) {
+      targetMap.delete(data.pid);
+      if (targetMap.size === 0) {
+        this.projectilesByTarget.delete(target);
+      }
+    }
+
+    this.pidToTarget.delete(data.pid);
+  };
+
+  _bindEvents() {
+    this.socket.on("action", this._onIncomingProjectile);
+    this.socket.on("hit", this._onProjectileHit);
+  }
+
+  _cleanExpiredProjectile() {
+    const now = performance.now();
+
+    for (const [target, map] of this.projectilesByTarget) {
+      for (const [pid, projectile] of map) {
+        if (projectile.arrival + 100 < now) {
+          map.delete(pid);
+          this.pidToTarget.delete(pid);
+        }
+      }
+
+      if (map.size === 0) {
+        this.projectilesByTarget.delete(target);
+      }
+    }
+  }
+
+  cleanUp() {
+    if (this.socket) {
+      this.socket.off("action", this._onIncomingProjectile);
+      this.socket.off("hit", this._onProjectileHit);
+    }
+
+    if (this._cleanupInterval) {
+      clearInterval(this._cleanupInterval);
+      this._cleanupInterval = null;
+    }
+
+    this.projectilesByTarget.clear();
+    this.pidToTarget.clear();
+
+    this._initialized = false;
+    this.socket = null;
+  }
+
+  getIncomingNumber(target) {
+    const map = this.projectilesByTarget.get(target);
+    if (!map) return 0;
+
+    let total = 0;
+    for (const projectile of map.values()) {
+      total += projectile.value;
+    }
+    return total;
+  }
+
+  init() {
+    if (!this.socket) return;
+
+    // Prevent double init
+    if (this._initialized) return;
+    this._initialized = true;
+
+    // Bind socket listeners
+    this._bindEvents();
+
+    this._cleanupInterval = setInterval(() => {
+      this._cleanExpiredProjectile();
+    }, 500); // clear projectile once every 500ms
+  }
+}
+
+if (!PROJECTILE_MANAGER && parent.socket && character.ctype === "priest") {
+  var PROJECTILE_MANAGER = new ProjectileManagement(parent.socket);
+}

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -55,7 +55,7 @@ function rawAttackMultiplier() {
 
   if (character.ctype === "paladin")
     return character.str / 20 + character.int / 40;
-  else return mainStat / 20;
+  else return character[mainStat] / 20;
 }
 
 function canOneShotWithWeapon(weaponInfo, targets) {

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -349,6 +349,8 @@ function chooseFireOrPouchForSplashing(targets) {
     fireInfo.explosion_delta = fireInfo.explosion - currentBowExplosion;
   }
 
+  console.warn (fireInfo.explosion_delta, pouchInfo.explosion_delta);
+
   const fireScore = explosionScore(fireInfo, targets);
   const pouchScore = explosionScore(pouchInfo, targets);
 

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -651,7 +651,7 @@ function calculateDamage(fromEntity, toEntity, recursion = true) {
             toEntity.resistance -
               (fromEntity.type === "monster"
                 ? G.monsters[fromEntity.mtype].rpiercing ?? 0
-                : 0),
+                : 0) * 2,
           ) *
           fromEntity.frequency +
         (fromEntity.reflection && recursion

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -789,7 +789,7 @@ function listOfMonsterAttacking(characterEntity) {
 function mobbingMultiplier(numberOfMobs) {
   // return numberOfMobs < 5 ? 1.7 : numberOfMobs < 6 ? 1.8 : 2;
 
-  return numberOfMobs < 3 ? 1 : 1.7;
+  return numberOfMobs < 3 ? 1 : 1.5;
 }
 
 function avgDmgTaken(characterEntity, dmgType = null) {

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -948,3 +948,68 @@ function shouldAttack(target = get_target()) {
 
   return true;
 }
+
+// New Temporal Surge Logic
+async function useTemporalSurge() {
+  if (
+    is_on_cooldown("temporalsurge") ||
+    character.mp < G.skills["temporalsurge"].mp + 400
+  )
+    return false;
+
+  if (
+    findMaxLevelItem("orboftemporal") === -1 &&
+    character.slots.orb?.name !== "orboftemporal"
+  ) {
+    return false;
+  }
+
+  const currentMap = character.map;
+  const temporalsurgeRange = G.skills["temporalsurge"].range;
+
+  const isSpawnInRange = (boundary) => {
+    const [x1, y1, x2, y2] = boundary;
+
+    return (
+      distance(character, {
+        map: currentMap,
+        x: (x1 + x2) / 2,
+        y: (y1 + y2) / 2,
+        awidth: Math.abs(x2 - x1),
+        aheight: Math.abs(y2 - y1),
+      }) < temporalsurgeRange
+    );
+  };
+
+  const nearbySpawn = Object.values(parent.G.maps[currentMap].spawns).filter(
+    (spawn) => {
+      if (spawn.boundaries) {
+        return spawn.boundaries.some((boundary) => isSpawnInRange(boundary));
+      } else {
+        return isSpawnInRange(spawn.boundary);
+      }
+    },
+  );
+
+  const nearbySpawnWithSpawnMechanic = nearbySpawn.filter(
+    (spawn) => G.monsters[spawn.type].spawns,
+  );
+
+  const promises = [];
+
+  if (nearbySpawn.length && nearbySpawnWithSpawnMechanic.length === 0) {
+    if (character.slots.orb?.name !== "orboftemporal") {
+      promises.push(equipBatch({ orb: "orboftemporal" }, true));
+    }
+    promises.push(use_skill("temporalsurge"));
+  }
+
+  return withTimeout(Promise.allSettled(promises)).finally(() => {
+    reduce_cooldown("temporalsurge", 0.95 * character.ping);
+  });
+}
+
+// Surge loop
+setInterval(() => {
+  useTemporalSurge();
+}, 1000);

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -141,7 +141,8 @@ function shouldWearLuckGear() {
       !mob.dead &&
       mob.hp > 0 &&
       (mob.target === character.name || mob.cooperative) &&
-      (mob.hp <= Math.min(mob.max_hp * 0.15, 300000) || mob.max_hp < calculateDamage(character, mob, false) * 2),
+      (mob.hp <= Math.min(mob.max_hp * 0.15, 300000) ||
+        mob.max_hp < calculateDamage(character, mob, false) * 2),
   );
 }
 
@@ -153,7 +154,8 @@ function shouldWearExpGear() {
       !mob.dead &&
       mob.hp > 0 &&
       (parent.party_list.includes(mob.target) || mob.cooperative) &&
-      mob.hp <= Math.min(mob.max_hp * 0.1, 300000) && mob.max_hp > calculateDamage(character, mob, false) * 2,
+      mob.hp <= Math.min(mob.max_hp * 0.1, 300000) &&
+      mob.max_hp > calculateDamage(character, mob, false) * 2,
   );
 }
 

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -58,6 +58,9 @@ function shouldWearLuckGear() {
   return Object.values(parent.entities).some(
     (mob) =>
       mob.type === "monster" &&
+      !mob.rip &&
+      !mob.dead &&
+      mob.hp > 0 &&
       (mob.target === character.name || mob.cooperative) &&
       mob.hp <= Math.min(mob.max_hp * 0.15, 300000),
   );
@@ -67,6 +70,9 @@ function shouldWearExpGear() {
   return Object.values(parent.entities).some(
     (mob) =>
       mob.type === "monster" &&
+      !mob.rip &&
+      !mob.dead &&
+      mob.hp > 0 &&
       (parent.party_list.includes(mob.target) || mob.cooperative) &&
       mob.hp <= Math.min(mob.max_hp * 0.1, 300000),
   );
@@ -74,10 +80,14 @@ function shouldWearExpGear() {
 
 // Class Items logic
 function calculateMageItems() {
+  const currentTarget = get_target();
+  const numberOfMobsAroundCurrentTarget =
+    numberOfMonsterAroundTarget(currentTarget);
+  const haveEnoughMobsToSplash =
+    numberOfMobsAroundCurrentTarget >= TARGET_TO_SWITCH_TO_BLASTER_WEAPON;
   const shouldUseBlaster =
-    numberOfMonsterAroundTarget(get_targeted_monster()) >=
-      TARGET_TO_SWITCH_TO_BLASTER_WEAPON &&
-    !get_targeted_monster()?.["1hp"] &&
+    haveEnoughMobsToSplash &&
+    !currentTarget?.["1hp"] &&
     character.mp > G.skills["magiport"].mp + G.skills["blink"].mp;
 
   const feelingLucky = shouldWearLuckGear();
@@ -85,16 +95,18 @@ function calculateMageItems() {
 
   return {
     mainhand:
-      currentStrategy === usePullStrategies
+      character.map === "crypt" && !currentTarget?.s?.frozen
+        ? "froststaff"
+        : ["pinkgoo", "snowman", "wabbit", "crab"].includes(
+            currentTarget?.mtype,
+          ) ||
+          (currentTarget?.max_hp < 2000 &&
+            (currentStrategy !== usePullStrategies || !haveEnoughMobsToSplash))
+        ? "pinkie"
+        : currentStrategy === usePullStrategies
         ? shouldUseBlaster
           ? "sparkstaff"
           : "firestaff"
-        : character.map === "crypt" && !get_targeted_monster()?.s?.frozen
-        ? "froststaff"
-        : ["pinkgoo", "snowman", "wabbit", "crab"].includes(
-            get_targeted_monster()?.mtype,
-          ) || get_targeted_monster()?.max_hp < 2000
-        ? "pinkie"
         : "firestaff",
     offhand:
       currentStrategy === usePullStrategies
@@ -112,7 +124,7 @@ function calculateMageItems() {
   };
 }
 
-const STUN_FOCUS_LIST = ["crabxx"];
+const STUN_FOCUS_LIST = ["crabxx", "grinch"];
 function calculateWarriorItems() {
   const currentTarget = get_target();
   const shouldUseBlaster =
@@ -343,7 +355,7 @@ function calculatePriestItems(target) {
         ? "wbookhs"
         : feelingLucky
         ? "mshield"
-        : TANKER === character.name ||
+        : isTanking ||
           Object.values(parent.entities).some(
             (mob) =>
               mob.type === "monster" &&
@@ -365,8 +377,9 @@ function calculatePriestItems(target) {
         : "test_orb",
     gloves: "supermittens",
     amulet: isTanking ? "t2stramulet" : "intamulet",
-    ring1: "cring",
+    ring1: feelingLucky ? "ringhs" : "cring",
     ring2: "zapper",
+    cape: "angelwings",
   };
 }
 
@@ -910,19 +923,27 @@ async function warriorStomp() {
   });
 }
 
-function shouldAttack() {
-  const currentTarget = get_target();
-  const partyPriest = parent.party_list
-    .map((id) => get_player(id))
-    .filter((player) => player && player.ctype === "priest");
+function shouldAttack(target = get_target()) {
   const partyHealer = get_entity(HEALER) ?? get_entity(RANGER);
-  return character.map === "crypt"
-    ? partyHealer && !partyHealer.rip
-    : ["warrior", "rogue"].includes(character.ctype) &&
-      currentTarget &&
-      MELEE_IGNORE_LIST.includes(currentTarget.mtype ?? currentTarget.ctype)
-    ? false
-    : currentTarget && currentTarget.attack > 600 && !currentTarget.target
-    ? partyPriest.length > 0 || (partyHealer && !partyHealer.rip)
-    : true;
+
+  if (character.map === "crypt") {
+    return !!partyHealer && !partyHealer.rip;
+  }
+
+  if (
+    ["warrior", "rogue"].includes(character.ctype) &&
+    target &&
+    MELEE_IGNORE_LIST.includes(target.mtype ?? target.ctype)
+  ) {
+    return false;
+  }
+
+  if (target && target.attack > 600 && !target.target) {
+    const partyPriest = [...parent.party_list, ...partyMems]
+      .map((id) => get_player(id))
+      .filter((player) => player?.ctype === "priest");
+    return partyPriest.length > 0 || (partyHealer && !partyHealer.rip);
+  }
+
+  return true;
 }

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -648,7 +648,7 @@ async function equipBatch(suggestedItems, forced = false) {
   if (
     (character.cc > 130 ||
       isEquipingItems ||
-      character.s.penalty_cd ||
+      // character.s.penalty_cd ||
       isLooting) &&
     !forced
   )

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -740,7 +740,7 @@ function avgDmgTaken(characterEntity, dmgType = null) {
               (G.monsters[highestBurningMob.mtype].apiercing ?? 0) * 2
           : highestBurningMob.damage_type === "magical"
           ? characterEntity.resistance -
-            (G.monsters[highestBurningMob.mtype].rpiercing ?? 0)
+            (G.monsters[highestBurningMob.mtype].rpiercing ?? 0) * 2
           : 1,
       ) *
       ((100 - fireResist) / 100) *
@@ -1051,7 +1051,8 @@ async function useTemporalSurge() {
   if (isAdvanceSmartMoving || smart.moving) return false;
   if (
     is_on_cooldown("temporalsurge") ||
-    character.mp < G.skills["temporalsurge"].mp + 400
+    character.mp < G.skills["temporalsurge"].mp + 400 ||
+    (isAssignedAsTanker() && character.s.burned)
   )
     return false;
 

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -16,6 +16,76 @@ function mobsListAroundTarget(target, blastRadius = BLAST_RADIUS) {
   );
 }
 
+function getRelevantPiercing(wtype) {
+  const classData = G.classes?.[character.ctype];
+  if (!classData) return 0;
+
+  const damageType = classData.damage_type;
+  const weaponData = classData.mainhand?.[wtype];
+
+  if (!weaponData) return 0;
+
+  if (damageType === "physical") {
+    return weaponData.apiercing ?? 0;
+  }
+
+  if (damageType === "magical") {
+    return weaponData.rpiercing ?? 0;
+  }
+
+  return 0;
+}
+
+function getMobDefense(mob) {
+  const damageType = G.classes[character.ctype]?.damage_type;
+
+  if (damageType === "physical") {
+    return mob.armor ?? 0;
+  }
+
+  if (damageType === "magical") {
+    return mob.resistance ?? 0;
+  }
+
+  return 0;
+}
+
+function canOneShotWithWeapon(weaponInfo, targets) {
+  const classData = G.classes[character.ctype];
+  const damageType = classData.damage_type;
+
+  const currentInfo = character.slots.mainhand
+    ? item_info(character.slots.mainhand)
+    : { attack: 0, name: null, wtype: null };
+
+  const effectiveAttack =
+    character.attack + (weaponInfo.attack - currentInfo.attack);
+
+  let effectivePiercing =
+    damageType === "physical" ? character.apiercing : character.rpiercing;
+
+  if (currentInfo.name !== weaponInfo.name) {
+    effectivePiercing += getRelevantPiercing(weaponInfo.wtype);
+  }
+
+  const piercingMultiplier = damageType === "physical" ? 2 : 1;
+
+  const shotMultiplier =
+    targets.length >= 4 ? 0.5 : targets.length >= 2 ? 0.7 : 1;
+
+  return targets.some((mob) => {
+    const defense = getMobDefense(mob);
+
+    const dmg =
+      dps_multiplier(defense - effectivePiercing * piercingMultiplier) *
+      effectiveAttack *
+      0.9 *
+      shotMultiplier;
+
+    return mob.max_hp <= dmg;
+  });
+}
+
 // Counting
 function numberOfMonsterAroundTarget(target, blastRadius = BLAST_RADIUS) {
   if (!target) return 0;
@@ -237,63 +307,38 @@ function calculateRangerItems(target) {
     }
     // --- Calculate oneshot with crossbow ---
     else {
-      const currentEquippedBowInfo = character.slots.mainhand
-        ? item_info(character.slots.mainhand)
-        : {
-            name: undefined,
-            attack: 0,
-            apiercing: 0,
+      const current = character.slots.mainhand;
+      const currentInfo = current ? item_info(current) : { attack: 0 };
+      const rangedWeapons = character.items
+        .map((item, slot) => {
+          if (!item) return null;
+
+          const info = item_info(item);
+          if (!["bow", "crossbow"].includes(info.wtype)) return null;
+
+          return {
+            slot,
+            name: item.name,
+            info,
+            attackDelta: info.attack - currentInfo.attack,
           };
+        })
+        .filter(Boolean);
 
-      const fireBowInfo =
-        currentEquippedBowInfo.id === RANGER_INV_ITEMS.fireBow
-          ? currentEquippedBowInfo
-          : item_info(
-              character.items[findMaxLevelItem(RANGER_INV_ITEMS.fireBow)],
-            );
-      const crossbowInfo =
-        currentEquippedBowInfo.id === RANGER_INV_ITEMS.crossBow
-          ? currentEquippedBowInfo
-          : item_info(
-              character.items[findMaxLevelItem(RANGER_INV_ITEMS.crossBow)],
-            );
+      // Sort by smallest upgrade first (asc)
+      rangedWeapons.sort((lhs, rhs) => lhs.attackDelta - rhs.attackDelta);
 
-      if (crossbowInfo && fireBowInfo) {
-        // Effective attack with crossbow
-        const attackStatEquippingCrossbow =
-          character.attack +
-          (crossbowInfo.attack - currentEquippedBowInfo.attack);
+      const winningWeapon = rangedWeapons.find((weapon) =>
+        canOneShotWithWeapon(weapon.info, targets),
+      );
 
-        // Effective AP for crossbow
-        let aPiercingAfterEquipingCrossbow = character.apiercing;
-        if (currentEquippedBowInfo.name !== crossbowInfo.name) {
-          aPiercingAfterEquipingCrossbow += 120;
-        }
-
-        // Calculate damage per target
-        const attackDealtByCrossbow = targets.map(
-          (mob) =>
-            dps_multiplier(mob.armor - aPiercingAfterEquipingCrossbow * 2) *
-            attackStatEquippingCrossbow,
-        );
-
-        const shotMultiplier =
-          targets.length >= 4 ? 0.5 : targets.length >= 2 ? 0.7 : 1;
-
-        // Check if any target can be oneshot by crossbow
-        const oneshotableWithCrossbow = targets.some(
-          (mob, i) =>
-            mob.max_hp <= attackDealtByCrossbow[i] * 0.9 * shotMultiplier,
-        );
-
-        mainhand = oneshotableWithCrossbow
-          ? RANGER_INV_ITEMS.crossBow
-          : RANGER_INV_ITEMS.fireBow;
+      if (winningWeapon) {
+        mainhand = winningWeapon.name;
+      } else {
+        // fallback: strongest ranged weapon
+        const strongest = rangedWeapons.at(-1);
+        mainhand = strongest?.name ?? character.slots.mainhand?.name ?? "bow";
       }
-      // --- Fallback if only one bow is available ---
-      else if (!crossbowInfo) mainhand = RANGER_INV_ITEMS.fireBow;
-      else if (!fireBowInfo) mainhand = RANGER_INV_ITEMS.crossBow;
-      else mainhand = "bow";
     }
 
   return {

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -1,7 +1,7 @@
 const MAX_TARGET = 10;
 const BLAST_RADIUS = character.blast / 3.6 || 17;
 const TARGET_TO_SWITCH_TO_BLASTER_WEAPON = 2;
-const MAX_MOB_DPS = 1000;
+const MAX_MOB_DPS = 2500;
 const BOOSTERS = ["goldbooster", "xpbooster", "luckbooster"];
 const WATCHOUT_ABILITIES = ["burn"];
 

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -314,7 +314,12 @@ function calculateRangerItems(target) {
           if (!item) return null;
 
           const info = item_info(item);
-          if (!["bow", "crossbow"].includes(info.wtype)) return null;
+
+          if (
+            !["bow", "crossbow"].includes(info.wtype) ||
+            item.name === "cupid"
+          )
+            return null;
 
           return {
             slot,
@@ -994,7 +999,6 @@ function shouldAttack(target = get_target()) {
   return true;
 }
 
-// New Temporal Surge Logic
 // New Temporal Surge Logic
 async function useTemporalSurge() {
   if (isAdvanceSmartMoving || smart.moving) return false;

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -205,7 +205,7 @@ function calculateMageItems() {
         ? "pinkie"
         : currentStrategy === usePullStrategies
         ? shouldUseBlaster
-          ? "sparkstaff"
+          ? "gstaff" // or "sparkstaff"
           : "firestaff"
         : "firestaff",
     offhand:

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -273,7 +273,7 @@ function calculateRangerItems(target) {
         // Calculate damage per target
         const attackDealtByCrossbow = targets.map(
           (mob) =>
-            dps_multiplier(mob.armor - aPiercingAfterEquipingCrossbow) *
+            dps_multiplier(mob.armor - aPiercingAfterEquipingCrossbow * 2) *
             attackStatEquippingCrossbow,
         );
 
@@ -297,7 +297,7 @@ function calculateRangerItems(target) {
     }
 
   return {
-    helmet: "wcap",
+    helmet: feelingLucky ? "wcap" : "fury",
     mainhand,
     orb: feelingLucky
       ? "rabbitsfoot"
@@ -384,19 +384,19 @@ function calculatePriestItems(target) {
 }
 
 function calculateRogueItems(target) {
-  const haveLowHpMobsNearby = shouldWearLuckGear();
+  const feelingLucky = shouldWearLuckGear();
   const fieryWeapon = "firestars";
 
   // Safely handle missing target
   if (!target) {
     return {
-      helmet: haveLowHpMobsNearby ? "wcap" : "fury",
+      helmet: feelingLucky ? "wcap" : "fury",
       mainhand: "daggerofthedead",
       offhand: "daggerofthedead",
-      shoes: haveLowHpMobsNearby ? "wshoes" : "wingedboots",
-      gloves: haveLowHpMobsNearby ? "wgloves" : "supermittens",
-      amulet: haveLowHpMobsNearby ? "spookyamulet" : "dexamulet",
-      orb: haveLowHpMobsNearby ? "rabbitsfoot" : "orbofdex",
+      shoes: feelingLucky ? "wshoes" : "wingedboots",
+      gloves: feelingLucky ? "wgloves" : "supermittens",
+      amulet: feelingLucky ? "spookyamulet" : "dexamulet",
+      orb: feelingLucky ? "rabbitsfoot" : "orbofdex",
       chest: "wattire",
       pants: "wbreeches",
     };
@@ -417,7 +417,7 @@ function calculateRogueItems(target) {
     (item_info(characterFireStars)?.attack ?? 0);
 
   const rogueBurnDmg = characterFireStars
-    ? dps_multiplier((target.armor ?? 0) - (character.apiercing ?? 0)) *
+    ? dps_multiplier((target.armor ?? 0) - (character.apiercing * 2 ?? 0)) *
       ((100 - (target.firesistance ?? 0)) / 100) *
       1.5 *
       (character.attack - equipItemAttackOffset + targetStacks) *
@@ -428,13 +428,13 @@ function calculateRogueItems(target) {
     rogueBurnDmg > (target.s?.burned?.intensity ?? 0) || target.cooperative;
 
   return {
-    helmet: haveLowHpMobsNearby ? "wcap" : "fury",
+    helmet: feelingLucky ? "wcap" : "fury",
     mainhand: "daggerofthedead",
-    shoes: haveLowHpMobsNearby ? "wshoes" : "wingedboots",
-    gloves: haveLowHpMobsNearby ? "wgloves" : "supermittens",
+    shoes: feelingLucky ? "wshoes" : "wingedboots",
+    gloves: feelingLucky ? "wgloves" : "supermittens",
     offhand: shouldEquipFireStar ? fieryWeapon : "daggerofthedead",
-    amulet: haveLowHpMobsNearby ? "spookyamulet" : "dexamulet",
-    orb: haveLowHpMobsNearby ? "rabbitsfoot" : "orbofdex",
+    amulet: feelingLucky ? "spookyamulet" : "dexamulet",
+    orb: feelingLucky ? "rabbitsfoot" : "orbofdex",
     chest: "wattire",
     pants: "wbreeches",
   };
@@ -563,7 +563,7 @@ function calculateDamage(target, characterEntity, recursion = true) {
                 ? G.monsters[target.mtype].rpiercing ?? 0
                 : 0),
           ) *
-          (target.frequency < 0.9 ? 0.9 : target.frequency) +
+          target.frequency +
         (target.dreturn && recursion
           ? characterEntity.range < 100
             ? (calculateDamage(characterEntity, target, false) *
@@ -582,9 +582,10 @@ function calculateDamage(target, characterEntity, recursion = true) {
                 : 0) -
               (target.type === "monster"
                 ? G.monsters[target.mtype].apiercing ?? 0
-                : 0),
+                : 0) *
+                2,
           ) *
-          (target.frequency < 0.9 ? 0.9 : target.frequency) +
+          target.frequency +
         (target.dreturn && recursion
           ? characterEntity.range < 100
             ? (calculateDamage(characterEntity, target, false) *
@@ -638,7 +639,7 @@ function avgDmgTaken(characterEntity, dmgType = null) {
     ? dps_multiplier(
         highestBurningMob.damage_type === "physical"
           ? characterEntity.armor -
-              (G.monsters[highestBurningMob.mtype].apiercing ?? 0)
+              (G.monsters[highestBurningMob.mtype].apiercing ?? 0) * 2
           : highestBurningMob.damage_type === "magical"
           ? characterEntity.resistance -
             (G.monsters[highestBurningMob.mtype].rpiercing ?? 0)
@@ -813,7 +814,7 @@ async function warriorCleave(currentStrategy) {
         mob.type === "monster" &&
         mob.hp >
           character.attack *
-            dps_multiplier(mob.armor - character.apiercing) *
+            dps_multiplier(mob.armor - character.apiercing * 2) *
             1.5 &&
         mob.attack > 150
       );

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -981,7 +981,7 @@ async function useTemporalSurge() {
     );
   };
 
-  const nearbySpawn = Object.values(parent.G.maps[currentMap].spawns).filter(
+  const nearbySpawn = parent.G.maps[currentMap].monsters.filter(
     (spawn) => {
       if (spawn.boundaries) {
         return spawn.boundaries.some((boundary) => isSpawnInRange(boundary));

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -428,19 +428,19 @@ function calculatePriestItems(target) {
       target &&
       target.type !== "monster" &&
       ![
-        "firestaff",
-        "oozingterror",
-        "pmace",
+        // "firestaff", // only enable these when oozingterror is main designated weapon (currently: harbringer)
+        // "oozingterror",
+        // "pmace",
         ...(!character.s.burned ? ["lmace"] : []),
       ].includes(character.slots.mainhand?.name)
-        ? "oozingterror"
+        ? "harbringer"
         : // : ["pinkgoo", "snowman", "wabbit", "crab"].includes(
         //     get_targeted_monster()?.mtype,
         //   )
         // ? "pinkie"
         character.map === "crypt"
         ? currentTarget && currentTarget.s["frozen"]
-          ? "oozingterror"
+          ? "harbringer"
           : "froststaff"
         : feelingLucky
         ? "lmace"
@@ -449,7 +449,7 @@ function calculatePriestItems(target) {
             currentTarget["1hp"] ||
             currentTarget["avoidance"] > 90)
         ? "firestaff"
-        : "oozingterror",
+        : "harbringer",
     offhand:
       character.map === "crypt"
         ? "wbook1"

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -418,9 +418,12 @@ function calculatePriestItems(target) {
     mainhand:
       target &&
       target.type !== "monster" &&
-      !["firestaff", "oozingterror", "pmace", "lmace"].includes(
-        character.slots.mainhand?.name,
-      )
+      ![
+        "firestaff",
+        "oozingterror",
+        "pmace",
+        ...(!character.s.burned ? ["lmace"] : []),
+      ].includes(character.slots.mainhand?.name)
         ? "oozingterror"
         : // : ["pinkgoo", "snowman", "wabbit", "crab"].includes(
         //     get_targeted_monster()?.mtype,
@@ -651,7 +654,8 @@ function calculateDamage(fromEntity, toEntity, recursion = true) {
             toEntity.resistance -
               (fromEntity.type === "monster"
                 ? G.monsters[fromEntity.mtype].rpiercing ?? 0
-                : 0) * 2,
+                : 0) *
+                2,
           ) *
           fromEntity.frequency +
         (fromEntity.reflection && recursion

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -968,7 +968,14 @@ async function useTemporalSurge() {
   const temporalsurgeRange = G.skills["temporalsurge"].range;
 
   const isSpawnInRange = (boundary) => {
-    const [x1, y1, x2, y2] = boundary;
+    let map, x1, y1, x2, y2;
+
+    if (typeof boundary[0] === "string") {
+      [map, x1, y1, x2, y2] = boundary;
+      if (map !== currentMap) return false;
+    } else {
+      [x1, y1, x2, y2] = boundary;
+    }
 
     return (
       distance(character, {
@@ -981,15 +988,13 @@ async function useTemporalSurge() {
     );
   };
 
-  const nearbySpawn = parent.G.maps[currentMap].monsters.filter(
-    (spawn) => {
-      if (spawn.boundaries) {
-        return spawn.boundaries.some((boundary) => isSpawnInRange(boundary));
-      } else {
-        return isSpawnInRange(spawn.boundary);
-      }
-    },
-  );
+  const nearbySpawn = parent.G.maps[currentMap].monsters.filter((spawn) => {
+    if (spawn.boundaries) {
+      return spawn.boundaries.some((boundary) => isSpawnInRange(boundary));
+    } else {
+      return isSpawnInRange(spawn.boundary);
+    }
+  });
 
   const nearbySpawnWithSpawnMechanic = nearbySpawn.filter(
     (spawn) => G.monsters[spawn.type].spawns,

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -464,7 +464,7 @@ function calculateRangerItems(target) {
       : "orbofdex",
     amulet: feelingWise ? "spookyamulet" : "dexamulet",
     shoes: feelingLucky ? "wshoes" : "wingedboots",
-    gloves: feelingLucky ? "wgloves" : "mittens",
+    gloves: feelingLucky ? "wgloves" : "supermittens",
   };
 }
 

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -303,47 +303,54 @@ function explosionScore(itemInfo, targets) {
   if (!itemInfo || !targets?.length) return 0;
 
   const attack = itemInfo.attack || 0;
-  const explosion = (character.explosion ?? 0) + itemInfo.explosion_delta || 0;
+  const explosion =
+    (character.explosion ?? 0) + (itemInfo.explosion_delta ?? 0);
 
   return targets.reduce((sum, mob) => {
     const cluster =
       mob.cluster_count ??
       numberOfMonsterAroundTarget(mob, explosion / 3.6 || BLAST_RADIUS);
 
-    return sum + attack + attack * explosion * (cluster - 1);
+    return sum + attack + attack * explosion * Math.max(0, cluster - 1);
   }, 0);
 }
 
 function chooseFireOrPouchForSplashing(targets) {
-  const targetCount = estimateExplosionTargetCount(targets);
-
   const currentBow = {
-    ...item_info(character.slots.mainhand),
+    ...(item_info(character.slots.mainhand) ?? {}),
     explosion_delta: 0,
   };
+  const currentBowExplosion = currentBow.explosion ?? 0;
 
+  const firebowSlot = findMaxLevelItem(RANGER_INV_ITEMS.fireBow);
   const fireInfo =
     currentBow?.name === RANGER_INV_ITEMS.fireBow
       ? currentBow
-      : item_info(findMaxLevelItem(RANGER_INV_ITEMS.fireBow));
+      : firebowSlot !== -1
+      ? item_info(character.items[firebowSlot])
+      : undefined;
+
+  const pouchbowSlot = findMaxLevelItem(RANGER_INV_ITEMS.poucher);
   const pouchInfo =
     currentBow?.name === RANGER_INV_ITEMS.poucher
-      ? getBowInfo(RANGER_INV_ITEMS.poucher)
-      : item_info(findMaxLevelItem(RANGER_INV_ITEMS.poucher));
+      ? currentBow
+      : pouchbowSlot !== -1
+      ? item_info(character.items[pouchbowSlot])
+      : undefined;
 
   if (!pouchInfo) return RANGER_INV_ITEMS.fireBow;
   if (!fireInfo) return RANGER_INV_ITEMS.poucher;
 
-  if (!pouchInfo.explosion_delta) {
-    pouchInfo.explosion_delta = pouchInfo.explosion - currentBow.explosion;
+  if (pouchInfo.explosion_delta == null) {
+    pouchInfo.explosion_delta = pouchInfo.explosion - currentBowExplosion;
   }
 
-  if (!fireInfo.explosion_delta) {
-    fireInfo.explosion_delta = fireInfo.explosion - currentBow.explosion;
+  if (fireInfo.explosion_delta == null) {
+    fireInfo.explosion_delta = fireInfo.explosion - currentBowExplosion;
   }
 
-  const fireScore = explosionScore(fireInfo, targetCount);
-  const pouchScore = explosionScore(pouchInfo, targetCount);
+  const fireScore = explosionScore(fireInfo, targets);
+  const pouchScore = explosionScore(pouchInfo, targets);
 
   return pouchScore > fireScore
     ? RANGER_INV_ITEMS.poucher

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -648,9 +648,7 @@ async function equipBatch(suggestedItems, forced = false) {
   if (
     (character.cc > 130 ||
       isEquipingItems ||
-      (character.s.penalty_cd &&
-        character.s.penalty_cd.ms >
-          (ms_to_next_skill("attack") ?? 1000 / character.frequency)) ||
+      character.s.penalty_cd ||
       isLooting) &&
     !forced
   )

--- a/strategic_fn.11.js
+++ b/strategic_fn.11.js
@@ -1,6 +1,6 @@
 const MAX_TARGET = 10;
 const BLAST_RADIUS = character.blast / 3.6 || 17;
-const TARGET_TO_SWITCH_TO_BLASTER_WEAPON = 3;
+const TARGET_TO_SWITCH_TO_BLASTER_WEAPON = 2;
 const MAX_MOB_DPS = 1000;
 const BOOSTERS = ["goldbooster", "xpbooster", "luckbooster"];
 const WATCHOUT_ABILITIES = ["burn"];
@@ -225,7 +225,7 @@ const STUN_FOCUS_LIST = ["crabxx", "grinch"];
 function calculateWarriorItems() {
   const currentTarget = get_target();
   const shouldUseBlaster =
-    numberOfMonsterAroundTarget(currentTarget) >= 2 && !currentTarget["1hp"];
+    numberOfMonsterAroundTarget(currentTarget) >= TARGET_TO_SWITCH_TO_BLASTER_WEAPON && !currentTarget["1hp"];
 
   const feelingLucky = shouldWearLuckGear();
   const feelingWise = shouldWearExpGear();
@@ -320,7 +320,7 @@ function calculateRangerItems(target) {
             numberOfMonsterAroundTarget(
               mob,
               character.explosion / 3.6 || BLAST_RADIUS,
-            )) > 1,
+            )) >= TARGET_TO_SWITCH_TO_BLASTER_WEAPON,
       )
     ) {
       mainhand = RANGER_INV_ITEMS.poucher;


### PR DESCRIPTION
### New features
- [x] A smart move wrapper for earth's alpathfinder
- [x] A projectile tracking module to predict incoming healing/damage.

### Merchant
- [x] Add ancient computer to merchant logic, efficiently reduces his time spending on smart_move
- [x] Improve compound script, which makes him use his inventory more efficiently
- [x] Use quick sort for sorting inventory
- [x] He can now luring mecha gnomes to the farm spawn

### Fighters
- [x] Fix Mage's target priorities and items logic
- [x] Add new deploy strategy for snowman
- [x] Make priest Flapping his wing to activate snow_angel skin
- [x] Move booster shifting to equipBatch
- [x] Remove booster shifting from midasLooting
- [x] Add temporal surge logic
- [x] Add crabxx strategy and stucking logic for tanker

#### Ranger
- [x] Fix Cupid healing
- [x] Fix Multishot and apply shouldAttack() filter for each target
- [x] Make use of the projectile tracking module to predict and avoid overlapping cupid's heal with other players priest/ranger

#### Priest
- [x] Fix a bug where he will spamming move() towards healee if not walkable
- [x] Simplify equipment change with the new lmace that I got lately 🐄
- [x] Make use of the projectile tracking module to predict and avoid overlapping heal with other players priest/ranger

#### Warrior
- [x] Fix agitate and taunt

### Refactors
- [x] Seperate strategy call from attacks, which will avoid adding penalty_cd to attack cd
- [x] Chunking equipBatch to prevent penalty_cd from interferring with attack cd 

### Integrations
- [x] Put earthiverse's alpathfinder in use with caracAL

### Goal for next PR
- Fully integrate mage's strategy with earth's pathfinder instead of a wrapping watcher for start and end map of routing
